### PR TITLE
Build Docker Hub images via Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,36 +2,23 @@ name: Build
 
 on:
   push:
-    paths-ignore:
-      - "*.md"
-      - "*.txt"
-      - ".dockerignore"
-      - ".env.template"
-      - ".gitattributes"
-      - ".gitignore"
-      - "azure-pipelines.yml"
-      - "docker/**"
-      - "hooks/**"
-      - "tools/**"
-      - ".github/FUNDING.yml"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/security-contact.gif"
+    paths:
+      - ".github/workflows/build.yml"
+      - "src/**"
+      - "migrations/**"
+      - "Cargo.*"
+      - "build.rs"
+      - "diesel.toml"
+      - "rust-toolchain"
   pull_request:
-    # Ignore when there are only changes done too one of these paths
-    paths-ignore:
-      - "*.md"
-      - "*.txt"
-      - ".dockerignore"
-      - ".env.template"
-      - ".gitattributes"
-      - ".gitignore"
-      - "azure-pipelines.yml"
-      - "docker/**"
-      - "hooks/**"
-      - "tools/**"
-      - ".github/FUNDING.yml"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/security-contact.gif"
+    paths:
+      - ".github/workflows/build.yml"
+      - "src/**"
+      - "migrations/**"
+      - "Cargo.*"
+      - "build.rs"
+      - "diesel.toml"
+      - "rust-toolchain"
 
 jobs:
   build:

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,11 +2,10 @@ name: Hadolint
 
 on:
   push:
-    # Ignore when there are only changes done too one of these paths
     paths:
       - "docker/**"
+
   pull_request:
-    # Ignore when there are only changes done too one of these paths
     paths:
       - "docker/**"
 
@@ -28,7 +27,7 @@ jobs:
           sudo curl -L https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m) -o /usr/local/bin/hadolint && \
           sudo chmod +x /usr/local/bin/hadolint
         env:
-          HADOLINT_VERSION: 2.6.1
+          HADOLINT_VERSION: 2.7.0
       # End Download hadolint
 
       # Test Dockerfiles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    paths:
+      - ".github/workflows/release.yml"
+      - "src/**"
+      - "migrations/**"
+      - "hooks/**"
+      - "docker/**"
+      - "Cargo.*"
+      - "build.rs"
+      - "diesel.toml"
+      - "rust-toolchain"
+
+    branches: # Only on paths above
+      - main
+
+    tags: # Always, regardless of paths above
+      - '*'
+
+jobs:
+  # https://github.com/marketplace/actions/skip-duplicate-actions
+  # Some checks to determine if we need to continue with building a new docker.
+  # We will skip this check if we are creating a tag, because that has the same hash as a previous run already.
+  skip_check:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - name: Skip Duplicates Actions
+        id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          cancel_others: 'true'
+        # Only run this when not creating a tag
+        if: ${{ startsWith(github.ref, 'refs/heads/') }}
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: skip_check
+    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
+    env:
+      # DOCKER_BUILDKIT: 1 # Disabled for now, but we should look at this because it will speedup building!
+      # DOCKER_REPO/secrets.DOCKERHUB_REPO needs to be 'index.docker.io/<user>/<repo>'
+      DOCKER_REPO: ${{ secrets.DOCKERHUB_REPO }}
+      SOURCE_COMMIT: ${{ github.sha }}
+      SOURCE_REPOSITORY_URL: "https://github.com/${{ github.repository }}"
+    steps:
+      # Checkout the repo
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Login to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Determine Docker Tag
+      - name: Init Variables
+        id: vars
+        shell: bash
+        run: |
+          # Check which main tag we are going to build determined by github.ref
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "set-output name=DOCKER_TAG::${GITHUB_REF#refs/*/}"
+            echo "::set-output name=DOCKER_TAG::${GITHUB_REF#refs/*/}"
+          elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
+            echo "set-output name=DOCKER_TAG::testing"
+            echo "::set-output name=DOCKER_TAG::testing"
+          fi
+      # End Determine Docker Tag
+
+      - name: Build Debian based images
+        shell: bash
+        env:
+          DOCKER_TAG: ${{steps.vars.outputs.DOCKER_TAG}}
+        run: |
+          ./hooks/build
+
+      - name: Push Debian based images
+        shell: bash
+        env:
+          DOCKER_TAG: ${{steps.vars.outputs.DOCKER_TAG}}
+        run: |
+          ./hooks/push
+
+      - name: Build Alpine based images
+        shell: bash
+        env:
+          DOCKER_TAG: "${{steps.vars.outputs.DOCKER_TAG}}-alpine"
+        run: |
+          ./hooks/build
+
+      - name: Push Alpine based images
+        shell: bash
+        env:
+          DOCKER_TAG: "${{steps.vars.outputs.DOCKER_TAG}}-alpine"
+        run: |
+          ./hooks/push

--- a/hooks/push
+++ b/hooks/push
@@ -25,7 +25,10 @@ echo ">>> Starting local Docker registry..."
 # Use host networking so the buildx container can access the registry via
 # localhost.
 #
-docker run -d --name registry --network host registry:2 # defaults to port 5000
+# First check if there already is a registry container running, else skip it.
+# This will only happen either locally or running it via Github Actions
+#
+docker start registry > /dev/null 2>&1 || docker run -d --name registry --network host registry:2 # defaults to port 5000
 
 # Docker Hub sets a `DOCKER_REPO` env var with the format `index.docker.io/user/repo`.
 # Strip the registry portion to construct a local repo path for use in `Dockerfile.buildx`.
@@ -49,7 +52,12 @@ echo ">>> Setting up Docker Buildx..."
 #
 # Ref: https://github.com/docker/buildx/issues/94#issuecomment-534367714
 #
-docker buildx create --name builder --use --driver-opt network=host
+# Check if there already is a builder running, else skip this and use the existing.
+# This will only happen either locally or running it via Github Actions
+#
+if ! docker buildx inspect builder > /dev/null 2>&1 ; then
+    docker buildx create --name builder --use --driver-opt network=host
+fi
 
 echo ">>> Running Docker Buildx..."
 


### PR DESCRIPTION
Since docker hub stopped Autobuild, we need to switch to something else.
This will trigger building of images on Github Actions and pushes them
to Docker Hub.

You only need to add 3 secrets before you merge this PR to have it working directly.

- DOCKERHUB_USERNAME : The username of the account you are going to push the builds to
- DOCKERHUB_TOKEN : The token needed to login and push builds
- DOCKERHUB_REPO : The repo name in the following form `index.docker.io/<user>/<repo>`
  So for vaultwarden that would be `index.docker.io/vaultwarden/server`