### PR TITLE
2FA org policy: do not enforce on invited (not accepted) users

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1238,7 +1238,10 @@ fn put_policy(
             let user_twofactor_disabled = TwoFactor::find_by_user(&member.user_uuid, &conn).is_empty();
 
             // Policy only applies to non-Owner/non-Admin members who have accepted joining the org
-            if user_twofactor_disabled && member.atype < UserOrgType::Admin && member.status != UserOrgStatus::Invited as i32 {
+            if user_twofactor_disabled
+                && member.atype < UserOrgType::Admin
+                && member.status != UserOrgStatus::Invited as i32
+            {
                 if CONFIG.mail_enabled() {
                     let org = Organization::find_by_uuid(&member.org_uuid, &conn).unwrap();
                     let user = User::find_by_uuid(&member.user_uuid, &conn).unwrap();


### PR DESCRIPTION
As per the issue raised by @jjlin in https://github.com/dani-garcia/vaultwarden/pull/1991#discussion_r720706163, we should only enforce org policies on accepted or confirmed members, and not just invited members.

I've also added explanatory comments, as well as updated the variable names according to the feedback given in https://github.com/dani-garcia/vaultwarden/pull/1991#discussion_r719133373