### PR TITLE
Add `sends_allowed` config setting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -56,6 +56,11 @@
 # WEBSOCKET_ADDRESS=0.0.0.0
 # WEBSOCKET_PORT=3012
 
+## Controls whether users are allowed to create Bitwarden Sends.
+## This setting applies globally to all users.
+## To control this on a per-org basis instead, use the "Disable Send" org policy.
+# SENDS_ALLOWED=true
+
 ## Job scheduler settings
 ##
 ## Job schedules use a cron-like syntax (as parsed by https://crates.io/crates/cron),

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -51,10 +51,13 @@ pub struct SendData {
 /// modify existing ones, but is allowed to delete them.
 ///
 /// Ref: https://bitwarden.com/help/article/policies/#disable-send
+///
+/// There is also a Vaultwarden-specific `sends_allowed` config setting that
+/// controls this policy globally.
 fn enforce_disable_send_policy(headers: &Headers, conn: &DbConn) -> EmptyResult {
     let user_uuid = &headers.user.uuid;
     let policy_type = OrgPolicyType::DisableSend;
-    if OrgPolicy::is_applicable_to_user(user_uuid, policy_type, conn) {
+    if !CONFIG.sends_allowed() || OrgPolicy::is_applicable_to_user(user_uuid, policy_type, conn) {
         err!("Due to an Enterprise Policy, you are only able to delete an existing Send.")
     }
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -342,6 +342,10 @@ make_config! {
         /// Enable web vault
         web_vault_enabled:      bool,   false,  def,    true;
 
+        /// Allow Sends |> Controls whether users are allowed to create Bitwarden Sends.
+        /// This setting applies globally to all users. To control this on a per-org basis instead, use the "Disable Send" org policy.
+        sends_allowed:          bool,   true,   def,    true;
+
         /// HIBP Api Key |> HaveIBeenPwned API Key, request it here: https://haveibeenpwned.com/API/Key
         hibp_api_key:           Pass,   true,   option;
 


### PR DESCRIPTION
This provides global control over whether users can create Bitwarden Sends.