### PR TITLE
Only create private key in pem format if it doesn't already exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -263,17 +263,19 @@ fn check_rsa_keys() {
 
         info!("OpenSSL detected, creating keys...");
 
-        let key = CONFIG.rsa_key_filename();
+        let pem = CONFIG.private_rsa_key_pem();
+        let priv_der = CONFIG.private_rsa_key();
+        let pub_der = CONFIG.public_rsa_key();
 
-        let pem = format!("{}.pem", key);
-        let priv_der = format!("{}.der", key);
-        let pub_der = format!("{}.pub.der", key);
+        let mut success = true;
 
-        let mut success = Command::new("openssl")
-            .args(&["genrsa", "-out", &pem])
-            .status()
-            .expect("Failed to create private pem file")
-            .success();
+        if !util::file_exists(&pem) {
+            success = Command::new("openssl")
+                .args(&["genrsa", "-out", &pem])
+                .status()
+                .expect("Failed to create private pem file")
+                .success();
+        }
 
         success &= Command::new("openssl")
             .args(&["rsa", "-in", &pem, "-outform", "DER", "-out", &priv_der])


### PR DESCRIPTION
The original logic checks if the private and public key are available in the `.der` format, but ignores the private key in `.pem` format.

This change does not have any impact on the already working setups, it merely enables the User to only provide a single private key in `.pem` format.

My use case is simple. I deploy vaultwarden on kubernetes through terraform and I'm unable to create private keys in `.der` format directly. By simply checking for an existing `.pem` key first, I can simply mount the key that I've created with terraform and on startup the application will automatically convert it to the correct format.

Since the `CONFIG` provides methods to get the key names I also switched to using those instead of generating the names.