### PR TITLE
Fix syncing with Bitwarden Desktop v1.28.0

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -290,6 +290,8 @@ impl UserOrganization {
             // For now they still have that code also in the web-vault, but they will remove it at some point.
             // https://github.com/bitwarden/server/tree/master/bitwarden_license/src/
             "UseBusinessPortal": false, // Disable BusinessPortal Button
+            "ProviderId": null,
+            "ProviderName": null,
 
             // TODO: Add support for Custom User Roles
             // See: https://bitwarden.com/help/article/user-types-access-control/#custom-role

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -210,7 +210,10 @@ impl User {
             "PrivateKey": self.private_key,
             "SecurityStamp": self.security_stamp,
             "Organizations": orgs_json,
-            "Object": "profile"
+            "Providers": [],
+            "ProviderOrganizations": [],
+            "ForcePasswordReset": false,
+            "Object": "profile",
         })
     }
 


### PR DESCRIPTION
Syncing with the latest desktop client (v1.28.0) fails because it expects some json key/values to be there.

This PR adds those key/value pairs.

Resolves #1924