### PR TITLE
Updated attachment limit descriptions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -194,11 +194,13 @@
 ## Name shown in the invitation emails that don't come from a specific organization
 # INVITATION_ORG_NAME=Vaultwarden
 
-## Per-organization attachment limit (KB)
-## Limit in kilobytes for an organization attachments, once the limit is exceeded it won't be possible to upload more
+## Per-organization attachment storage limit (KB)
+## Max kilobytes of attachment storage allowed per organization.
+## When this limit is reached, organization members will not be allowed to upload further attachments for ciphers owned by that organization.
 # ORG_ATTACHMENT_LIMIT=
-## Per-user attachment limit (KB).
-## Limit in kilobytes for a users attachments, once the limit is exceeded it won't be possible to upload more
+## Per-user attachment storage limit (KB)
+## Max kilobytes of attachment storage allowed per user.
+## When this limit is reached, the user will not be allowed to upload further attachments.
 # USER_ATTACHMENT_LIMIT=
 
 ## Number of days to wait before auto-deleting a trashed item.

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -871,7 +871,7 @@ fn save_attachment(
             Some(limit_kb) => {
                 let left = (limit_kb * 1024) - Attachment::size_by_user(user_uuid, conn) + size_adjust;
                 if left <= 0 {
-                    err_discard!("Attachment size limit reached! Delete some files to open space", data)
+                    err_discard!("Attachment storage limit reached! Delete some attachments to free up space", data)
                 }
                 Some(left as u64)
             }
@@ -883,7 +883,7 @@ fn save_attachment(
             Some(limit_kb) => {
                 let left = (limit_kb * 1024) - Attachment::size_by_org(org_uuid, conn) + size_adjust;
                 if left <= 0 {
-                    err_discard!("Attachment size limit reached! Delete some files to open space", data)
+                    err_discard!("Attachment storage limit reached! Delete some attachments to free up space", data)
                 }
                 Some(left as u64)
             }
@@ -937,7 +937,7 @@ fn save_attachment(
                                 return;
                             }
                             SaveResult::Partial(_, reason) => {
-                                error = Some(format!("Attachment size limit exceeded with this file: {:?}", reason));
+                                error = Some(format!("Attachment storage limit exceeded with this file: {:?}", reason));
                                 return;
                             }
                             SaveResult::Error(e) => {

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -173,7 +173,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
         Some(limit_kb) => {
             let left = (limit_kb * 1024) - Attachment::size_by_user(&headers.user.uuid, &conn);
             if left <= 0 {
-                err!("Attachment size limit reached! Delete some files to open space")
+                err!("Attachment storage limit reached! Delete some attachments to free up space")
             }
             std::cmp::Ord::max(left as u64, SIZE_110_MB)
         }
@@ -205,7 +205,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
         }
         SaveResult::Partial(_, reason) => {
             std::fs::remove_file(&file_path).ok();
-            err!(format!("Attachment size limit exceeded with this file: {:?}", reason));
+            err!(format!("Attachment storage limit exceeded with this file: {:?}", reason));
         }
         SaveResult::Error(e) => {
             std::fs::remove_file(&file_path).ok();

--- a/src/config.rs
+++ b/src/config.rs
@@ -356,9 +356,9 @@ make_config! {
         /// HIBP Api Key |> HaveIBeenPwned API Key, request it here: https://haveibeenpwned.com/API/Key
         hibp_api_key:           Pass,   true,   option;
 
-        /// Per-user attachment limit (KB) |> Limit in kilobytes for a users attachments, once the limit is exceeded it won't be possible to upload more
+        /// Per-user attachment storage limit (KB) |> Max kilobytes of attachment storage allowed per user. When this limit is reached, the user will not be allowed to upload further attachments.
         user_attachment_limit:  i64,    true,   option;
-        /// Per-organization attachment limit (KB) |> Limit in kilobytes for an organization attachments, once the limit is exceeded it won't be possible to upload more
+        /// Per-organization attachment storage limit (KB) |> Max kilobytes of attachment storage allowed per org. When this limit is reached, org members will not be allowed to upload further attachments for ciphers owned by that org.
         org_attachment_limit:   i64,    true,   option;
 
         /// Trash auto-delete days |> Number of days to wait before auto-deleting a trashed item.


### PR DESCRIPTION
The user and org attachment limit use `size` as wording while it should
have been `storage` since it isn't per attachment, but the sum of all attachments.

- Changed the wording in the config/env
- Changed the wording of the error messages.

Resolves #1818