### PR TITLE
Add RPM package

### DIFF
--- a/.rpm/bitwarden_rs.service
+++ b/.rpm/bitwarden_rs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=bitwarden_rs
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/bitwarden_rs
+Environment=WEB_VAULT_ENABLED=false
+Environment=DATA_FOLDER=/var/lib/bitwarden_rs
+User=bitwarden_rs
+Group=bitwarden_rs
+
+[Install]
+WantedBy=multi-user.target

--- a/.rpm/bitwarden_rs.spec
+++ b/.rpm/bitwarden_rs.spec
@@ -1,0 +1,54 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: bitwarden_rs
+Summary: foo
+Version: @@VERSION@@
+Release: @@RELEASE@@
+License: GPLv3
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires: systemd
+
+Requires(pre): shadow-utils
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+mkdir -p %{buildroot}%{_localstatedir}/lib/bitwarden_rs/
+
+%clean
+rm -rf %{buildroot}
+
+%systemd_post bitwarden_rs.service
+
+%preun
+%systemd_preun bitwarden_rs.service
+
+%postun
+%systemd_postun_with_restart bitwarden_rs.service
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*
+%{_unitdir}/bitwarden_rs.service
+%attr(0755,bitwarden_rs,root) %dir %{_localstatedir}/lib/bitwarden_rs
+
+%pre
+getent group bitwarden_rs >/dev/null || groupadd -r bitwarden_rs
+getent passwd bitwarden_rs >/dev/null || \
+    useradd -r -g bitwarden_rs -d / -s /sbin/nologin bitwarden_rs
+exit 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "vaultwarden"
-version = "1.0.0"
+name = "bitwarden_rs"
+version = "1.24.0"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>"]
 edition = "2021"
 rust-version = "1.60"
@@ -11,6 +11,7 @@ readme = "README.md"
 license = "GPL-3.0-only"
 publish = false
 build = "build.rs"
+description = "foo"
 
 [features]
 # Empty to keep compatibility, prefer to set USE_SYSLOG=true
@@ -152,3 +153,12 @@ rocket_contrib = { git = 'https://github.com/SergioBenitez/Rocket', rev = '263e3
 # In particular, `cron` has since implemented parsing of some common syntax
 # that wasn't previously supported (https://github.com/zslayton/cron/pull/64).
 job_scheduler = { git = 'https://github.com/jjlin/job_scheduler', rev = 'ee023418dbba2bfe1e30a5fd7d937f9e33739806' }
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release", "--features=sqlite"]
+
+[package.metadata.rpm.targets]
+bitwarden_rs = { path = "/usr/bin/bitwarden_rs" }
+
+[package.metadata.rpm.files]
+"bitwarden_rs.service" = { path = "/usr/lib/systemd/system/bitwarden_rs.service" }

--- a/packages/centos8/Dockerfile
+++ b/packages/centos8/Dockerfile
@@ -1,0 +1,10 @@
+FROM rockylinux/rockylinux:8
+RUN yum install -y epel-release
+RUN yum install -y openssl-devel copr-cli
+RUN yum groupinstall -y 'Development Tools'
+ARG toolchain
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${toolchain}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install cargo-rpm
+COPY . /root/src
+WORKDIR /root/src/

--- a/packages/centos8/README
+++ b/packages/centos8/README
@@ -1,0 +1,7 @@
+Run:
+
+$ ./packages/centos8/build
+
+From the repo root to build RPMs and push them to COPR.
+
+Check the contents of the build script to see how to develop.

--- a/packages/centos8/build
+++ b/packages/centos8/build
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ue
+
+mkdir -p target
+docker build . --build-arg toolchain=$(cat rust-toolchain) -f packages/centos8/Dockerfile -t bitwarden_centos8_rpm
+
+# to build locally, and not push to copr:
+#
+# $ docker run -it --rm -v $(pwd)/target:/root/src/target bitwarden_centos8_rpm
+# $ cargo rpm build
+#
+# RPMs will be in target/release/rpmbuild/RPMS/x86_64/
+
+docker run -it --rm --env copr_login --env copr_token bitwarden_centos8_rpm ./packages/centos8/build-in-docker

--- a/packages/centos8/build-in-docker
+++ b/packages/centos8/build-in-docker
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ue
+
+mkdir -p ~/.config
+
+cat >~/.config/copr <<EOF
+[copr-cli]
+login = $copr_login
+username = koalillo
+token = $copr_token
+copr_url = https://copr.fedorainfracloud.org
+EOF
+
+mkdir -p target
+
+cargo rpm build
+copr-cli build bitwarden_rs target/release/rpmbuild/SRPMS/bitwarden_rs*.src.rpm


### PR DESCRIPTION
This is a WIP, I'm interested in creating a CentOS 8 package for bitwarden_rs that installs a systemd user service using SQLite and provide a COPR dnf/yum repo.

(My thought is that from reading the documentation, I see that bitwarden_rs is meant to be single-user? Having a systemd user service would mean that you could have every user in a system run their own bitwarden_rs easily, but maybe I got this part wrong).

There is no reason this wouldn't work for other CentOS/RHEL/Fedora versions.

The package "works" right now, but it's running with `WEB_VAULT_ENABLED=false`, it only supports SQLite.

It's also pushing to a COPR repo in my fork. To test it:

```
$ sudo dnf copr enable koalillo/bitwarden_rs 
$ sudo dnf install bitwarden_rs
$ curl http://localhost:8000/
```

This is in part a RPM/COPR learning exercise, but I think it would be a cool idea to mainline RPM support. If we merge something like this, it should be easy to set up CI to push new packages to a COPR repo for every release automatically. People then can install it with the two commands above and have it automatically patched with dnf-automatic.

I'm happy to fix more stuff. If you guys don't want to mainline this (I know maintaining more things is never easy), I'm happy to keep this in an external repo.

Also note that at this point:

* Fedora/CentOS apparently won't accept nightly-based Rust software in their main repos
* I think this PR manages to evade best practices in all steps of the way. It works, but it's not "good"