### PR TITLE
Revert Debian images back to Buster.

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -3,7 +3,7 @@
 # This file was generated using a Jinja2 template.
 # Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfiles.
 
-{% set build_stage_base_image = "rust:1.54-bullseye" %}
+{% set build_stage_base_image = "rust:1.55-buster" %}
 {% if "alpine" in target_file %}
 {%   if "amd64" in target_file %}
 {%     set build_stage_base_image = "clux/muslrust:nightly-2021-08-22" %}
@@ -15,19 +15,19 @@
 {%     set package_arch_target = "armv7-unknown-linux-musleabihf" %}
 {%   endif %}
 {% elif "amd64" in target_file %}
-{%   set runtime_stage_base_image = "debian:bullseye-slim" %}
+{%   set runtime_stage_base_image = "debian:buster-slim" %}
 {% elif "arm64" in target_file %}
-{%   set runtime_stage_base_image = "balenalib/aarch64-debian:bullseye" %}
+{%   set runtime_stage_base_image = "balenalib/aarch64-debian:buster" %}
 {%   set package_arch_name = "arm64" %}
 {%   set package_arch_target = "aarch64-unknown-linux-gnu" %}
 {%   set package_cross_compiler = "aarch64-linux-gnu" %}
 {% elif "armv6" in target_file %}
-{%   set runtime_stage_base_image = "balenalib/rpi-debian:bullseye" %}
+{%   set runtime_stage_base_image = "balenalib/rpi-debian:buster" %}
 {%   set package_arch_name = "armel" %}
 {%   set package_arch_target = "arm-unknown-linux-gnueabi" %}
 {%   set package_cross_compiler = "arm-linux-gnueabi" %}
 {% elif "armv7" in target_file %}
-{%   set runtime_stage_base_image = "balenalib/armv7hf-debian:bullseye" %}
+{%   set runtime_stage_base_image = "balenalib/armv7hf-debian:buster" %}
 {%   set package_arch_name = "armhf" %}
 {%   set package_arch_target = "armv7-unknown-linux-gnueabihf" %}
 {%   set package_cross_compiler = "arm-linux-gnueabihf" %}

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -84,7 +84,7 @@ RUN cargo build --features ${DB} --release
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/amd64/Dockerfile.buildx
+++ b/docker/amd64/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -84,7 +84,7 @@ RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/aarch64-debian:bullseye
+FROM balenalib/aarch64-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/arm64/Dockerfile.buildx
+++ b/docker/arm64/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/aarch64-debian:bullseye
+FROM balenalib/aarch64-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/rpi-debian:bullseye
+FROM balenalib/rpi-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/rpi-debian:bullseye
+FROM balenalib/rpi-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabih
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/armv7hf-debian:bullseye
+FROM balenalib/armv7hf-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80

--- a/docker/armv7/Dockerfile.buildx
+++ b/docker/armv7/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.54-bullseye as build
+FROM rust:1.55-buster as build
 
 # Debian-based builds support multidb
 ARG DB=sqlite,mysql,postgresql
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
-FROM balenalib/armv7hf-debian:bullseye
+FROM balenalib/armv7hf-debian:buster
 
 ENV ROCKET_ENV "staging"
 ENV ROCKET_PORT=80


### PR DESCRIPTION
This fixes #1998 where with some checking it seems Bullseye has some
issues with the glibc sleep call. It returns a SIGILL.

The glibc on Buster doesn't seem to have this issue, so revert back for
now until a fix has been released.