### PR TITLE
Fixed issue #2154

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -182,7 +182,7 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
 
     let grantee_user = match User::find_by_mail(&email, &conn) {
         None => {
-            if !CONFIG.signups_allowed() {
+            if !CONFIG.invitations_allowed() {
                 err!(format!("Grantee user does not exist: {}", email))
             }
 


### PR DESCRIPTION
For emergency access invitations we need to check if invites are
allowed, not if sign-ups are allowed.

Resolves #2154