### PR TITLE
Set file permissions for created files

### DIFF
--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -10,6 +10,7 @@ use crate::{
     api::{ApiResult, EmptyResult, JsonResult, JsonUpcase, Notify, UpdateType},
     auth::{Headers, Host},
     db::{models::*, DbConn, DbPool},
+    util::set_file_mode,
     CONFIG,
 };
 
@@ -212,6 +213,8 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
             err!(format!("Error: {:?}", e));
         }
     };
+
+    set_file_mode(&file_path, 0o600)?;
 
     // Set ID and sizes
     let mut data_value: Value = serde_json::from_str(&send.data)?;

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fs::{create_dir_all, remove_file, symlink_metadata, File},
+    fs::{remove_file, symlink_metadata, File},
     io::prelude::*,
     net::{IpAddr, ToSocketAddrs},
     sync::{Arc, RwLock},
@@ -14,7 +14,7 @@ use rocket::{http::ContentType, response::Content, Route};
 
 use crate::{
     error::Error,
-    util::{get_reqwest_client_builder, Cached},
+    util::{get_reqwest_client_builder, write_file, Cached},
     CONFIG,
 };
 
@@ -705,13 +705,8 @@ fn download_icon(domain: &str) -> Result<(Vec<u8>, Option<&str>), Error> {
 }
 
 fn save_icon(path: &str, icon: &[u8]) {
-    match File::create(path) {
-        Ok(mut f) => {
-            f.write_all(icon).expect("Error writing icon file");
-        }
-        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
-            create_dir_all(&CONFIG.icon_cache_folder()).expect("Error creating icon cache");
-        }
+    match write_file(path, icon) {
+        Ok(_) => (),
         Err(e) => {
             warn!("Icon save error: {:?}", e);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use reqwest::Url;
 use crate::{
     db::DbConnType,
     error::Error,
-    util::{get_env, get_env_bool},
+    util::{get_env, get_env_bool, write_file},
 };
 
 static CONFIG_FILE: Lazy<String> = Lazy::new(|| {
@@ -691,9 +691,7 @@ impl Config {
         }
 
         //Save to file
-        use std::{fs::File, io::Write};
-        let mut file = File::create(&*CONFIG_FILE)?;
-        file.write_all(config_str.as_bytes())?;
+        write_file(&CONFIG_FILE, config_str.as_bytes())?;
 
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use reqwest::Url;
 use crate::{
     db::DbConnType,
     error::Error,
-    util::{get_env, get_env_bool, write_file},
+    util::{get_env, get_env_bool, set_file_mode, write_file},
 };
 
 static CONFIG_FILE: Lazy<String> = Lazy::new(|| {
@@ -692,6 +692,7 @@ impl Config {
 
         //Save to file
         write_file(&CONFIG_FILE, config_str.as_bytes())?;
+        set_file_mode(&*CONFIG_FILE, 0o600)?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ mod util;
 
 pub use config::CONFIG;
 pub use error::{Error, MapResult};
-pub use util::is_running_in_docker;
+pub use util::{is_running_in_docker, set_file_mode};
 
 fn main() {
     parse_args();
@@ -254,6 +254,7 @@ fn check_rsa_keys() -> Result<(), crate::error::Error> {
 
         let priv_key = rsa_key.private_key_to_pem()?;
         crate::util::write_file(&priv_path, &priv_key)?;
+        set_file_mode(&priv_path, 0o600)?;
         info!("Private key created correctly.");
     }
 
@@ -262,6 +263,7 @@ fn check_rsa_keys() -> Result<(), crate::error::Error> {
 
         let pub_key = rsa_key.public_key_to_pem()?;
         crate::util::write_file(&pub_path, &pub_key)?;
+        set_file_mode(&pub_path, 0o600)?;
         info!("Public key created correctly.");
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -248,6 +248,17 @@ pub fn delete_file(path: &str) -> IOResult<()> {
     res
 }
 
+pub fn set_file_mode<P: AsRef<Path>>(path: P, mode: u32) -> IOResult<()> {
+    if !cfg!(unix) {
+        // noop on non-unix
+        return Ok(());
+    }
+    use std::fs::{set_permissions, Permissions};
+    use std::os::unix::fs::PermissionsExt;
+
+    set_permissions(&path, Permissions::from_mode(mode))
+}
+
 const UNITS: [&str; 6] = ["bytes", "KB", "MB", "GB", "TB", "PB"];
 
 pub fn get_display_size(size: i32) -> String {


### PR DESCRIPTION
Fixes https://github.com/dani-garcia/vaultwarden/discussions/1784

This isn't a full audit of all places files are created, but it covers most. Intentionally not set them on the image cache, as they're not sensitive.

It only works on unix, because that's the only place permissions like this work. It should work fine under docker even if docker isn't run on unix.

This also reuses the existing `write_file` util in a few places which custom implemented it.