### PR TITLE
Fix issue when using uppercase chars in emails

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -269,7 +269,7 @@ fn invite_user(data: Json<InviteData>, _token: AdminToken, conn: DbConn) -> Json
         if CONFIG.mail_enabled() {
             mail::send_invite(&user.email, &user.uuid, None, None, &CONFIG.invitation_org_name(), None)?;
         } else {
-            let invitation = Invitation::new(data.email);
+            let invitation = Invitation::new(user.email.clone());
             invitation.save(&conn)?;
         }
 

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -62,11 +62,12 @@ struct KeysData {
 #[post("/accounts/register", data = "<data>")]
 fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
     let data: RegisterData = data.into_inner().data;
+    let email = data.Email.to_lowercase();
 
-    let mut user = match User::find_by_mail(&data.Email, &conn) {
+    let mut user = match User::find_by_mail(&email, &conn) {
         Some(user) => {
             if !user.password_hash.is_empty() {
-                if CONFIG.is_signup_allowed(&data.Email) {
+                if CONFIG.is_signup_allowed(&email) {
                     err!("User already exists")
                 } else {
                     err!("Registration not allowed or user already exists")
@@ -75,19 +76,19 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
 
             if let Some(token) = data.Token {
                 let claims = decode_invite(&token)?;
-                if claims.email == data.Email {
+                if claims.email == email {
                     user
                 } else {
                     err!("Registration email does not match invite email")
                 }
-            } else if Invitation::take(&data.Email, &conn) {
+            } else if Invitation::take(&email, &conn) {
                 for mut user_org in UserOrganization::find_invited_by_user(&user.uuid, &conn).iter_mut() {
                     user_org.status = UserOrgStatus::Accepted as i32;
                     user_org.save(&conn)?;
                 }
 
                 user
-            } else if CONFIG.is_signup_allowed(&data.Email) {
+            } else if CONFIG.is_signup_allowed(&email) {
                 err!("Account with this email already exists")
             } else {
                 err!("Registration not allowed or user already exists")
@@ -97,8 +98,8 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
             // Order is important here; the invitation check must come first
             // because the vaultwarden admin can invite anyone, regardless
             // of other signup restrictions.
-            if Invitation::take(&data.Email, &conn) || CONFIG.is_signup_allowed(&data.Email) {
-                User::new(data.Email.clone())
+            if Invitation::take(&email, &conn) || CONFIG.is_signup_allowed(&email) {
+                User::new(email.clone())
             } else {
                 err!("Registration not allowed or user already exists")
             }
@@ -106,7 +107,7 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
     };
 
     // Make sure we don't leave a lingering invitation.
-    Invitation::take(&data.Email, &conn);
+    Invitation::take(&email, &conn);
 
     if let Some(client_kdf_iter) = data.KdfIterations {
         user.client_kdf_iter = client_kdf_iter;

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -540,18 +540,19 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
     }
 
     for email in data.Emails.iter() {
+        let email = email.to_lowercase();
         let mut user_org_status = if CONFIG.mail_enabled() {
             UserOrgStatus::Invited as i32
         } else {
             UserOrgStatus::Accepted as i32 // Automatically mark user as accepted if no email invites
         };
-        let user = match User::find_by_mail(email, &conn) {
+        let user = match User::find_by_mail(&email, &conn) {
             None => {
                 if !CONFIG.invitations_allowed() {
                     err!(format!("User does not exist: {}", email))
                 }
 
-                if !CONFIG.is_email_domain_allowed(email) {
+                if !CONFIG.is_email_domain_allowed(&email) {
                     err!("Email domain not eligible for invitations")
                 }
 
@@ -601,7 +602,7 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
             };
 
             mail::send_invite(
-                email,
+                &email,
                 &user.uuid,
                 Some(org_id.clone()),
                 Some(new_user.uuid),

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -73,9 +73,9 @@ impl User {
     pub const CLIENT_KDF_TYPE_DEFAULT: i32 = 0; // PBKDF2: 0
     pub const CLIENT_KDF_ITER_DEFAULT: i32 = 100_000;
 
-    pub fn new(mail: String) -> Self {
+    pub fn new(email: String) -> Self {
         let now = Utc::now().naive_utc();
-        let email = mail.to_lowercase();
+        let email = email.to_lowercase();
 
         Self {
             uuid: crate::util::get_uuid(),
@@ -349,7 +349,8 @@ impl User {
 }
 
 impl Invitation {
-    pub const fn new(email: String) -> Self {
+    pub fn new(email: String) -> Self {
+        let email = email.to_lowercase();
         Self {
             email,
         }


### PR DESCRIPTION
In the case when SMTP is disabled and.
when inviting new users either via the admin interface or into an
organization and using uppercase letters, this would fail for those
users to be able to register since the checks which were done are
case-sensitive and never matched.

This PR fixes that issue by ensuring everything is lowercase.
Fixes #1963