### PR TITLE
Fix attachment downloads

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -308,7 +308,8 @@ fn invite_user(data: Json<InviteData>, _token: AdminToken, conn: DbConn) -> Json
         }
 
         user.save(&conn)
-    })().map_err(|e| e.with_code(Status::InternalServerError.code))?;
+    })()
+    .map_err(|e| e.with_code(Status::InternalServerError.code))?;
 
     Ok(Json(user.to_json(&conn)))
 }

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -39,6 +39,7 @@ pub fn routes() -> Vec<Route> {
         post_ciphers_admin,
         post_ciphers_create,
         post_ciphers_import,
+        get_attachment,
         post_attachment,
         post_attachment_admin,
         post_attachment_share,
@@ -752,6 +753,15 @@ fn share_cipher_by_uuid(
     )?;
 
     Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
+}
+
+#[get("/ciphers/<uuid>/attachment/<attachment_id>")]
+fn get_attachment(uuid: String, attachment_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+    match Attachment::find_by_id(&attachment_id, &conn) {
+        Some(attachment) if uuid == attachment.cipher_uuid => Ok(Json(attachment.to_json(&headers.host))),
+        Some(_) => err!("Attachment doesn't belong to cipher"),
+        None => err!("Attachment doesn't exist"),
+    }
 }
 
 #[post("/ciphers/<uuid>/attachment", format = "multipart/form-data", data = "<data>")]

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -55,9 +55,9 @@ fn web_files(p: PathBuf) -> Cached<Option<NamedFile>> {
     Cached::long(NamedFile::open(Path::new(&CONFIG.web_vault_folder()).join(p)).ok())
 }
 
-#[get("/attachments/<uuid>/<file..>")]
-fn attachments(uuid: String, file: PathBuf) -> Option<NamedFile> {
-    NamedFile::open(Path::new(&CONFIG.attachments_folder()).join(uuid).join(file)).ok()
+#[get("/attachments/<uuid>/<file_id>")]
+fn attachments(uuid: String, file_id: String) -> Option<NamedFile> {
+    NamedFile::open(Path::new(&CONFIG.attachments_folder()).join(uuid).join(file_id)).ok()
 }
 
 #[get("/sends/<send_id>/<file_id>")]


### PR DESCRIPTION
Upstream switched to new upload/download APIs. Uploads fall back to the
legacy APIs for now, but not downloads apparently.

Fixes #1697.

Upstream PR: https://github.com/bitwarden/server/pull/1153