### PR TITLE
Add support for v2 attachment upload APIs

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -808,7 +808,7 @@ fn post_attachment_v2(
         err!("Cipher is not write accessible")
     }
 
-    let attachment_id = crypto::generate_file_id();
+    let attachment_id = crypto::generate_attachment_id();
     let data: AttachmentRequestData = data.into_inner().data;
     let attachment =
         Attachment::new(attachment_id.clone(), cipher.uuid.clone(), data.FileName, data.FileSize, Some(data.Key));
@@ -912,7 +912,7 @@ fn save_attachment(
                     // In the v2 API, we use the value from post_attachment_v2().
                     let file_id = match &attachment {
                         Some(attachment) => attachment.id.clone(), // v2 API
-                        None => crypto::generate_file_id(),        // Legacy API
+                        None => crypto::generate_attachment_id(),  // Legacy API
                     };
                     path = base_path.join(&file_id);
 

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -173,7 +173,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
 
     // Create the Send
     let mut send = create_send(data.data, headers.user.uuid.clone())?;
-    let file_id = crate::crypto::generate_file_id();
+    let file_id = crate::crypto::generate_send_id();
 
     if send.atype != SendType::File as i32 {
         err!("Send content is not a file");

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -173,7 +173,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
 
     // Create the Send
     let mut send = create_send(data.data, headers.user.uuid.clone())?;
-    let file_id: String = data_encoding::HEXLOWER.encode(&crate::crypto::get_random(vec![0; 32]));
+    let file_id = crate::crypto::generate_file_id();
 
     if send.atype != SendType::File as i32 {
         err!("Send content is not a file");

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -51,8 +51,18 @@ pub fn get_random(mut array: Vec<u8>) -> Vec<u8> {
     array
 }
 
-pub fn generate_file_id() -> String {
-    HEXLOWER.encode(&get_random(vec![0; 16])) // 128 bits
+pub fn generate_id(num_bytes: usize) -> String {
+    HEXLOWER.encode(&get_random(vec![0; num_bytes]))
+}
+
+pub fn generate_send_id() -> String {
+    // Send IDs are globally scoped, so make them longer to avoid collisions.
+    generate_id(32) // 256 bits
+}
+
+pub fn generate_attachment_id() -> String {
+    // Attachment IDs are scoped to a cipher, so they can be smaller.
+    generate_id(10) // 80 bits
 }
 
 pub fn generate_token(token_size: u32) -> Result<String, Error> {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -3,6 +3,7 @@
 //
 use std::num::NonZeroU32;
 
+use data_encoding::HEXLOWER;
 use ring::{digest, hmac, pbkdf2};
 
 use crate::error::Error;
@@ -28,8 +29,6 @@ pub fn verify_password_hash(secret: &[u8], salt: &[u8], previous: &[u8], iterati
 // HMAC
 //
 pub fn hmac_sign(key: &str, data: &str) -> String {
-    use data_encoding::HEXLOWER;
-
     let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key.as_bytes());
     let signature = hmac::sign(&key, data.as_bytes());
 
@@ -50,6 +49,10 @@ pub fn get_random(mut array: Vec<u8>) -> Vec<u8> {
     SystemRandom::new().fill(&mut array).expect("Error generating random values");
 
     array
+}
+
+pub fn generate_file_id() -> String {
+    HEXLOWER.encode(&get_random(vec![0; 16])) // 128 bits
 }
 
 pub fn generate_token(token_size: u32) -> Result<String, Error> {

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -12,7 +12,7 @@ db_object! {
     pub struct Attachment {
         pub id: String,
         pub cipher_uuid: String,
-        pub file_name: String,
+        pub file_name: String, // encrypted
         pub file_size: i32,
         pub akey: Option<String>,
     }
@@ -20,13 +20,13 @@ db_object! {
 
 /// Local methods
 impl Attachment {
-    pub const fn new(id: String, cipher_uuid: String, file_name: String, file_size: i32) -> Self {
+    pub const fn new(id: String, cipher_uuid: String, file_name: String, file_size: i32, akey: Option<String>) -> Self {
         Self {
             id,
             cipher_uuid,
             file_name,
             file_size,
-            akey: None,
+            akey,
         }
     }
 
@@ -34,18 +34,17 @@ impl Attachment {
         format!("{}/{}/{}", CONFIG.attachments_folder(), self.cipher_uuid, self.id)
     }
 
+    pub fn get_url(&self, host: &str) -> String {
+        format!("{}/attachments/{}/{}", host, self.cipher_uuid, self.id)
+    }
+
     pub fn to_json(&self, host: &str) -> Value {
-        use crate::util::get_display_size;
-
-        let web_path = format!("{}/attachments/{}/{}", host, self.cipher_uuid, self.id);
-        let display_size = get_display_size(self.file_size);
-
         json!({
             "Id": self.id,
-            "Url": web_path,
+            "Url": self.get_url(host),
             "FileName": self.file_name,
             "Size": self.file_size.to_string(),
-            "SizeName": display_size,
+            "SizeName": crate::util::get_display_size(self.file_size),
             "Key": self.akey,
             "Object": "attachment"
         })
@@ -91,7 +90,7 @@ impl Attachment {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub fn delete(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             crate::util::retry(
                 || diesel::delete(attachments::table.filter(attachments::id.eq(&self.id))).execute(conn),


### PR DESCRIPTION
Upstream PR: https://github.com/bitwarden/server/pull/1229

The legacy upload flow can be tested with v2.19 of the web vault.

The v2 upload flow can be tested with v2.20 of the web vault.