### PR TITLE
Expose $ROCKET_PORT instead of 80

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -239,7 +239,7 @@ RUN [ "cross-build-end" ]
 {% endif %}
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -94,7 +94,7 @@ RUN mkdir /data \
 
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -89,7 +89,7 @@ RUN mkdir /data \
 
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -134,7 +134,7 @@ RUN mkdir /data \
 RUN [ "cross-build-end" ]
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -134,7 +134,7 @@ RUN mkdir /data \
 RUN [ "cross-build-end" ]
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -134,7 +134,7 @@ RUN mkdir /data \
 RUN [ "cross-build-end" ]
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -96,7 +96,7 @@ RUN mkdir /data \
 RUN [ "cross-build-end" ]
 
 VOLUME /data
-EXPOSE 80
+EXPOSE $ROCKET_PORT
 EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)


### PR DESCRIPTION
EXPOSE in the Dockerfiles is hard-coded to 80 instead using the defined rocket port. This is causing problems e.g. when setting up a reverse proxy via Traefik using labels as Traefik will use the ports set by the EXPOSE command. Current workaround is to provide the rocket port to the service using an extra label.