### PR TITLE
Add config option to set the HTTP redirect code for external icons

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -135,12 +135,19 @@
 ## which is replaced with the domain. For example: `https://icon.example.com/domain/{}`.
 ##
 ## `internal` refers to Vaultwarden's built-in icon fetching implementation.
-## If an external service is set, an icon request to Vaultwarden will return an HTTP 307
+## If an external service is set, an icon request to Vaultwarden will return an HTTP
 ## redirect to the corresponding icon at the external service. An external service may
 ## be useful if your Vaultwarden instance has no external network connectivity, or if
 ## you are concerned that someone may probe your instance to try to detect whether icons
 ## for certain sites have been cached.
 # ICON_SERVICE=internal
+
+## Icon redirect code
+## The HTTP status code to use for redirects to an external icon service.
+## The supported codes are 307 (temporary) and 308 (permanent).
+## Temporary redirects are useful while testing different icon services, but once a service
+## has been decided on, consider using permanent redirects for cacheability.
+# ICON_REDIRECT_CODE=307
 
 ## Disable icon downloading
 ## Set to true to disable icon downloading in the internal icon service.

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -71,7 +71,14 @@ fn icon_redirect(domain: &str, template: &str) -> Option<Redirect> {
     }
 
     let url = template.replace("{}", domain);
-    Some(Redirect::temporary(url))
+    match CONFIG.icon_redirect_code() {
+        308 => Some(Redirect::permanent(url)),
+        307 => Some(Redirect::temporary(url)),
+        _ => {
+            error!("Unexpected redirect code {}", CONFIG.icon_redirect_code());
+            None
+        }
+    }
 }
 
 #[get("/<domain>/icon.png")]


### PR DESCRIPTION
The default code is 307 (temporary) to make it easier to test different icon services, but once a service has been decided on, users should ideally switch to using permanent redirects for cacheability.