### PR TITLE
Updated icon downloading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ handlebars = { version = "4.1.3", features = ["dir_source"] }
 # For favicon extraction from main website
 html5ever = "0.25.1"
 markup5ever_rcdom = "0.1.0"
-regex = { version = "1.5.4", features = ["std", "perf"], default-features = false }
+regex = { version = "1.5.4", features = ["std", "perf", "unicode-perl"], default-features = false }
 data-url = "0.1.0"
 
 # Used by U2F, JWT and Postgres

--- a/src/error.rs
+++ b/src/error.rs
@@ -220,6 +220,15 @@ macro_rules! err {
     }};
 }
 
+macro_rules! err_silent {
+    ($msg:expr) => {{
+        return Err(crate::error::Error::new($msg, $msg));
+    }};
+    ($usr_msg:expr, $log_value:expr) => {{
+        return Err(crate::error::Error::new($usr_msg, $log_value));
+    }};
+}
+
 #[macro_export]
 macro_rules! err_code {
     ($msg:expr, $err_code: expr) => {{


### PR DESCRIPTION
- Unicode websites could break (www.post.japanpost.jp for example).
  regex would fail because it was missing the unicode-perl feature.
- Be less verbose in logging with icon downloads
- Removed duplicate info/error messages
- Added err_silent! macro to help with the less verbose error/info messages.