### PR TITLE
Add Edge's frame-ancestors

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -29,7 +29,7 @@ impl Fairing for AppHeaders {
         res.set_raw_header("X-Content-Type-Options", "nosniff");
         res.set_raw_header("X-XSS-Protection", "1; mode=block");
         let csp = format!(
-            "frame-ancestors 'self' chrome-extension://nngceckbapebfimnlniiiahkandclblb moz-extension://* {};",
+            "frame-ancestors 'self' chrome-extension://nngceckbapebfimnlniiiahkandclblb chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh moz-extension://* {};",
             CONFIG.allowed_iframe_ancestors()
         );
         res.set_raw_header("Content-Security-Policy", csp);

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,7 +31,7 @@ impl Fairing for AppHeaders {
         let csp = format!(
             // Chrome Web Store: https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb
             // Edge Add-ons: https://microsoftedge.microsoft.com/addons/detail/bitwarden-free-password/jbkfoedolllekgbhcbcoahefnbanhhlh?hl=en-US
-            // Firefox Browser Add-ons: https://addons.mozilla.org/ja/firefox/addon/bitwarden-password-manager/
+            // Firefox Browser Add-ons: https://addons.mozilla.org/en-US/firefox/addon/bitwarden-password-manager/
             "frame-ancestors 'self' chrome-extension://nngceckbapebfimnlniiiahkandclblb chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh moz-extension://* {};",
             CONFIG.allowed_iframe_ancestors()
         );

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,6 +29,9 @@ impl Fairing for AppHeaders {
         res.set_raw_header("X-Content-Type-Options", "nosniff");
         res.set_raw_header("X-XSS-Protection", "1; mode=block");
         let csp = format!(
+            // Chrome Web Store: https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb
+            // Edge Add-ons: https://microsoftedge.microsoft.com/addons/detail/bitwarden-free-password/jbkfoedolllekgbhcbcoahefnbanhhlh?hl=en-US
+            // Firefox Browser Add-ons: https://addons.mozilla.org/ja/firefox/addon/bitwarden-password-manager/
             "frame-ancestors 'self' chrome-extension://nngceckbapebfimnlniiiahkandclblb chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh moz-extension://* {};",
             CONFIG.allowed_iframe_ancestors()
         );


### PR DESCRIPTION
Edge's frame-ancestors are required for Edge extension to do WebAuthn.

<img width="372" alt="スクリーンショット 2021-07-08 0 41 26" src="https://user-images.githubusercontent.com/1067855/124794934-81bc1500-df8a-11eb-957c-eccbd7adbe52.png">
