### PR TITLE
fix: Support no-data enterprise policies

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1183,7 +1183,7 @@ struct PolicyData {
     enabled: bool,
     #[serde(rename = "type")]
     _type: i32,
-    data: Value,
+    data: Option<Value>,
 }
 
 #[put("/organizations/<org_id>/policies/<pol_type>", data = "<data>")]


### PR DESCRIPTION
Boolean-toggle enterprise policies (like 'Two-Step Login' and 'Personal Ownership') don't provide a data attribute in the new version of the web client. This updates the backend to expect these to be optional.

Web change introduced in https://github.com/bitwarden/web/pull/1147 which added https://github.com/bitwarden/web/blob/2cbe023a38792ff70a2a4907f4748354bb4e0573/src/app/organizations/policies/base-policy.component.ts#L48-L50