### PR TITLE
Fix emergency access invites for new users

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -87,14 +87,11 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
                     user_org.status = UserOrgStatus::Accepted as i32;
                     user_org.save(&conn)?;
                 }
-
+                user
+            } else if EmergencyAccess::find_invited_by_grantee_email(&email, &conn).is_some() {
                 user
             } else if CONFIG.is_signup_allowed(&email) {
-                // check if it's invited by emergency contact
-                match EmergencyAccess::find_invited_by_grantee_email(&data.Email, &conn) {
-                    Some(_) => user,
-                    _ => err!("Account with this email already exists"),
-                }
+                err!("Account with this email already exists")
             } else {
                 err!("Registration not allowed or user already exists")
             }


### PR DESCRIPTION
If a new user gets invited it should check if the user is invited via
emergency access, if so, allow that user to register.