### PR TITLE
Fix missing encrypted key after emergency access reject

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -539,7 +539,6 @@ fn reject_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> J
         };
 
         emergency_access.status = EmergencyAccessStatus::Confirmed as i32;
-        emergency_access.key_encrypted = None;
         emergency_access.save(&conn)?;
 
         if CONFIG.mail_enabled() {


### PR DESCRIPTION
Rejecting an emergency access request should transition the grantor/grantee
relationship back into the `Confirmed` state, and the grantor's encrypted key
should remain in escrow rather than being cleared, or else future emergency
access requsts from that grantee will fail.

This probably fixes #2061.