### PR TITLE
Adding tzdata to Alpine container

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -212,6 +212,7 @@ RUN mkdir /data \
 {% if "alpine" in runtime_stage_base_image %}
     && apk add --no-cache \
         openssl \
+        tzdata \
         curl \
         dumb-init \
 {%   if "mysql" in features %}

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -82,6 +82,7 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 RUN mkdir /data \
     && apk add --no-cache \
         openssl \
+        tzdata \
         curl \
         dumb-init \
         postgresql-libs \

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -88,6 +88,7 @@ RUN [ "cross-build-start" ]
 RUN mkdir /data \
     && apk add --no-cache \
         openssl \
+        tzdata \
         curl \
         dumb-init \
         ca-certificates


### PR DESCRIPTION
To be able to set a timezone inside a Alpine container with the env variable TZ the tzdata package is needed. Otherwise only UTC will be set. In my case fail2ban (which is running on the host with Europe/Berlin) is complaining about a too large time deviation.