### PR TITLE
Add support for external icon services

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -129,10 +129,24 @@
 ## Number of times to retry the database connection during startup, with 1 second delay between each retry, set to 0 to retry indefinitely
 # DB_CONNECTION_RETRIES=15
 
+## Icon service
+## The predefined icon services are: internal, bitwarden, duckduckgo, google.
+## To specify a custom icon service, set a URL template with exactly one instance of `{}`,
+## which is replaced with the domain. For example: `https://icon.example.com/domain/{}`.
+##
+## `internal` refers to Vaultwarden's built-in icon fetching implementation.
+## If an external service is set, an icon request to Vaultwarden will return an HTTP 307
+## redirect to the corresponding icon at the external service. An external service may
+## be useful if your Vaultwarden instance has no external network connectivity, or if
+## you are concerned that someone may probe your instance to try to detect whether icons
+## for certain sites have been cached.
+# ICON_SERVICE=internal
+
 ## Disable icon downloading
-## Set to true to disable icon downloading, this would still serve icons from $ICON_CACHE_FOLDER,
-## but it won't produce any external network request. Needs to set $ICON_CACHE_TTL to 0,
-## otherwise it will delete them and they won't be downloaded again.
+## Set to true to disable icon downloading in the internal icon service.
+## This still serves existing icons from $ICON_CACHE_FOLDER, without generating any external
+## network requests. $ICON_CACHE_TTL must also be set to 0; otherwise, the existing icons
+## will be deleted eventually, but won't be downloaded again.
 # DISABLE_ICON_DOWNLOAD=false
 
 ## Icon download timeout


### PR DESCRIPTION
If an external icon service is configured, icon requests return an HTTP redirect to the corresponding icon at the external service.

An external service may be useful for various reasons, such as if:

* The Vaultwarden instance has no external network connectivity.
* The Vaultwarden instance has trouble handling large bursts of icon requests.
* There are concerns that an attacker may probe the instance to try to detect whether icons for certain sites have been cached, which would suggest that the instance contains entries for those sites.
* The external icon service does a better job of providing icons than the built-in fetcher.