### PR TITLE
Added DbConn to /alive healthcheck

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -64,8 +64,10 @@ fn attachments(uuid: SafeString, file_id: SafeString) -> Option<NamedFile> {
     NamedFile::open(Path::new(&CONFIG.attachments_folder()).join(uuid).join(file_id)).ok()
 }
 
+// We use DbConn here to let the alive healthcheck also verify the database connection.
+use crate::db::DbConn;
 #[get("/alive")]
-fn alive() -> Json<String> {
+fn alive(_conn: DbConn) -> Json<String> {
     use crate::util::format_date;
     use chrono::Utc;
 


### PR DESCRIPTION
During a small discusson on Matrix it seems logical to have the /alive
endpoint also check if the database connection still works.

The reason for this was regarding a certificate which failed/expired
while vaultwarden and the database were still up-and-running, but
suddenly vaultwarden couldn't connect anymore.

With this `DbConn` added to `/alive`, it will be more accurate, because
of vaultwarden can't reach the database, it isn't alive.