### PR TITLE
Fix sends notification format and add endpoints to get all sends or one send by id

### DIFF
--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -18,6 +18,8 @@ const SEND_INACCESSIBLE_MSG: &str = "Send does not exist or is no longer availab
 
 pub fn routes() -> Vec<rocket::Route> {
     routes![
+        get_sends,
+        get_send,
         post_send,
         post_send_file,
         post_access,
@@ -128,6 +130,32 @@ fn create_send(data: SendData, user_uuid: String) -> ApiResult<Send> {
     Ok(send)
 }
 
+#[get("/sends")]
+fn get_sends(headers: Headers, conn: DbConn) -> Json<Value> {
+    let sends = Send::find_by_user(&headers.user.uuid, &conn);
+    let sends_json: Vec<Value> = sends.iter().map(|s| s.to_json()).collect();
+
+    Json(json!({
+      "Data": sends_json,
+      "Object": "list",
+      "ContinuationToken": null
+    }))
+}
+
+#[get("/sends/<uuid>")]
+fn get_send(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
+    let send = match Send::find_by_uuid(&uuid, &conn) {
+        Some(send) => send,
+        None => err!("Send not found"),
+    };
+
+    if send.user_uuid.as_ref() != Some(&headers.user.uuid) {
+        err!("Send is not owned by user")
+    }
+
+    Ok(Json(send.to_json()))
+}
+
 #[post("/sends", data = "<data>")]
 fn post_send(data: JsonUpcase<SendData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
     enforce_disable_send_policy(&headers, &conn)?;
@@ -141,7 +169,7 @@ fn post_send(data: JsonUpcase<SendData>, headers: Headers, conn: DbConn, nt: Not
 
     let mut send = create_send(data, headers.user.uuid.clone())?;
     send.save(&conn)?;
-    nt.send_user_update(UpdateType::SyncSendCreate, &headers.user);
+    nt.send_send_update(UpdateType::SyncSendCreate, &send, &send.update_users_revision(&conn));
 
     Ok(Json(send.to_json()))
 }
@@ -225,7 +253,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
 
     // Save the changes in the database
     send.save(&conn)?;
-    nt.send_user_update(UpdateType::SyncSendCreate, &headers.user);
+    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&conn));
 
     Ok(Json(send.to_json()))
 }
@@ -397,7 +425,7 @@ fn put_send(id: String, data: JsonUpcase<SendData>, headers: Headers, conn: DbCo
     }
 
     send.save(&conn)?;
-    nt.send_user_update(UpdateType::SyncSendUpdate, &headers.user);
+    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&conn));
 
     Ok(Json(send.to_json()))
 }
@@ -414,7 +442,7 @@ fn delete_send(id: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyR
     }
 
     send.delete(&conn)?;
-    nt.send_user_update(UpdateType::SyncSendDelete, &headers.user);
+    nt.send_send_update(UpdateType::SyncSendDelete, &send, &send.update_users_revision(&conn));
 
     Ok(())
 }
@@ -434,7 +462,7 @@ fn put_remove_password(id: String, headers: Headers, conn: DbConn, nt: Notify) -
 
     send.set_password(None);
     send.save(&conn)?;
-    nt.send_user_update(UpdateType::SyncSendUpdate, &headers.user);
+    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&conn));
 
     Ok(Json(send.to_json()))
 }

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -167,7 +167,7 @@ fn post_send(data: JsonUpcase<SendData>, headers: Headers, conn: DbConn, nt: Not
         err!("File sends should use /api/sends/file")
     }
 
-    let mut send = create_send(data, headers.user.uuid.clone())?;
+    let mut send = create_send(data, headers.user.uuid)?;
     send.save(&conn)?;
     nt.send_send_update(UpdateType::SyncSendCreate, &send, &send.update_users_revision(&conn));
 
@@ -210,7 +210,7 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
     };
 
     // Create the Send
-    let mut send = create_send(data.data, headers.user.uuid.clone())?;
+    let mut send = create_send(data.data, headers.user.uuid)?;
     let file_id = crate::crypto::generate_send_id();
 
     if send.atype != SendType::File as i32 {

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -65,7 +65,7 @@ use chashmap::CHashMap;
 use chrono::NaiveDateTime;
 use serde_json::from_str;
 
-use crate::db::models::{Cipher, Folder, User};
+use crate::db::models::{Cipher, Folder, User, Send};
 
 use rmpv::Value;
 
@@ -327,6 +327,23 @@ impl WebSocketUsers {
                 ("OrganizationId".into(), org_uuid),
                 ("CollectionIds".into(), Value::Nil),
                 ("RevisionDate".into(), serialize_date(cipher.updated_at)),
+            ],
+            ut,
+        );
+
+        for uuid in user_uuids {
+            self.send_update(uuid, &data).ok();
+        }
+    }
+
+    pub fn send_send_update(&self, ut: UpdateType, send: &Send, user_uuids: &[String]) {
+        let user_uuid = convert_option(send.user_uuid.clone());
+
+        let data = create_update(
+            vec![
+                ("Id".into(), send.uuid.clone().into()),
+                ("UserId".into(), user_uuid),
+                ("RevisionDate".into(), serialize_date(send.revision_date)),
             ],
             ut,
         );

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -65,7 +65,7 @@ use chashmap::CHashMap;
 use chrono::NaiveDateTime;
 use serde_json::from_str;
 
-use crate::db::models::{Cipher, Folder, User, Send};
+use crate::db::models::{Cipher, Folder, Send, User};
 
 use rmpv::Value;
 

--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -232,15 +232,18 @@ impl Send {
         }
     }
 
-    pub fn update_users_revision(&self, conn: &DbConn) {
-        match &self.user_uuid {
-            Some(user_uuid) => {
+    pub fn update_users_revision(&self, conn: &DbConn) -> Vec<String> {
+        let mut user_uuids = Vec::new();
+        match self.user_uuid {
+            Some(ref user_uuid) => {
                 User::update_uuid_revision(user_uuid, conn);
+                user_uuids.push(user_uuid.clone())
             }
             None => {
                 // Belongs to Organization, not implemented
             }
-        }
+        };
+        user_uuids
     }
 
     pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {

--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -234,8 +234,8 @@ impl Send {
 
     pub fn update_users_revision(&self, conn: &DbConn) -> Vec<String> {
         let mut user_uuids = Vec::new();
-        match self.user_uuid {
-            Some(ref user_uuid) => {
+        match &self.user_uuid {
+            Some(user_uuid) => {
                 User::update_uuid_revision(user_uuid, conn);
                 user_uuids.push(user_uuid.clone())
             }


### PR DESCRIPTION
This small pull request fixes the notification format for `SyncSendCreate`, `SyncSendUpdate` and `SyncSendDelete`notification types.

With the correct notification format, the sends in the web vault and other bitwarden clients are automatically updated when the user creates, updates or deletes a send in another session. To allow the clients to update specific sends, this PR also includes new endpoints for getting all sends or one specific send by uuid.

I've verified that this works with the web vault and the bitwarden mobile client.