### PR TITLE
admin: More granular HTTP return codes for user-related endpoints

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -30,6 +30,7 @@ pub fn routes() -> Vec<Route> {
     routes![
         admin_login,
         get_users_json,
+        get_user_json,
         post_admin_login,
         admin_page,
         invite_user,
@@ -347,6 +348,13 @@ fn users_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
 
     let text = AdminTemplateData::users(users_json).render()?;
     Ok(Html(text))
+}
+
+#[get("/users/<uuid>")]
+fn get_user_json(uuid: String, _token: AdminToken, conn: DbConn) -> JsonResult {
+    let user = User::find_by_uuid(&uuid, &conn).map_res("User doesn't exist")?;
+
+    Ok(Json(user.to_json(&conn)))
 }
 
 #[post("/users/<uuid>/delete")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -217,11 +217,11 @@ macro_rules! err {
 
 #[macro_export]
 macro_rules! err_code {
-    ($msg:expr, $err_code: literal) => {{
+    ($msg:expr, $err_code: expr) => {{
         error!("{}", $msg);
         return Err(crate::error::Error::new($msg, $msg).with_code($err_code));
     }};
-    ($usr_msg:expr, $log_value:expr, $err_code: literal) => {{
+    ($usr_msg:expr, $log_value:expr, $err_code: expr) => {{
         error!("{}. {}", $usr_msg, $log_value);
         return Err(crate::error::Error::new($usr_msg, $log_value).with_code($err_code));
     }};


### PR DESCRIPTION
Based on: #1663

```
 admin: Specifically return 404 for user not found

- Modify err_code to accept an expr for err_code
- Add get_user_or_404, properly returning 404 instead of a generic 400
  for cases where user is not found
- Use get_user_or_404 where appropriate.
```

```
admin: Make invite_user error codes more specific

- Return 409 Conflict for when a user with that email already exists
- Return 500 InternalServerError for everything else
```