### PR TITLE
Update OpenSSL via an updated clux build image.

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -6,7 +6,7 @@
 {% set build_stage_base_image = "rust:1.55-buster" %}
 {% if "alpine" in target_file %}
 {%   if "amd64" in target_file %}
-{%     set build_stage_base_image = "clux/muslrust:nightly-2021-08-22" %}
+{%     set build_stage_base_image = "clux/muslrust:nightly-2021-10-06" %}
 {%     set runtime_stage_base_image = "alpine:3.14" %}
 {%     set package_arch_target = "x86_64-unknown-linux-musl" %}
 {%   elif "armv7" in target_file %}
@@ -114,6 +114,7 @@ RUN {{ mount_rust_cache -}} mkdir -pv "${CARGO_HOME}" \
 {% if "alpine" in target_file %}
 ENV RUSTFLAGS='-C link-arg=-s'
 {%   if "armv7" in target_file %}
+{#- https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html -#}
 ENV CFLAGS_armv7_unknown_linux_musleabihf="-mfpu=vfpv3-d16"
 {%   endif %}
 {% elif "arm" in target_file %}

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM clux/muslrust:nightly-2021-08-22 as build
+FROM clux/muslrust:nightly-2021-10-06 as build
 
 # Alpine-based AMD64 (musl) does not support mysql/mariadb during compile time.
 ARG DB=sqlite,postgresql

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:68790f9a62bf3edd6d54ce62ba9f0a2d2ddc7d3e1e9e36324fcbe632293f8fbc as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM clux/muslrust:nightly-2021-08-22 as build
+FROM clux/muslrust:nightly-2021-10-06 as build
 
 # Alpine-based AMD64 (musl) does not support mysql/mariadb during compile time.
 ARG DB=sqlite,postgresql


### PR DESCRIPTION
Recently the LetsEncrypt DST certificate has expired.
Older versions of OpenSSL like v1.0.x have issues using this certificate.

Recently clux has updated his image to support OpenSSL v1.1.1[a-z].
This solves issues with those certificates.

This issues was disscused on Matrix.