### PR TITLE
Fix PostgreSQL migration

### DIFF
--- a/migrations/postgresql/2021-10-24-164321_add_2fa_incomplete/up.sql
+++ b/migrations/postgresql/2021-10-24-164321_add_2fa_incomplete/up.sql
@@ -2,7 +2,7 @@ CREATE TABLE twofactor_incomplete (
   user_uuid   VARCHAR(40) NOT NULL REFERENCES users(uuid),
   device_uuid VARCHAR(40) NOT NULL,
   device_name TEXT        NOT NULL,
-  login_time  DATETIME    NOT NULL,
+  login_time  TIMESTAMP   NOT NULL,
   ip_address  TEXT        NOT NULL,
 
   PRIMARY KEY (user_uuid, device_uuid)


### PR DESCRIPTION
The PostgreSQL migration should have used `TIMESTAMP` rather than `DATETIME`.

Fixes #2079.