### PR TITLE
Fix limitation on sharing ciphers with attachments

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -687,12 +687,6 @@ fn put_cipher_share_selected(
         };
     }
 
-    let attachments = Attachment::find_by_ciphers(cipher_ids, &conn);
-
-    if !attachments.is_empty() {
-        err!("Ciphers should not have any attachments.")
-    }
-
     while let Some(cipher) = data.Ciphers.pop() {
         let mut shared_cipher_data = ShareCipherData {
             Cipher: cipher,

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -143,16 +143,6 @@ impl Attachment {
         }}
     }
 
-    pub fn find_by_ciphers(cipher_uuids: Vec<String>, conn: &DbConn) -> Vec<Self> {
-        db_run! { conn: {
-            attachments::table
-                .filter(attachments::cipher_uuid.eq_any(cipher_uuids))
-                .load::<AttachmentDb>(conn)
-                .expect("Error loading attachments")
-                .from_db()
-        }}
-    }
-
     pub fn size_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             let result: Option<i64> = attachments::table


### PR DESCRIPTION
This check is several years old, so maybe there was a valid reason for having it before, but it's not correct anymore.

Fixes #1909.