### PR TITLE
Update Rocket to 0.5 and async, and compile on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,14 +65,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -103,16 +142,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
 
 [[package]]
 name = "base64"
@@ -193,16 +222,6 @@ checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -311,24 +330,24 @@ checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "percent-encoding 2.1.0",
- "time 0.2.27",
- "version_check 0.9.4",
-]
-
-[[package]]
-name = "cookie"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
 dependencies = [
  "percent-encoding 2.1.0",
  "time 0.2.27",
- "version_check 0.9.4",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
+dependencies = [
+ "percent-encoding 2.1.0",
+ "time 0.3.7",
+ "version_check",
 ]
 
 [[package]]
@@ -339,7 +358,7 @@ checksum = "b3f7034c0932dc36f5bd8ec37368d971346809435824f277cb3b8299fc56167c"
 dependencies = [
  "cookie 0.15.1",
  "idna 0.2.3",
- "log 0.4.14",
+ "log",
  "publicsuffix",
  "serde",
  "serde_json",
@@ -423,6 +442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+dependencies = [
+ "nix",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,8 +478,9 @@ dependencies = [
 
 [[package]]
 name = "devise"
-version = "0.3.0"
-source = "git+https://github.com/SergioBenitez/Devise.git?rev=e58b3ac9a#e58b3ac9afc3b6ff10a8aaf02a3e768a8f530089"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595"
 dependencies = [
  "devise_codegen",
  "devise_core",
@@ -458,22 +488,25 @@ dependencies = [
 
 [[package]]
 name = "devise_codegen"
-version = "0.3.0"
-source = "git+https://github.com/SergioBenitez/Devise.git?rev=e58b3ac9a#e58b3ac9afc3b6ff10a8aaf02a3e768a8f530089"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2"
 dependencies = [
  "devise_core",
- "quote 1.0.15",
+ "quote",
 ]
 
 [[package]]
 name = "devise_core"
-version = "0.3.0"
-source = "git+https://github.com/SergioBenitez/Devise.git?rev=e58b3ac9a#e58b3ac9afc3b6ff10a8aaf02a3e768a8f530089"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0"
 dependencies = [
  "bitflags",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -499,9 +532,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -566,9 +599,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -601,8 +634,22 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
- "log 0.4.14",
+ "log",
  "syslog",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -734,9 +781,9 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -776,6 +823,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -876,7 +936,7 @@ version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25546a65e5cf1f471f3438796fc634650b31d7fcde01d444c309aeb28b92e3a8"
 dependencies = [
- "log 0.4.14",
+ "log",
  "pest",
  "pest_derive",
  "quick-error 2.0.1",
@@ -946,12 +1006,12 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcf38a1a36118242d29b92e1b08ef84e67e4a5ed06e0a80be20e6a32bfed6b"
 dependencies = [
- "log 0.4.14",
+ "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -990,25 +1050,6 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time 0.1.44",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
@@ -1032,25 +1073,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-sync-rustls"
-version = "0.3.0-rc.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb014c4ea00486e2b62860b5e15229d37516d4924177218beafbf46583de3ab"
-dependencies = [
- "hyper 0.10.16",
- "rustls",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.1.0",
- "hyper 0.14.16",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1086,7 +1115,14 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -1180,12 +1216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,7 +1238,7 @@ dependencies = [
  "hostname",
  "httpdate",
  "idna 0.2.3",
- "mime 0.3.16",
+ "mime",
  "native-tls",
  "nom 7.1.0",
  "once_cell",
@@ -1252,20 +1282,26 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.14",
-]
-
-[[package]]
-name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5c7d328e32cc4954e8e01193d7f0ef5ab257b5090b70a964e099a36034309"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1304,7 +1340,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
 dependencies = [
- "log 0.4.14",
+ "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "string_cache",
@@ -1331,6 +1367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "migrations_internals"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,18 +1418,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
-]
-
-[[package]]
-name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1383,16 +1428,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime 0.3.16",
- "unicase 2.6.0",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1422,7 +1457,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.14",
+ "log",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -1436,7 +1471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
- "log 0.4.14",
+ "log",
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
@@ -1449,7 +1484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.14",
+ "log",
  "mio 0.6.23",
  "slab",
 ]
@@ -1476,21 +1511,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "multipart"
-version = "0.18.0"
+name = "multer"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
 dependencies = [
- "buf_redux",
+ "bytes 1.1.0",
+ "encoding_rs",
+ "futures-util",
+ "http",
  "httparse",
- "log 0.4.14",
- "mime 0.3.16",
- "mime_guess",
- "quick-error 1.2.3",
- "rand 0.8.4",
- "safemem",
- "tempfile",
- "twoway",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.2",
+ "tokio",
+ "tokio-util",
+ "version_check",
 ]
 
 [[package]]
@@ -1511,7 +1548,7 @@ checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.14",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -1539,6 +1576,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,7 +1611,7 @@ checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -1596,9 +1646,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1627,6 +1677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -1718,7 +1777,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "httparse",
- "log 0.4.14",
+ "log",
  "mio 0.6.23",
  "mio-extras",
  "rand 0.7.3",
@@ -1791,24 +1850,25 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pear"
-version = "0.1.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5320f212db967792b67cfe12bd469d08afd6318a249bd917d5c19bc92200ab8a"
+checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
 dependencies = [
+ "inlinable_string",
  "pear_codegen",
+ "yansi",
 ]
 
 [[package]]
 name = "pear_codegen"
-version = "0.1.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc1c836fdc3d1ef87c348b237b5b5c4dff922156fb2d968f57734f9669768ca"
+checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "version_check 0.9.4",
- "yansi",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1861,9 +1921,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2007,20 +2067,24 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2071,20 +2135,11 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -2099,7 +2154,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
- "log 0.4.14",
+ "log",
  "parking_lot 0.11.2",
  "scheduled-thread-pool",
 ]
@@ -2251,6 +2306,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300f2a835d808734ee295d45007adacb9ebb29dd3ae2424acfa17930cae541da"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2333,15 @@ checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -2293,13 +2377,13 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.16",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.14",
- "mime 0.3.16",
+ "log",
+ "mime",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
@@ -2338,7 +2422,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
@@ -2366,65 +2450,82 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=263e39b5b429de1913ce7e3036575a7b4d88b6d7#263e39b5b429de1913ce7e3036575a7b4d88b6d7"
+version = "0.5.0-rc.1"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=8cae077ba1d54b92cdef3e171a730b819d5eeb8e#8cae077ba1d54b92cdef3e171a730b819d5eeb8e"
 dependencies = [
+ "async-stream",
+ "async-trait",
+ "atomic",
  "atty",
  "binascii",
- "log 0.4.14",
+ "bytes 1.1.0",
+ "either",
+ "figment",
+ "futures",
+ "indexmap",
+ "log",
  "memchr",
+ "multer",
  "num_cpus",
- "pear",
+ "parking_lot 0.11.2",
+ "pin-project-lite",
+ "rand 0.8.4",
+ "ref-cast",
  "rocket_codegen",
  "rocket_http",
+ "serde",
+ "serde_json",
  "state",
- "time 0.2.27",
- "toml",
- "version_check 0.9.4",
+ "tempfile",
+ "time 0.3.7",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ubyte",
+ "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=263e39b5b429de1913ce7e3036575a7b4d88b6d7#263e39b5b429de1913ce7e3036575a7b4d88b6d7"
+version = "0.5.0-rc.1"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=8cae077ba1d54b92cdef3e171a730b819d5eeb8e#8cae077ba1d54b92cdef3e171a730b819d5eeb8e"
 dependencies = [
  "devise",
  "glob",
  "indexmap",
- "quote 1.0.15",
+ "proc-macro2",
+ "quote",
  "rocket_http",
- "version_check 0.9.4",
- "yansi",
-]
-
-[[package]]
-name = "rocket_contrib"
-version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=263e39b5b429de1913ce7e3036575a7b4d88b6d7#263e39b5b429de1913ce7e3036575a7b4d88b6d7"
-dependencies = [
- "log 0.4.14",
- "rocket",
- "serde",
- "serde_json",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.5.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=263e39b5b429de1913ce7e3036575a7b4d88b6d7#263e39b5b429de1913ce7e3036575a7b4d88b6d7"
+version = "0.5.0-rc.1"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=8cae077ba1d54b92cdef3e171a730b819d5eeb8e#8cae077ba1d54b92cdef3e171a730b819d5eeb8e"
 dependencies = [
- "cookie 0.14.4",
- "hyper 0.10.16",
- "hyper-sync-rustls",
+ "cookie 0.16.0",
+ "either",
+ "http",
+ "hyper",
  "indexmap",
+ "log",
+ "memchr",
  "pear",
- "percent-encoding 1.0.1",
+ "percent-encoding 2.1.0",
+ "pin-project-lite",
+ "ref-cast",
  "rustls",
+ "serde",
  "smallvec 1.8.0",
+ "stable-pattern",
  "state",
- "time 0.2.27",
- "unicode-xid 0.2.2",
+ "time 0.3.7",
+ "tokio",
+ "tokio-rustls",
+ "uncased",
 ]
 
 [[package]]
@@ -2444,28 +2545,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.11.0",
- "log 0.4.14",
+ "base64 0.13.0",
+ "log",
  "ring",
  "sct",
  "webpki",
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -2494,6 +2595,12 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot 0.11.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2574,9 +2681,9 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2656,6 +2763,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simple_asn1"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2846,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stable-pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,14 +2872,17 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
 name = "state"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
+checksum = "87cf4f5369e6d3044b5e365c9690f451516ac8f0954084622b49ea3fde2f6de5"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "stdweb"
@@ -2761,11 +2904,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_derive",
- "syn 1.0.86",
+ "syn",
 ]
 
 [[package]]
@@ -2775,13 +2918,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "proc-macro2",
+ "quote",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.86",
+ "syn",
 ]
 
 [[package]]
@@ -2812,8 +2955,8 @@ checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2824,24 +2967,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2852,7 +2984,7 @@ checksum = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 dependencies = [
  "error-chain",
  "libc",
- "log 0.4.14",
+ "log",
  "time 0.1.44",
 ]
 
@@ -2896,9 +3028,18 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2931,9 +3072,21 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
- "version_check 0.9.4",
+ "time-macros 0.1.1",
+ "version_check",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros 0.2.3",
 ]
 
 [[package]]
@@ -2947,16 +3100,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+
+[[package]]
 name = "time-macros-impl"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
+ "proc-macro2",
+ "quote",
  "standback",
- "syn 1.0.86",
+ "syn",
 ]
 
 [[package]]
@@ -2985,8 +3144,23 @@ dependencies = [
  "memchr",
  "mio 0.7.14",
  "num_cpus",
+ "once_cell",
+ "parking_lot 0.11.2",
  "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2997,6 +3171,17 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -3012,6 +3197,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,16 +3216,16 @@ dependencies = [
  "bytes 1.1.0",
  "futures-core",
  "futures-sink",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "0.4.10"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -3059,7 +3255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.14",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3071,9 +3267,9 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3086,10 +3282,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
+name = "tracing-log"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "sharded-slab",
+ "smallvec 1.8.0",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "trust-dns-proto"
@@ -3107,7 +3326,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "rand 0.8.4",
  "smallvec 1.8.0",
  "thiserror",
@@ -3126,7 +3345,7 @@ dependencies = [
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log 0.4.14",
+ "log",
  "lru-cache",
  "parking_lot 0.11.2",
  "resolv-conf",
@@ -3141,21 +3360,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -3181,6 +3385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ubyte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42756bb9e708855de2f8a98195643dff31a97f0485d90d8467b39dc24be9e8fe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,25 +3405,8 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
 dependencies = [
- "version_check 0.9.4",
-]
-
-[[package]]
-name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check 0.9.4",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -3233,12 +3429,6 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -3302,12 +3492,14 @@ dependencies = [
  "chrono-tz",
  "cookie 0.15.1",
  "cookie_store",
+ "ctrlc",
  "data-encoding",
  "data-url",
  "diesel",
  "diesel_migrations",
  "dotenv",
  "fern",
+ "futures",
  "governor",
  "handlebars",
  "html5ever",
@@ -3316,9 +3508,8 @@ dependencies = [
  "jsonwebtoken",
  "lettre",
  "libsqlite3-sys",
- "log 0.4.14",
+ "log",
  "markup5ever_rcdom",
- "multipart",
  "num-derive",
  "num-traits",
  "once_cell",
@@ -3333,11 +3524,11 @@ dependencies = [
  "ring",
  "rmpv",
  "rocket",
- "rocket_contrib",
  "serde",
  "serde_json",
  "syslog",
  "time 0.2.27",
+ "tokio",
  "totp-lite",
  "tracing",
  "u2f",
@@ -3352,12 +3543,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -3382,7 +3567,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.14",
+ "log",
  "try-lock",
 ]
 
@@ -3416,10 +3601,10 @@ checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
- "log 0.4.14",
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3441,7 +3626,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
- "quote 1.0.15",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3451,9 +3636,9 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.15",
- "syn 1.0.86",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3501,15 +3686,6 @@ checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -3595,7 +3771,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865"
 dependencies = [
- "log 0.4.14",
+ "log",
  "mac",
  "markup5ever",
  "time 0.1.44",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "vaultwarden"
 version = "1.0.0"
 authors = ["Daniel García <dani-garcia@users.noreply.github.com>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.56"
 resolver = "2"
 
 repository = "https://github.com/dani-garcia/vaultwarden"
@@ -13,6 +13,7 @@ publish = false
 build = "build.rs"
 
 [features]
+# default = ["sqlite"]
 # Empty to keep compatibility, prefer to set USE_SYSLOG=true
 enable_syslog = []
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]
@@ -29,21 +30,21 @@ unstable = []
 syslog = "4.0.1"
 
 [dependencies]
-# Web framework for nightly with a focus on ease-of-use, expressibility, and speed.
-rocket = { version = "=0.5.0-dev", features = ["tls"], default-features = false }
-rocket_contrib = "=0.5.0-dev"
+# Web framework
+rocket = { version = "0.5.0-rc.1", features = ["tls", "json"], default-features = false }
 
-# HTTP client
-reqwest = { version = "0.11.9", features = ["blocking", "json", "gzip", "brotli", "socks", "cookies", "trust-dns"] }
+# Async futures
+futures = "0.3.19"
+tokio = { version = "1.16.1", features = ["rt-multi-thread", "fs", "io-util", "parking_lot"] }
+ 
+ # HTTP client
+reqwest = { version = "0.11.9", features = ["stream", "json", "gzip", "brotli", "socks", "cookies", "trust-dns"] }
+bytes = "1.1.0"
 
 # Used for custom short lived cookie jar
 cookie = "0.15.1"
 cookie_store = "0.15.1"
-bytes = "1.1.0"
 url = "2.2.2"
-
-# multipart/form-data support
-multipart = { version = "0.18.0", features = ["server"], default-features = false }
 
 # WebSockets library
 ws = { version = "0.11.1", package = "parity-ws" }
@@ -141,10 +142,10 @@ backtrace = "0.3.64"
 paste = "1.0.6"
 governor = "0.4.1"
 
+ctrlc = { version = "3.2.1", features = ["termination"] }
+
 [patch.crates-io]
-# Use newest ring
-rocket = { git = 'https://github.com/SergioBenitez/Rocket', rev = '263e39b5b429de1913ce7e3036575a7b4d88b6d7' }
-rocket_contrib = { git = 'https://github.com/SergioBenitez/Rocket', rev = '263e39b5b429de1913ce7e3036575a7b4d88b6d7' }
+rocket = { git = 'https://github.com/SergioBenitez/Rocket', rev = '8cae077ba1d54b92cdef3e171a730b819d5eeb8e' }
 
 # The maintainer of the `job_scheduler` crate doesn't seem to have responded
 # to any issues or PRs for almost a year (as of April 2021). This hopefully

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,2 +1,0 @@
-[global.limits]
-json = 10485760 # 10 MiB

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -241,7 +241,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 {% if package_arch_target is defined %}
 COPY --from=build /app/target/{{ package_arch_target }}/release/vaultwarden .
@@ -255,5 +254,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -115,7 +115,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/release/vaultwarden .
 
@@ -125,5 +124,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -107,7 +107,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/vaultwarden .
 
@@ -117,5 +116,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/amd64/Dockerfile.buildx
+++ b/docker/amd64/Dockerfile.buildx
@@ -115,7 +115,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/release/vaultwarden .
 
@@ -125,5 +124,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -107,7 +107,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/vaultwarden .
 
@@ -117,5 +116,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -111,7 +111,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-musl/release/vaultwarden .
 
@@ -121,5 +120,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/arm64/Dockerfile.buildx
+++ b/docker/arm64/Dockerfile.buildx
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/arm64/Dockerfile.buildx.alpine
+++ b/docker/arm64/Dockerfile.buildx.alpine
@@ -111,7 +111,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/aarch64-unknown-linux-musl/release/vaultwarden .
 
@@ -121,5 +120,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -111,7 +111,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-musleabi/release/vaultwarden .
 
@@ -121,5 +120,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv6/Dockerfile.buildx.alpine
+++ b/docker/armv6/Dockerfile.buildx.alpine
@@ -111,7 +111,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/arm-unknown-linux-musleabi/release/vaultwarden .
 
@@ -121,5 +120,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -114,7 +114,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-musleabihf/release/vaultwarden .
 
@@ -124,5 +123,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv7/Dockerfile.buildx
+++ b/docker/armv7/Dockerfile.buildx
@@ -139,7 +139,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden .
 
@@ -149,5 +148,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -114,7 +114,6 @@ EXPOSE 3012
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage
 WORKDIR /
-COPY Rocket.toml .
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/armv7-unknown-linux-musleabihf/release/vaultwarden .
 
@@ -124,5 +123,9 @@ COPY docker/start.sh /start.sh
 HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
 
 # Configures the startup!
+# We should be able to remove the dumb-init now with Rocket 0.5
+# But the balenalib images have some issues with there entry.sh
+# See: https://github.com/balena-io-library/base-images/issues/735
+# Lets keep using dumb-init for now, since that is working fine.
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/start.sh"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-01-23
+stable

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
-version = "Two"
-edition = "2018"
+#version = "One"
+edition = "2021"
 max_width = 120
 newline_style = "Unix"
 use_small_heuristics = "Off"
-struct_lit_single_line = false
-overflow_delimited_expr = true
+#struct_lit_single_line = false
+#overflow_delimited_expr = true

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -3,13 +3,14 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::env;
 
+use rocket::serde::json::Json;
 use rocket::{
-    http::{Cookie, Cookies, SameSite, Status},
-    request::{self, FlashMessage, Form, FromRequest, Outcome, Request},
-    response::{content::Html, Flash, Redirect},
+    form::Form,
+    http::{Cookie, CookieJar, SameSite, Status},
+    request::{self, FlashMessage, FromRequest, Outcome, Request},
+    response::{content::RawHtml as Html, Flash, Redirect},
     Route,
 };
-use rocket_contrib::json::Json;
 
 use crate::{
     api::{ApiResult, EmptyResult, JsonResult, NumberOrString},
@@ -85,10 +86,11 @@ fn admin_path() -> String {
 
 struct Referer(Option<String>);
 
-impl<'a, 'r> FromRequest<'a, 'r> for Referer {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for Referer {
     type Error = ();
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         Outcome::Success(Referer(request.headers().get_one("Referer").map(str::to_string)))
     }
 }
@@ -96,10 +98,11 @@ impl<'a, 'r> FromRequest<'a, 'r> for Referer {
 #[derive(Debug)]
 struct IpHeader(Option<String>);
 
-impl<'a, 'r> FromRequest<'a, 'r> for IpHeader {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for IpHeader {
     type Error = ();
 
-    fn from_request(req: &'a Request<'r>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         if req.headers().get_one(&CONFIG.ip_header()).is_some() {
             Outcome::Success(IpHeader(Some(CONFIG.ip_header())))
         } else if req.headers().get_one("X-Client-IP").is_some() {
@@ -138,7 +141,7 @@ fn admin_url(referer: Referer) -> String {
 #[get("/", rank = 2)]
 fn admin_login(flash: Option<FlashMessage>) -> ApiResult<Html<String>> {
     // If there is an error, show it
-    let msg = flash.map(|msg| format!("{}: {}", msg.name(), msg.msg()));
+    let msg = flash.map(|msg| format!("{}: {}", msg.kind(), msg.message()));
     let json = json!({
         "page_content": "admin/login",
         "version": VERSION,
@@ -159,7 +162,7 @@ struct LoginForm {
 #[post("/", data = "<data>")]
 fn post_admin_login(
     data: Form<LoginForm>,
-    mut cookies: Cookies,
+    cookies: &CookieJar,
     ip: ClientIp,
     referer: Referer,
 ) -> Result<Redirect, Flash<Redirect>> {
@@ -180,7 +183,7 @@ fn post_admin_login(
 
         let cookie = Cookie::build(COOKIE_NAME, jwt)
             .path(admin_path())
-            .max_age(time::Duration::minutes(20))
+            .max_age(rocket::time::Duration::minutes(20))
             .same_site(SameSite::Strict)
             .http_only(true)
             .finish();
@@ -297,7 +300,7 @@ fn test_smtp(data: Json<InviteData>, _token: AdminToken) -> EmptyResult {
 }
 
 #[get("/logout")]
-fn logout(mut cookies: Cookies, referer: Referer) -> Redirect {
+fn logout(cookies: &CookieJar, referer: Referer) -> Redirect {
     cookies.remove(Cookie::named(COOKIE_NAME));
     Redirect::to(admin_url(referer))
 }
@@ -462,23 +465,23 @@ struct GitCommit {
     sha: String,
 }
 
-fn get_github_api<T: DeserializeOwned>(url: &str) -> Result<T, Error> {
+async fn get_github_api<T: DeserializeOwned>(url: &str) -> Result<T, Error> {
     let github_api = get_reqwest_client();
 
-    Ok(github_api.get(url).send()?.error_for_status()?.json::<T>()?)
+    Ok(github_api.get(url).send().await?.error_for_status()?.json::<T>().await?)
 }
 
-fn has_http_access() -> bool {
+async fn has_http_access() -> bool {
     let http_access = get_reqwest_client();
 
-    match http_access.head("https://github.com/dani-garcia/vaultwarden").send() {
+    match http_access.head("https://github.com/dani-garcia/vaultwarden").send().await {
         Ok(r) => r.status().is_success(),
         _ => false,
     }
 }
 
 #[get("/diagnostics")]
-fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResult<Html<String>> {
+async fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResult<Html<String>> {
     use crate::util::read_file_string;
     use chrono::prelude::*;
     use std::net::ToSocketAddrs;
@@ -497,7 +500,7 @@ fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResu
 
     // Execute some environment checks
     let running_within_docker = is_running_in_docker();
-    let has_http_access = has_http_access();
+    let has_http_access = has_http_access().await;
     let uses_proxy = env::var_os("HTTP_PROXY").is_some()
         || env::var_os("http_proxy").is_some()
         || env::var_os("HTTPS_PROXY").is_some()
@@ -513,11 +516,14 @@ fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResu
     // TODO: Maybe we need to cache this using a LazyStatic or something. Github only allows 60 requests per hour, and we use 3 here already.
     let (latest_release, latest_commit, latest_web_build) = if has_http_access {
         (
-            match get_github_api::<GitRelease>("https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest") {
+            match get_github_api::<GitRelease>("https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest")
+                .await
+            {
                 Ok(r) => r.tag_name,
                 _ => "-".to_string(),
             },
-            match get_github_api::<GitCommit>("https://api.github.com/repos/dani-garcia/vaultwarden/commits/main") {
+            match get_github_api::<GitCommit>("https://api.github.com/repos/dani-garcia/vaultwarden/commits/main").await
+            {
                 Ok(mut c) => {
                     c.sha.truncate(8);
                     c.sha
@@ -531,7 +537,9 @@ fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResu
             } else {
                 match get_github_api::<GitRelease>(
                     "https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest",
-                ) {
+                )
+                .await
+                {
                     Ok(r) => r.tag_name.trim_start_matches('v').to_string(),
                     _ => "-".to_string(),
                 }
@@ -562,7 +570,7 @@ fn diagnostics(_token: AdminToken, ip_header: IpHeader, conn: DbConn) -> ApiResu
         "ip_header_config": &CONFIG.ip_header(),
         "uses_proxy": uses_proxy,
         "db_type": *DB_TYPE,
-        "db_version": get_sql_server_version(&conn),
+        "db_version": get_sql_server_version(&conn).await,
         "admin_url": format!("{}/diagnostics", admin_url(Referer(None))),
         "overrides": &CONFIG.get_overrides().join(", "),
         "server_time_local": Local::now().format("%Y-%m-%d %H:%M:%S %Z").to_string(),
@@ -591,9 +599,9 @@ fn delete_config(_token: AdminToken) -> EmptyResult {
 }
 
 #[post("/config/backup_db")]
-fn backup_db(_token: AdminToken, conn: DbConn) -> EmptyResult {
+async fn backup_db(_token: AdminToken, conn: DbConn) -> EmptyResult {
     if *CAN_BACKUP {
-        backup_database(&conn)
+        backup_database(&conn).await
     } else {
         err!("Can't back up current DB (Only SQLite supports this feature)");
     }
@@ -601,21 +609,22 @@ fn backup_db(_token: AdminToken, conn: DbConn) -> EmptyResult {
 
 pub struct AdminToken {}
 
-impl<'a, 'r> FromRequest<'a, 'r> for AdminToken {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AdminToken {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         if CONFIG.disable_admin_token() {
             Outcome::Success(AdminToken {})
         } else {
-            let mut cookies = request.cookies();
+            let cookies = request.cookies();
 
             let access_token = match cookies.get(COOKIE_NAME) {
                 Some(cookie) => cookie.value(),
                 None => return Outcome::Forward(()), // If there is no cookie, redirect to login
             };
 
-            let ip = match request.guard::<ClientIp>() {
+            let ip = match ClientIp::from_request(request).await {
                 Outcome::Success(ip) => ip.ip,
                 _ => err_handler!("Error getting Client IP"),
             };

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -25,6 +25,8 @@ use crate::{
     CONFIG, VERSION,
 };
 
+use futures::{stream, stream::StreamExt};
+
 pub fn routes() -> Vec<Route> {
     if !CONFIG.disable_admin_token() && !CONFIG.is_admin_token_set() {
         return routes![admin_disabled];
@@ -253,8 +255,8 @@ struct InviteData {
     email: String,
 }
 
-fn get_user_or_404(uuid: &str, conn: &DbConn) -> ApiResult<User> {
-    if let Some(user) = User::find_by_uuid(uuid, conn) {
+async fn get_user_or_404(uuid: &str, conn: &DbConn) -> ApiResult<User> {
+    if let Some(user) = User::find_by_uuid(uuid, conn).await {
         Ok(user)
     } else {
         err_code!("User doesn't exist", Status::NotFound.code);
@@ -262,30 +264,28 @@ fn get_user_or_404(uuid: &str, conn: &DbConn) -> ApiResult<User> {
 }
 
 #[post("/invite", data = "<data>")]
-fn invite_user(data: Json<InviteData>, _token: AdminToken, conn: DbConn) -> JsonResult {
+async fn invite_user(data: Json<InviteData>, _token: AdminToken, conn: DbConn) -> JsonResult {
     let data: InviteData = data.into_inner();
     let email = data.email.clone();
-    if User::find_by_mail(&data.email, &conn).is_some() {
+    if User::find_by_mail(&data.email, &conn).await.is_some() {
         err_code!("User already exists", Status::Conflict.code)
     }
 
     let mut user = User::new(email);
 
-    // TODO: After try_blocks is stabilized, this can be made more readable
-    // See: https://github.com/rust-lang/rust/issues/31436
-    (|| {
+    async fn _generate_invite(user: &User, conn: &DbConn) -> EmptyResult {
         if CONFIG.mail_enabled() {
-            mail::send_invite(&user.email, &user.uuid, None, None, &CONFIG.invitation_org_name(), None)?;
+            mail::send_invite(&user.email, &user.uuid, None, None, &CONFIG.invitation_org_name(), None)
         } else {
             let invitation = Invitation::new(user.email.clone());
-            invitation.save(&conn)?;
+            invitation.save(conn).await
         }
+    }
 
-        user.save(&conn)
-    })()
-    .map_err(|e| e.with_code(Status::InternalServerError.code))?;
+    _generate_invite(&user, &conn).await.map_err(|e| e.with_code(Status::InternalServerError.code))?;
+    user.save(&conn).await.map_err(|e| e.with_code(Status::InternalServerError.code))?;
 
-    Ok(Json(user.to_json(&conn)))
+    Ok(Json(user.to_json(&conn).await))
 }
 
 #[post("/test/smtp", data = "<data>")]
@@ -306,84 +306,90 @@ fn logout(cookies: &CookieJar, referer: Referer) -> Redirect {
 }
 
 #[get("/users")]
-fn get_users_json(_token: AdminToken, conn: DbConn) -> Json<Value> {
-    let users = User::get_all(&conn);
-    let users_json: Vec<Value> = users.iter().map(|u| u.to_json(&conn)).collect();
+async fn get_users_json(_token: AdminToken, conn: DbConn) -> Json<Value> {
+    let users_json = stream::iter(User::get_all(&conn).await)
+        .then(|u| async {
+            let u = u; // Move out this single variable
+            u.to_json(&conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     Json(Value::Array(users_json))
 }
 
 #[get("/users/overview")]
-fn users_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
-    let users = User::get_all(&conn);
-    let dt_fmt = "%Y-%m-%d %H:%M:%S %Z";
-    let users_json: Vec<Value> = users
-        .iter()
-        .map(|u| {
-            let mut usr = u.to_json(&conn);
-            usr["cipher_count"] = json!(Cipher::count_owned_by_user(&u.uuid, &conn));
-            usr["attachment_count"] = json!(Attachment::count_by_user(&u.uuid, &conn));
-            usr["attachment_size"] = json!(get_display_size(Attachment::size_by_user(&u.uuid, &conn) as i32));
+async fn users_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
+    const DT_FMT: &str = "%Y-%m-%d %H:%M:%S %Z";
+
+    let users_json = stream::iter(User::get_all(&conn).await)
+        .then(|u| async {
+            let u = u; // Move out this single variable
+            let mut usr = u.to_json(&conn).await;
+            usr["cipher_count"] = json!(Cipher::count_owned_by_user(&u.uuid, &conn).await);
+            usr["attachment_count"] = json!(Attachment::count_by_user(&u.uuid, &conn).await);
+            usr["attachment_size"] = json!(get_display_size(Attachment::size_by_user(&u.uuid, &conn).await as i32));
             usr["user_enabled"] = json!(u.enabled);
-            usr["created_at"] = json!(format_naive_datetime_local(&u.created_at, dt_fmt));
-            usr["last_active"] = match u.last_active(&conn) {
-                Some(dt) => json!(format_naive_datetime_local(&dt, dt_fmt)),
+            usr["created_at"] = json!(format_naive_datetime_local(&u.created_at, DT_FMT));
+            usr["last_active"] = match u.last_active(&conn).await {
+                Some(dt) => json!(format_naive_datetime_local(&dt, DT_FMT)),
                 None => json!("Never"),
             };
             usr
         })
-        .collect();
+        .collect::<Vec<Value>>()
+        .await;
 
     let text = AdminTemplateData::with_data("admin/users", json!(users_json)).render()?;
     Ok(Html(text))
 }
 
 #[get("/users/<uuid>")]
-fn get_user_json(uuid: String, _token: AdminToken, conn: DbConn) -> JsonResult {
-    let user = get_user_or_404(&uuid, &conn)?;
+async fn get_user_json(uuid: String, _token: AdminToken, conn: DbConn) -> JsonResult {
+    let user = get_user_or_404(&uuid, &conn).await?;
 
-    Ok(Json(user.to_json(&conn)))
+    Ok(Json(user.to_json(&conn).await))
 }
 
 #[post("/users/<uuid>/delete")]
-fn delete_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let user = get_user_or_404(&uuid, &conn)?;
-    user.delete(&conn)
+async fn delete_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let user = get_user_or_404(&uuid, &conn).await?;
+    user.delete(&conn).await
 }
 
 #[post("/users/<uuid>/deauth")]
-fn deauth_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let mut user = get_user_or_404(&uuid, &conn)?;
-    Device::delete_all_by_user(&user.uuid, &conn)?;
+async fn deauth_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let mut user = get_user_or_404(&uuid, &conn).await?;
+    Device::delete_all_by_user(&user.uuid, &conn).await?;
     user.reset_security_stamp();
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[post("/users/<uuid>/disable")]
-fn disable_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let mut user = get_user_or_404(&uuid, &conn)?;
-    Device::delete_all_by_user(&user.uuid, &conn)?;
+async fn disable_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let mut user = get_user_or_404(&uuid, &conn).await?;
+    Device::delete_all_by_user(&user.uuid, &conn).await?;
     user.reset_security_stamp();
     user.enabled = false;
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[post("/users/<uuid>/enable")]
-fn enable_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let mut user = get_user_or_404(&uuid, &conn)?;
+async fn enable_user(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let mut user = get_user_or_404(&uuid, &conn).await?;
     user.enabled = true;
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[post("/users/<uuid>/remove-2fa")]
-fn remove_2fa(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let mut user = get_user_or_404(&uuid, &conn)?;
-    TwoFactor::delete_all_by_user(&user.uuid, &conn)?;
+async fn remove_2fa(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let mut user = get_user_or_404(&uuid, &conn).await?;
+    TwoFactor::delete_all_by_user(&user.uuid, &conn).await?;
     user.totp_recover = None;
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[derive(Deserialize, Debug)]
@@ -394,10 +400,10 @@ struct UserOrgTypeData {
 }
 
 #[post("/users/org_type", data = "<data>")]
-fn update_user_org_type(data: Json<UserOrgTypeData>, _token: AdminToken, conn: DbConn) -> EmptyResult {
+async fn update_user_org_type(data: Json<UserOrgTypeData>, _token: AdminToken, conn: DbConn) -> EmptyResult {
     let data: UserOrgTypeData = data.into_inner();
 
-    let mut user_to_edit = match UserOrganization::find_by_user_and_org(&data.user_uuid, &data.org_uuid, &conn) {
+    let mut user_to_edit = match UserOrganization::find_by_user_and_org(&data.user_uuid, &data.org_uuid, &conn).await {
         Some(user) => user,
         None => err!("The specified user isn't member of the organization"),
     };
@@ -409,7 +415,8 @@ fn update_user_org_type(data: Json<UserOrgTypeData>, _token: AdminToken, conn: D
 
     if user_to_edit.atype == UserOrgType::Owner && new_type != UserOrgType::Owner {
         // Removing owner permmission, check that there are at least another owner
-        let num_owners = UserOrganization::find_by_org_and_type(&data.org_uuid, UserOrgType::Owner as i32, &conn).len();
+        let num_owners =
+            UserOrganization::find_by_org_and_type(&data.org_uuid, UserOrgType::Owner as i32, &conn).await.len();
 
         if num_owners <= 1 {
             err!("Can't change the type of the last owner")
@@ -417,37 +424,37 @@ fn update_user_org_type(data: Json<UserOrgTypeData>, _token: AdminToken, conn: D
     }
 
     user_to_edit.atype = new_type as i32;
-    user_to_edit.save(&conn)
+    user_to_edit.save(&conn).await
 }
 
 #[post("/users/update_revision")]
-fn update_revision_users(_token: AdminToken, conn: DbConn) -> EmptyResult {
-    User::update_all_revisions(&conn)
+async fn update_revision_users(_token: AdminToken, conn: DbConn) -> EmptyResult {
+    User::update_all_revisions(&conn).await
 }
 
 #[get("/organizations/overview")]
-fn organizations_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
-    let organizations = Organization::get_all(&conn);
-    let organizations_json: Vec<Value> = organizations
-        .iter()
-        .map(|o| {
+async fn organizations_overview(_token: AdminToken, conn: DbConn) -> ApiResult<Html<String>> {
+    let organizations_json = stream::iter(Organization::get_all(&conn).await)
+        .then(|o| async {
+            let o = o; //Move out this single variable
             let mut org = o.to_json();
-            org["user_count"] = json!(UserOrganization::count_by_org(&o.uuid, &conn));
-            org["cipher_count"] = json!(Cipher::count_by_org(&o.uuid, &conn));
-            org["attachment_count"] = json!(Attachment::count_by_org(&o.uuid, &conn));
-            org["attachment_size"] = json!(get_display_size(Attachment::size_by_org(&o.uuid, &conn) as i32));
+            org["user_count"] = json!(UserOrganization::count_by_org(&o.uuid, &conn).await);
+            org["cipher_count"] = json!(Cipher::count_by_org(&o.uuid, &conn).await);
+            org["attachment_count"] = json!(Attachment::count_by_org(&o.uuid, &conn).await);
+            org["attachment_size"] = json!(get_display_size(Attachment::size_by_org(&o.uuid, &conn).await as i32));
             org
         })
-        .collect();
+        .collect::<Vec<Value>>()
+        .await;
 
     let text = AdminTemplateData::with_data("admin/organizations", json!(organizations_json)).render()?;
     Ok(Html(text))
 }
 
 #[post("/organizations/<uuid>/delete")]
-fn delete_organization(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
-    let org = Organization::find_by_uuid(&uuid, &conn).map_res("Organization doesn't exist")?;
-    org.delete(&conn)
+async fn delete_organization(uuid: String, _token: AdminToken, conn: DbConn) -> EmptyResult {
+    let org = Organization::find_by_uuid(&uuid, &conn).await.map_res("Organization doesn't exist")?;
+    org.delete(&conn).await
 }
 
 #[derive(Deserialize)]

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -141,7 +141,7 @@ fn admin_url(referer: Referer) -> String {
 }
 
 #[get("/", rank = 2)]
-fn admin_login(flash: Option<FlashMessage>) -> ApiResult<Html<String>> {
+fn admin_login(flash: Option<FlashMessage<'_>>) -> ApiResult<Html<String>> {
     // If there is an error, show it
     let msg = flash.map(|msg| format!("{}: {}", msg.kind(), msg.message()));
     let json = json!({
@@ -164,7 +164,7 @@ struct LoginForm {
 #[post("/", data = "<data>")]
 fn post_admin_login(
     data: Form<LoginForm>,
-    cookies: &CookieJar,
+    cookies: &CookieJar<'_>,
     ip: ClientIp,
     referer: Referer,
 ) -> Result<Redirect, Flash<Redirect>> {
@@ -300,7 +300,7 @@ fn test_smtp(data: Json<InviteData>, _token: AdminToken) -> EmptyResult {
 }
 
 #[get("/logout")]
-fn logout(cookies: &CookieJar, referer: Referer) -> Redirect {
+fn logout(cookies: &CookieJar<'_>, referer: Referer) -> Redirect {
     cookies.remove(Cookie::named(COOKIE_NAME));
     Redirect::to(admin_url(referer))
 }

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
 use serde_json::Value;
 
 use crate::{

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -664,7 +664,12 @@ fn verify_password(data: JsonUpcase<SecretVerificationRequest>, headers: Headers
     Ok(())
 }
 
-async fn _api_key(data: JsonUpcase<SecretVerificationRequest>, rotate: bool, headers: Headers, conn: DbConn) -> JsonResult {
+async fn _api_key(
+    data: JsonUpcase<SecretVerificationRequest>,
+    rotate: bool,
+    headers: Headers,
+    conn: DbConn,
+) -> JsonResult {
     let data: SecretVerificationRequest = data.into_inner().data;
     let mut user = headers.user;
 

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -63,11 +63,11 @@ struct KeysData {
 }
 
 #[post("/accounts/register", data = "<data>")]
-fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
+async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
     let data: RegisterData = data.into_inner().data;
     let email = data.Email.to_lowercase();
 
-    let mut user = match User::find_by_mail(&email, &conn) {
+    let mut user = match User::find_by_mail(&email, &conn).await {
         Some(user) => {
             if !user.password_hash.is_empty() {
                 if CONFIG.is_signup_allowed(&email) {
@@ -84,13 +84,13 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
                 } else {
                     err!("Registration email does not match invite email")
                 }
-            } else if Invitation::take(&email, &conn) {
-                for mut user_org in UserOrganization::find_invited_by_user(&user.uuid, &conn).iter_mut() {
+            } else if Invitation::take(&email, &conn).await {
+                for mut user_org in UserOrganization::find_invited_by_user(&user.uuid, &conn).await.iter_mut() {
                     user_org.status = UserOrgStatus::Accepted as i32;
-                    user_org.save(&conn)?;
+                    user_org.save(&conn).await?;
                 }
                 user
-            } else if EmergencyAccess::find_invited_by_grantee_email(&email, &conn).is_some() {
+            } else if EmergencyAccess::find_invited_by_grantee_email(&email, &conn).await.is_some() {
                 user
             } else if CONFIG.is_signup_allowed(&email) {
                 err!("Account with this email already exists")
@@ -102,7 +102,7 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
             // Order is important here; the invitation check must come first
             // because the vaultwarden admin can invite anyone, regardless
             // of other signup restrictions.
-            if Invitation::take(&email, &conn) || CONFIG.is_signup_allowed(&email) {
+            if Invitation::take(&email, &conn).await || CONFIG.is_signup_allowed(&email) {
                 User::new(email.clone())
             } else {
                 err!("Registration not allowed or user already exists")
@@ -111,7 +111,7 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
     };
 
     // Make sure we don't leave a lingering invitation.
-    Invitation::take(&email, &conn);
+    Invitation::take(&email, &conn).await;
 
     if let Some(client_kdf_iter) = data.KdfIterations {
         user.client_kdf_iter = client_kdf_iter;
@@ -150,12 +150,12 @@ fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
         }
     }
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[get("/accounts/profile")]
-fn profile(headers: Headers, conn: DbConn) -> Json<Value> {
-    Json(headers.user.to_json(&conn))
+async fn profile(headers: Headers, conn: DbConn) -> Json<Value> {
+    Json(headers.user.to_json(&conn).await)
 }
 
 #[derive(Deserialize, Debug)]
@@ -168,12 +168,12 @@ struct ProfileData {
 }
 
 #[put("/accounts/profile", data = "<data>")]
-fn put_profile(data: JsonUpcase<ProfileData>, headers: Headers, conn: DbConn) -> JsonResult {
-    post_profile(data, headers, conn)
+async fn put_profile(data: JsonUpcase<ProfileData>, headers: Headers, conn: DbConn) -> JsonResult {
+    post_profile(data, headers, conn).await
 }
 
 #[post("/accounts/profile", data = "<data>")]
-fn post_profile(data: JsonUpcase<ProfileData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn post_profile(data: JsonUpcase<ProfileData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: ProfileData = data.into_inner().data;
 
     let mut user = headers.user;
@@ -183,13 +183,13 @@ fn post_profile(data: JsonUpcase<ProfileData>, headers: Headers, conn: DbConn) -
         Some(ref h) if h.is_empty() => None,
         _ => data.MasterPasswordHint,
     };
-    user.save(&conn)?;
-    Ok(Json(user.to_json(&conn)))
+    user.save(&conn).await?;
+    Ok(Json(user.to_json(&conn).await))
 }
 
 #[get("/users/<uuid>/public-key")]
-fn get_public_keys(uuid: String, _headers: Headers, conn: DbConn) -> JsonResult {
-    let user = match User::find_by_uuid(&uuid, &conn) {
+async fn get_public_keys(uuid: String, _headers: Headers, conn: DbConn) -> JsonResult {
+    let user = match User::find_by_uuid(&uuid, &conn).await {
         Some(user) => user,
         None => err!("User doesn't exist"),
     };
@@ -202,7 +202,7 @@ fn get_public_keys(uuid: String, _headers: Headers, conn: DbConn) -> JsonResult 
 }
 
 #[post("/accounts/keys", data = "<data>")]
-fn post_keys(data: JsonUpcase<KeysData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn post_keys(data: JsonUpcase<KeysData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: KeysData = data.into_inner().data;
 
     let mut user = headers.user;
@@ -210,7 +210,7 @@ fn post_keys(data: JsonUpcase<KeysData>, headers: Headers, conn: DbConn) -> Json
     user.private_key = Some(data.EncryptedPrivateKey);
     user.public_key = Some(data.PublicKey);
 
-    user.save(&conn)?;
+    user.save(&conn).await?;
 
     Ok(Json(json!({
         "PrivateKey": user.private_key,
@@ -228,7 +228,7 @@ struct ChangePassData {
 }
 
 #[post("/accounts/password", data = "<data>")]
-fn post_password(data: JsonUpcase<ChangePassData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_password(data: JsonUpcase<ChangePassData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: ChangePassData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -241,7 +241,7 @@ fn post_password(data: JsonUpcase<ChangePassData>, headers: Headers, conn: DbCon
         Some(vec![String::from("post_rotatekey"), String::from("get_contacts"), String::from("get_public_keys")]),
     );
     user.akey = data.Key;
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[derive(Deserialize)]
@@ -256,7 +256,7 @@ struct ChangeKdfData {
 }
 
 #[post("/accounts/kdf", data = "<data>")]
-fn post_kdf(data: JsonUpcase<ChangeKdfData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_kdf(data: JsonUpcase<ChangeKdfData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: ChangeKdfData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -268,7 +268,7 @@ fn post_kdf(data: JsonUpcase<ChangeKdfData>, headers: Headers, conn: DbConn) -> 
     user.client_kdf_type = data.Kdf;
     user.set_password(&data.NewMasterPasswordHash, None);
     user.akey = data.Key;
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[derive(Deserialize)]
@@ -291,7 +291,7 @@ struct KeyData {
 }
 
 #[post("/accounts/key", data = "<data>")]
-fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
+async fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
     let data: KeyData = data.into_inner().data;
 
     if !headers.user.check_valid_password(&data.MasterPasswordHash) {
@@ -302,7 +302,7 @@ fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt:
 
     // Update folder data
     for folder_data in data.Folders {
-        let mut saved_folder = match Folder::find_by_uuid(&folder_data.Id, &conn) {
+        let mut saved_folder = match Folder::find_by_uuid(&folder_data.Id, &conn).await {
             Some(folder) => folder,
             None => err!("Folder doesn't exist"),
         };
@@ -312,14 +312,14 @@ fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt:
         }
 
         saved_folder.name = folder_data.Name;
-        saved_folder.save(&conn)?
+        saved_folder.save(&conn).await?
     }
 
     // Update cipher data
     use super::ciphers::update_cipher_from_data;
 
     for cipher_data in data.Ciphers {
-        let mut saved_cipher = match Cipher::find_by_uuid(cipher_data.Id.as_ref().unwrap(), &conn) {
+        let mut saved_cipher = match Cipher::find_by_uuid(cipher_data.Id.as_ref().unwrap(), &conn).await {
             Some(cipher) => cipher,
             None => err!("Cipher doesn't exist"),
         };
@@ -330,7 +330,7 @@ fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt:
 
         // Prevent triggering cipher updates via WebSockets by settings UpdateType::None
         // The user sessions are invalidated because all the ciphers were re-encrypted and thus triggering an update could cause issues.
-        update_cipher_from_data(&mut saved_cipher, cipher_data, &headers, false, &conn, &nt, UpdateType::None)?
+        update_cipher_from_data(&mut saved_cipher, cipher_data, &headers, false, &conn, &nt, UpdateType::None).await?
     }
 
     // Update user data
@@ -340,11 +340,11 @@ fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, conn: DbConn, nt:
     user.private_key = Some(data.PrivateKey);
     user.reset_security_stamp();
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[post("/accounts/security-stamp", data = "<data>")]
-fn post_sstamp(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_sstamp(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: PasswordData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -352,9 +352,9 @@ fn post_sstamp(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -
         err!("Invalid password")
     }
 
-    Device::delete_all_by_user(&user.uuid, &conn)?;
+    Device::delete_all_by_user(&user.uuid, &conn).await?;
     user.reset_security_stamp();
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[derive(Deserialize)]
@@ -365,7 +365,7 @@ struct EmailTokenData {
 }
 
 #[post("/accounts/email-token", data = "<data>")]
-fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: EmailTokenData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -373,7 +373,7 @@ fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: Db
         err!("Invalid password")
     }
 
-    if User::find_by_mail(&data.NewEmail, &conn).is_some() {
+    if User::find_by_mail(&data.NewEmail, &conn).await.is_some() {
         err!("Email already in use");
     }
 
@@ -391,7 +391,7 @@ fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, conn: Db
 
     user.email_new = Some(data.NewEmail);
     user.email_new_token = Some(token);
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[derive(Deserialize)]
@@ -406,7 +406,7 @@ struct ChangeEmailData {
 }
 
 #[post("/accounts/email", data = "<data>")]
-fn post_email(data: JsonUpcase<ChangeEmailData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_email(data: JsonUpcase<ChangeEmailData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: ChangeEmailData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -414,7 +414,7 @@ fn post_email(data: JsonUpcase<ChangeEmailData>, headers: Headers, conn: DbConn)
         err!("Invalid password")
     }
 
-    if User::find_by_mail(&data.NewEmail, &conn).is_some() {
+    if User::find_by_mail(&data.NewEmail, &conn).await.is_some() {
         err!("Email already in use");
     }
 
@@ -449,7 +449,7 @@ fn post_email(data: JsonUpcase<ChangeEmailData>, headers: Headers, conn: DbConn)
     user.set_password(&data.NewMasterPasswordHash, None);
     user.akey = data.Key;
 
-    user.save(&conn)
+    user.save(&conn).await
 }
 
 #[post("/accounts/verify-email")]
@@ -475,10 +475,10 @@ struct VerifyEmailTokenData {
 }
 
 #[post("/accounts/verify-email-token", data = "<data>")]
-fn post_verify_email_token(data: JsonUpcase<VerifyEmailTokenData>, conn: DbConn) -> EmptyResult {
+async fn post_verify_email_token(data: JsonUpcase<VerifyEmailTokenData>, conn: DbConn) -> EmptyResult {
     let data: VerifyEmailTokenData = data.into_inner().data;
 
-    let mut user = match User::find_by_uuid(&data.UserId, &conn) {
+    let mut user = match User::find_by_uuid(&data.UserId, &conn).await {
         Some(user) => user,
         None => err!("User doesn't exist"),
     };
@@ -493,7 +493,7 @@ fn post_verify_email_token(data: JsonUpcase<VerifyEmailTokenData>, conn: DbConn)
     user.verified_at = Some(Utc::now().naive_utc());
     user.last_verifying_at = None;
     user.login_verify_count = 0;
-    if let Err(e) = user.save(&conn) {
+    if let Err(e) = user.save(&conn).await {
         error!("Error saving email verification: {:#?}", e);
     }
 
@@ -507,13 +507,11 @@ struct DeleteRecoverData {
 }
 
 #[post("/accounts/delete-recover", data = "<data>")]
-fn post_delete_recover(data: JsonUpcase<DeleteRecoverData>, conn: DbConn) -> EmptyResult {
+async fn post_delete_recover(data: JsonUpcase<DeleteRecoverData>, conn: DbConn) -> EmptyResult {
     let data: DeleteRecoverData = data.into_inner().data;
 
-    let user = User::find_by_mail(&data.Email, &conn);
-
     if CONFIG.mail_enabled() {
-        if let Some(user) = user {
+        if let Some(user) = User::find_by_mail(&data.Email, &conn).await {
             if let Err(e) = mail::send_delete_account(&user.email, &user.uuid) {
                 error!("Error sending delete account email: {:#?}", e);
             }
@@ -536,10 +534,10 @@ struct DeleteRecoverTokenData {
 }
 
 #[post("/accounts/delete-recover-token", data = "<data>")]
-fn post_delete_recover_token(data: JsonUpcase<DeleteRecoverTokenData>, conn: DbConn) -> EmptyResult {
+async fn post_delete_recover_token(data: JsonUpcase<DeleteRecoverTokenData>, conn: DbConn) -> EmptyResult {
     let data: DeleteRecoverTokenData = data.into_inner().data;
 
-    let user = match User::find_by_uuid(&data.UserId, &conn) {
+    let user = match User::find_by_uuid(&data.UserId, &conn).await {
         Some(user) => user,
         None => err!("User doesn't exist"),
     };
@@ -551,16 +549,16 @@ fn post_delete_recover_token(data: JsonUpcase<DeleteRecoverTokenData>, conn: DbC
     if claims.sub != user.uuid {
         err!("Invalid claim");
     }
-    user.delete(&conn)
+    user.delete(&conn).await
 }
 
 #[post("/accounts/delete", data = "<data>")]
-fn post_delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
-    delete_account(data, headers, conn)
+async fn post_delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
+    delete_account(data, headers, conn).await
 }
 
 #[delete("/accounts", data = "<data>")]
-fn delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: PasswordData = data.into_inner().data;
     let user = headers.user;
 
@@ -568,7 +566,7 @@ fn delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn
         err!("Invalid password")
     }
 
-    user.delete(&conn)
+    user.delete(&conn).await
 }
 
 #[get("/accounts/revision-date")]
@@ -584,7 +582,7 @@ struct PasswordHintData {
 }
 
 #[post("/accounts/password-hint", data = "<data>")]
-fn password_hint(data: JsonUpcase<PasswordHintData>, conn: DbConn) -> EmptyResult {
+async fn password_hint(data: JsonUpcase<PasswordHintData>, conn: DbConn) -> EmptyResult {
     if !CONFIG.mail_enabled() && !CONFIG.show_password_hint() {
         err!("This server is not configured to provide password hints.");
     }
@@ -594,7 +592,7 @@ fn password_hint(data: JsonUpcase<PasswordHintData>, conn: DbConn) -> EmptyResul
     let data: PasswordHintData = data.into_inner().data;
     let email = &data.Email;
 
-    match User::find_by_mail(email, &conn) {
+    match User::find_by_mail(email, &conn).await {
         None => {
             // To prevent user enumeration, act as if the user exists.
             if CONFIG.mail_enabled() {
@@ -633,10 +631,10 @@ struct PreloginData {
 }
 
 #[post("/accounts/prelogin", data = "<data>")]
-fn prelogin(data: JsonUpcase<PreloginData>, conn: DbConn) -> Json<Value> {
+async fn prelogin(data: JsonUpcase<PreloginData>, conn: DbConn) -> Json<Value> {
     let data: PreloginData = data.into_inner().data;
 
-    let (kdf_type, kdf_iter) = match User::find_by_mail(&data.Email, &conn) {
+    let (kdf_type, kdf_iter) = match User::find_by_mail(&data.Email, &conn).await {
         Some(user) => (user.client_kdf_type, user.client_kdf_iter),
         None => (User::CLIENT_KDF_TYPE_DEFAULT, User::CLIENT_KDF_ITER_DEFAULT),
     };
@@ -666,7 +664,7 @@ fn verify_password(data: JsonUpcase<SecretVerificationRequest>, headers: Headers
     Ok(())
 }
 
-fn _api_key(data: JsonUpcase<SecretVerificationRequest>, rotate: bool, headers: Headers, conn: DbConn) -> JsonResult {
+async fn _api_key(data: JsonUpcase<SecretVerificationRequest>, rotate: bool, headers: Headers, conn: DbConn) -> JsonResult {
     let data: SecretVerificationRequest = data.into_inner().data;
     let mut user = headers.user;
 
@@ -676,7 +674,7 @@ fn _api_key(data: JsonUpcase<SecretVerificationRequest>, rotate: bool, headers: 
 
     if rotate || user.api_key.is_none() {
         user.api_key = Some(crypto::generate_api_key());
-        user.save(&conn).expect("Error saving API key");
+        user.save(&conn).await.expect("Error saving API key");
     }
 
     Ok(Json(json!({
@@ -686,11 +684,11 @@ fn _api_key(data: JsonUpcase<SecretVerificationRequest>, rotate: bool, headers: 
 }
 
 #[post("/accounts/api-key", data = "<data>")]
-fn api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
-    _api_key(data, false, headers, conn)
+async fn api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
+    _api_key(data, false, headers, conn).await
 }
 
 #[post("/accounts/rotate-api-key", data = "<data>")]
-fn rotate_api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
-    _api_key(data, true, headers, conn)
+async fn rotate_api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
+    _api_key(data, true, headers, conn).await
 }

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -1,12 +1,13 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
 
 use chrono::{NaiveDateTime, Utc};
-use rocket::{http::ContentType, request::Form, Data, Route};
-use rocket_contrib::json::Json;
+use rocket::fs::TempFile;
+use rocket::serde::json::Json;
+use rocket::{
+    form::{Form, FromForm},
+    Route,
+};
 use serde_json::Value;
-
-use multipart::server::{save::SavedData, Multipart, SaveResult};
 
 use crate::{
     api::{self, EmptyResult, JsonResult, JsonUpcase, Notify, PasswordData, UpdateType},
@@ -79,9 +80,9 @@ pub fn routes() -> Vec<Route> {
     ]
 }
 
-pub fn purge_trashed_ciphers(pool: DbPool) {
+pub async fn purge_trashed_ciphers(pool: DbPool) {
     debug!("Purging trashed ciphers");
-    if let Ok(conn) = pool.get() {
+    if let Ok(conn) = pool.get().await {
         Cipher::purge_trash(&conn);
     } else {
         error!("Failed to get DB connection while purging trashed ciphers")
@@ -90,12 +91,12 @@ pub fn purge_trashed_ciphers(pool: DbPool) {
 
 #[derive(FromForm, Default)]
 struct SyncData {
-    #[form(field = "excludeDomains")]
+    #[field(name = "excludeDomains")]
     exclude_domains: bool, // Default: 'false'
 }
 
 #[get("/sync?<data..>")]
-fn sync(data: Form<SyncData>, headers: Headers, conn: DbConn) -> Json<Value> {
+fn sync(data: SyncData, headers: Headers, conn: DbConn) -> Json<Value> {
     let user_json = headers.user.to_json(&conn);
 
     let folders = Folder::find_by_user(&headers.user.uuid, &conn);
@@ -828,6 +829,12 @@ fn post_attachment_v2(
     })))
 }
 
+#[derive(FromForm)]
+struct UploadData<'f> {
+    key: Option<String>,
+    data: TempFile<'f>,
+}
+
 /// Saves the data content of an attachment to a file. This is common code
 /// shared between the v2 and legacy attachment APIs.
 ///
@@ -836,22 +843,21 @@ fn post_attachment_v2(
 ///
 /// When used with the v2 API, post_attachment_v2() has already created the
 /// database record, which is passed in as `attachment`.
-fn save_attachment(
+async fn save_attachment(
     mut attachment: Option<Attachment>,
     cipher_uuid: String,
-    data: Data,
-    content_type: &ContentType,
+    data: Form<UploadData<'_>>,
     headers: &Headers,
-    conn: &DbConn,
-    nt: Notify,
-) -> Result<Cipher, crate::error::Error> {
-    let cipher = match Cipher::find_by_uuid(&cipher_uuid, conn) {
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> Result<(Cipher, DbConn), crate::error::Error> {
+    let cipher = match Cipher::find_by_uuid(&cipher_uuid, &conn) {
         Some(cipher) => cipher,
-        None => err_discard!("Cipher doesn't exist", data),
+        None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn) {
-        err_discard!("Cipher is not write accessible", data)
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn) {
+        err!("Cipher is not write accessible")
     }
 
     // In the v2 API, the attachment record has already been created,
@@ -863,11 +869,11 @@ fn save_attachment(
 
     let size_limit = if let Some(ref user_uuid) = cipher.user_uuid {
         match CONFIG.user_attachment_limit() {
-            Some(0) => err_discard!("Attachments are disabled", data),
+            Some(0) => err!("Attachments are disabled"),
             Some(limit_kb) => {
-                let left = (limit_kb * 1024) - Attachment::size_by_user(user_uuid, conn) + size_adjust;
+                let left = (limit_kb * 1024) - Attachment::size_by_user(user_uuid, &conn) + size_adjust;
                 if left <= 0 {
-                    err_discard!("Attachment storage limit reached! Delete some attachments to free up space", data)
+                    err!("Attachment storage limit reached! Delete some attachments to free up space")
                 }
                 Some(left as u64)
             }
@@ -875,130 +881,78 @@ fn save_attachment(
         }
     } else if let Some(ref org_uuid) = cipher.organization_uuid {
         match CONFIG.org_attachment_limit() {
-            Some(0) => err_discard!("Attachments are disabled", data),
+            Some(0) => err!("Attachments are disabled"),
             Some(limit_kb) => {
-                let left = (limit_kb * 1024) - Attachment::size_by_org(org_uuid, conn) + size_adjust;
+                let left = (limit_kb * 1024) - Attachment::size_by_org(org_uuid, &conn) + size_adjust;
                 if left <= 0 {
-                    err_discard!("Attachment storage limit reached! Delete some attachments to free up space", data)
+                    err!("Attachment storage limit reached! Delete some attachments to free up space")
                 }
                 Some(left as u64)
             }
             None => None,
         }
     } else {
-        err_discard!("Cipher is neither owned by a user nor an organization", data);
+        err!("Cipher is neither owned by a user nor an organization");
     };
 
-    let mut params = content_type.params();
-    let boundary_pair = params.next().expect("No boundary provided");
-    let boundary = boundary_pair.1;
+    let mut data = data.into_inner();
 
-    let base_path = Path::new(&CONFIG.attachments_folder()).join(&cipher_uuid);
-    let mut path = PathBuf::new();
-
-    let mut attachment_key = None;
-    let mut error = None;
-
-    Multipart::with_body(data.open(), boundary)
-        .foreach_entry(|mut field| {
-            match &*field.headers.name {
-                "key" => {
-                    use std::io::Read;
-                    let mut key_buffer = String::new();
-                    if field.data.read_to_string(&mut key_buffer).is_ok() {
-                        attachment_key = Some(key_buffer);
-                    }
-                }
-                "data" => {
-                    // In the legacy API, this is the encrypted filename
-                    // provided by the client, stored to the database as-is.
-                    // In the v2 API, this value doesn't matter, as it was
-                    // already provided and stored via an earlier API call.
-                    let encrypted_filename = field.headers.filename;
-
-                    // This random ID is used as the name of the file on disk.
-                    // In the legacy API, we need to generate this value here.
-                    // In the v2 API, we use the value from post_attachment_v2().
-                    let file_id = match &attachment {
-                        Some(attachment) => attachment.id.clone(), // v2 API
-                        None => crypto::generate_attachment_id(),  // Legacy API
-                    };
-                    path = base_path.join(&file_id);
-
-                    let size =
-                        match field.data.save().memory_threshold(0).size_limit(size_limit).with_path(path.clone()) {
-                            SaveResult::Full(SavedData::File(_, size)) => size as i32,
-                            SaveResult::Full(other) => {
-                                error = Some(format!("Attachment is not a file: {:?}", other));
-                                return;
-                            }
-                            SaveResult::Partial(_, reason) => {
-                                error = Some(format!("Attachment storage limit exceeded with this file: {:?}", reason));
-                                return;
-                            }
-                            SaveResult::Error(e) => {
-                                error = Some(format!("Error: {:?}", e));
-                                return;
-                            }
-                        };
-
-                    if let Some(attachment) = &mut attachment {
-                        // v2 API
-
-                        // Check the actual size against the size initially provided by
-                        // the client. Upstream allows +/- 1 MiB deviation from this
-                        // size, but it's not clear when or why this is needed.
-                        const LEEWAY: i32 = 1024 * 1024; // 1 MiB
-                        let min_size = attachment.file_size - LEEWAY;
-                        let max_size = attachment.file_size + LEEWAY;
-
-                        if min_size <= size && size <= max_size {
-                            if size != attachment.file_size {
-                                // Update the attachment with the actual file size.
-                                attachment.file_size = size;
-                                attachment.save(conn).expect("Error updating attachment");
-                            }
-                        } else {
-                            attachment.delete(conn).ok();
-
-                            let err_msg = "Attachment size mismatch".to_string();
-                            error!("{} (expected within [{}, {}], got {})", err_msg, min_size, max_size, size);
-                            error = Some(err_msg);
-                        }
-                    } else {
-                        // Legacy API
-
-                        if encrypted_filename.is_none() {
-                            error = Some("No filename provided".to_string());
-                            return;
-                        }
-                        if attachment_key.is_none() {
-                            error = Some("No attachment key provided".to_string());
-                            return;
-                        }
-                        let attachment = Attachment::new(
-                            file_id,
-                            cipher_uuid.clone(),
-                            encrypted_filename.unwrap(),
-                            size,
-                            attachment_key.clone(),
-                        );
-                        attachment.save(conn).expect("Error saving attachment");
-                    }
-                }
-                _ => error!("Invalid multipart name"),
-            }
-        })
-        .expect("Error processing multipart data");
-
-    if let Some(ref e) = error {
-        std::fs::remove_file(path).ok();
-        err!(e);
+    if let Some(size_limit) = size_limit {
+        if data.data.len() > size_limit {
+            err!("Attachment storage limit exceeded with this file");
+        }
     }
 
-    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn));
+    let file_id = match &attachment {
+        Some(attachment) => attachment.id.clone(), // v2 API
+        None => crypto::generate_attachment_id(),  // Legacy API
+    };
 
-    Ok(cipher)
+    let folder_path = tokio::fs::canonicalize(&CONFIG.attachments_folder()).await?.join(&cipher_uuid);
+    let file_path = folder_path.join(&file_id);
+    tokio::fs::create_dir_all(&folder_path).await?;
+
+    let size = data.data.len() as i32;
+    if let Some(attachment) = &mut attachment {
+        // v2 API
+
+        // Check the actual size against the size initially provided by
+        // the client. Upstream allows +/- 1 MiB deviation from this
+        // size, but it's not clear when or why this is needed.
+        const LEEWAY: i32 = 1024 * 1024; // 1 MiB
+        let min_size = attachment.file_size - LEEWAY;
+        let max_size = attachment.file_size + LEEWAY;
+
+        if min_size <= size && size <= max_size {
+            if size != attachment.file_size {
+                // Update the attachment with the actual file size.
+                attachment.file_size = size;
+                attachment.save(&conn).expect("Error updating attachment");
+            }
+        } else {
+            attachment.delete(&conn).ok();
+
+            err!(format!("Attachment size mismatch (expected within [{}, {}], got {})", min_size, max_size, size));
+        }
+    } else {
+        // Legacy API
+        let encrypted_filename = data.data.raw_name().map(|s| s.dangerous_unsafe_unsanitized_raw().to_string());
+
+        if encrypted_filename.is_none() {
+            err!("No filename provided")
+        }
+        if data.key.is_none() {
+            err!("No attachment key provided")
+        }
+        let attachment = Attachment::new(file_id, cipher_uuid.clone(), encrypted_filename.unwrap(), size, data.key);
+        attachment.save(&conn).expect("Error saving attachment");
+    }
+
+    data.data.persist_to(file_path).await?;
+
+    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn));
+
+    Ok((cipher, conn))
 }
 
 /// v2 API for uploading the actual data content of an attachment.
@@ -1006,14 +960,13 @@ fn save_attachment(
 /// /ciphers/<uuid>/attachment/v2 route, which would otherwise conflict
 /// with this one.
 #[post("/ciphers/<uuid>/attachment/<attachment_id>", format = "multipart/form-data", data = "<data>", rank = 1)]
-fn post_attachment_v2_data(
+async fn post_attachment_v2_data(
     uuid: String,
     attachment_id: String,
-    data: Data,
-    content_type: &ContentType,
+    data: Form<UploadData<'_>>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
     let attachment = match Attachment::find_by_id(&attachment_id, &conn) {
         Some(attachment) if uuid == attachment.cipher_uuid => Some(attachment),
@@ -1021,54 +974,51 @@ fn post_attachment_v2_data(
         None => err!("Attachment doesn't exist"),
     };
 
-    save_attachment(attachment, uuid, data, content_type, &headers, &conn, nt)?;
+    save_attachment(attachment, uuid, data, &headers, conn, nt).await?;
 
     Ok(())
 }
 
 /// Legacy API for creating an attachment associated with a cipher.
 #[post("/ciphers/<uuid>/attachment", format = "multipart/form-data", data = "<data>")]
-fn post_attachment(
+async fn post_attachment(
     uuid: String,
-    data: Data,
-    content_type: &ContentType,
+    data: Form<UploadData<'_>>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
     // Setting this as None signifies to save_attachment() that it should create
     // the attachment database record as well as saving the data to disk.
     let attachment = None;
 
-    let cipher = save_attachment(attachment, uuid, data, content_type, &headers, &conn, nt)?;
+    let (cipher, conn) = save_attachment(attachment, uuid, data, &headers, conn, nt).await?;
 
     Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
 }
 
 #[post("/ciphers/<uuid>/attachment-admin", format = "multipart/form-data", data = "<data>")]
-fn post_attachment_admin(
+async fn post_attachment_admin(
     uuid: String,
-    data: Data,
-    content_type: &ContentType,
+    data: Form<UploadData<'_>>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
-    post_attachment(uuid, data, content_type, headers, conn, nt)
+    post_attachment(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>/attachment/<attachment_id>/share", format = "multipart/form-data", data = "<data>")]
-fn post_attachment_share(
+async fn post_attachment_share(
     uuid: String,
     attachment_id: String,
-    data: Data,
-    content_type: &ContentType,
+    data: Form<UploadData<'_>>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
     _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt)?;
-    post_attachment(uuid, data, content_type, headers, conn, nt)
+    post_attachment(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>/attachment/<attachment_id>/delete-admin")]
@@ -1248,13 +1198,13 @@ fn move_cipher_selected_put(
 
 #[derive(FromForm)]
 struct OrganizationId {
-    #[form(field = "organizationId")]
+    #[field(name = "organizationId")]
     org_id: String,
 }
 
 #[post("/ciphers/purge?<organization..>", data = "<data>")]
 fn delete_all(
-    organization: Option<Form<OrganizationId>>,
+    organization: Option<OrganizationId>,
     data: JsonUpcase<PasswordData>,
     headers: Headers,
     conn: DbConn,

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -17,6 +17,8 @@ use crate::{
     CONFIG,
 };
 
+use futures::{stream, stream::StreamExt};
+
 pub fn routes() -> Vec<Route> {
     // Note that many routes have an `admin` variant; this seems to be
     // because the stored procedure that upstream Bitwarden uses to determine
@@ -83,7 +85,7 @@ pub fn routes() -> Vec<Route> {
 pub async fn purge_trashed_ciphers(pool: DbPool) {
     debug!("Purging trashed ciphers");
     if let Ok(conn) = pool.get().await {
-        Cipher::purge_trash(&conn);
+        Cipher::purge_trash(&conn).await;
     } else {
         error!("Failed to get DB connection while purging trashed ciphers")
     }
@@ -96,25 +98,33 @@ struct SyncData {
 }
 
 #[get("/sync?<data..>")]
-fn sync(data: SyncData, headers: Headers, conn: DbConn) -> Json<Value> {
-    let user_json = headers.user.to_json(&conn);
+async fn sync(data: SyncData, headers: Headers, conn: DbConn) -> Json<Value> {
+    let user_json = headers.user.to_json(&conn).await;
 
-    let folders = Folder::find_by_user(&headers.user.uuid, &conn);
+    let folders = Folder::find_by_user(&headers.user.uuid, &conn).await;
     let folders_json: Vec<Value> = folders.iter().map(Folder::to_json).collect();
 
-    let collections = Collection::find_by_user_uuid(&headers.user.uuid, &conn);
-    let collections_json: Vec<Value> =
-        collections.iter().map(|c| c.to_json_details(&headers.user.uuid, &conn)).collect();
+    let collections_json = stream::iter(Collection::find_by_user_uuid(&headers.user.uuid, &conn).await)
+        .then(|c| async {
+            let c = c; // Move out this single variable
+            c.to_json_details(&headers.user.uuid, &conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     let policies = OrgPolicy::find_confirmed_by_user(&headers.user.uuid, &conn);
-    let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
+    let policies_json: Vec<Value> = policies.await.iter().map(OrgPolicy::to_json).collect();
 
-    let ciphers = Cipher::find_by_user_visible(&headers.user.uuid, &conn);
-    let ciphers_json: Vec<Value> =
-        ciphers.iter().map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn)).collect();
+    let ciphers_json = stream::iter(Cipher::find_by_user_visible(&headers.user.uuid, &conn).await)
+        .then(|c| async {
+            let c = c; // Move out this single variable
+            c.to_json(&headers.host, &headers.user.uuid, &conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     let sends = Send::find_by_user(&headers.user.uuid, &conn);
-    let sends_json: Vec<Value> = sends.iter().map(|s| s.to_json()).collect();
+    let sends_json: Vec<Value> = sends.await.iter().map(|s| s.to_json()).collect();
 
     let domains_json = if data.exclude_domains {
         Value::Null
@@ -136,11 +146,14 @@ fn sync(data: SyncData, headers: Headers, conn: DbConn) -> Json<Value> {
 }
 
 #[get("/ciphers")]
-fn get_ciphers(headers: Headers, conn: DbConn) -> Json<Value> {
-    let ciphers = Cipher::find_by_user_visible(&headers.user.uuid, &conn);
-
-    let ciphers_json: Vec<Value> =
-        ciphers.iter().map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn)).collect();
+async fn get_ciphers(headers: Headers, conn: DbConn) -> Json<Value> {
+    let ciphers_json = stream::iter(Cipher::find_by_user_visible(&headers.user.uuid, &conn).await)
+        .then(|c| async {
+            let c = c; // Move out this single variable
+            c.to_json(&headers.host, &headers.user.uuid, &conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     Json(json!({
       "Data": ciphers_json,
@@ -150,28 +163,28 @@ fn get_ciphers(headers: Headers, conn: DbConn) -> Json<Value> {
 }
 
 #[get("/ciphers/<uuid>")]
-fn get_cipher(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
-    let cipher = match Cipher::find_by_uuid(&uuid, &conn) {
+async fn get_cipher(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
+    let cipher = match Cipher::find_by_uuid(&uuid, &conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_accessible_to_user(&headers.user.uuid, &conn) {
+    if !cipher.is_accessible_to_user(&headers.user.uuid, &conn).await {
         err!("Cipher is not owned by user")
     }
 
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn).await))
 }
 
 #[get("/ciphers/<uuid>/admin")]
-fn get_cipher_admin(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn get_cipher_admin(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
     // TODO: Implement this correctly
-    get_cipher(uuid, headers, conn)
+    get_cipher(uuid, headers, conn).await
 }
 
 #[get("/ciphers/<uuid>/details")]
-fn get_cipher_details(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
-    get_cipher(uuid, headers, conn)
+async fn get_cipher_details(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
+    get_cipher(uuid, headers, conn).await
 }
 
 #[derive(Deserialize, Debug)]
@@ -229,15 +242,25 @@ pub struct Attachments2Data {
 
 /// Called when an org admin clones an org cipher.
 #[post("/ciphers/admin", data = "<data>")]
-fn post_ciphers_admin(data: JsonUpcase<ShareCipherData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    post_ciphers_create(data, headers, conn, nt)
+async fn post_ciphers_admin(
+    data: JsonUpcase<ShareCipherData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    post_ciphers_create(data, headers, conn, nt).await
 }
 
 /// Called when creating a new org-owned cipher, or cloning a cipher (whether
 /// user- or org-owned). When cloning a cipher to a user-owned cipher,
 /// `organizationId` is null.
 #[post("/ciphers/create", data = "<data>")]
-fn post_ciphers_create(data: JsonUpcase<ShareCipherData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn post_ciphers_create(
+    data: JsonUpcase<ShareCipherData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
     let mut data: ShareCipherData = data.into_inner().data;
 
     // Check if there are one more more collections selected when this cipher is part of an organization.
@@ -249,11 +272,11 @@ fn post_ciphers_create(data: JsonUpcase<ShareCipherData>, headers: Headers, conn
     // This check is usually only needed in update_cipher_from_data(), but we
     // need it here as well to avoid creating an empty cipher in the call to
     // cipher.save() below.
-    enforce_personal_ownership_policy(Some(&data.Cipher), &headers, &conn)?;
+    enforce_personal_ownership_policy(Some(&data.Cipher), &headers, &conn).await?;
 
     let mut cipher = Cipher::new(data.Cipher.Type, data.Cipher.Name.clone());
     cipher.user_uuid = Some(headers.user.uuid.clone());
-    cipher.save(&conn)?;
+    cipher.save(&conn).await?;
 
     // When cloning a cipher, the Bitwarden clients seem to set this field
     // based on the cipher being cloned (when creating a new cipher, it's set
@@ -263,12 +286,12 @@ fn post_ciphers_create(data: JsonUpcase<ShareCipherData>, headers: Headers, conn
     // or otherwise), we can just ignore this field entirely.
     data.Cipher.LastKnownRevisionDate = None;
 
-    share_cipher_by_uuid(&cipher.uuid, data, &headers, &conn, &nt)
+    share_cipher_by_uuid(&cipher.uuid, data, &headers, &conn, &nt).await
 }
 
 /// Called when creating a new user-owned cipher.
 #[post("/ciphers", data = "<data>")]
-fn post_ciphers(data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn post_ciphers(data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
     let mut data: CipherData = data.into_inner().data;
 
     // The web/browser clients set this field to null as expected, but the
@@ -278,9 +301,9 @@ fn post_ciphers(data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt
     data.LastKnownRevisionDate = None;
 
     let mut cipher = Cipher::new(data.Type, data.Name.clone());
-    update_cipher_from_data(&mut cipher, data, &headers, false, &conn, &nt, UpdateType::CipherCreate)?;
+    update_cipher_from_data(&mut cipher, data, &headers, false, &conn, &nt, UpdateType::CipherCreate).await?;
 
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn).await))
 }
 
 /// Enforces the personal ownership policy on user-owned ciphers, if applicable.
@@ -290,27 +313,27 @@ fn post_ciphers(data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt
 /// allowed to delete or share such ciphers to an org, however.
 ///
 /// Ref: https://bitwarden.com/help/article/policies/#personal-ownership
-fn enforce_personal_ownership_policy(data: Option<&CipherData>, headers: &Headers, conn: &DbConn) -> EmptyResult {
+async fn enforce_personal_ownership_policy(data: Option<&CipherData>, headers: &Headers, conn: &DbConn) -> EmptyResult {
     if data.is_none() || data.unwrap().OrganizationId.is_none() {
         let user_uuid = &headers.user.uuid;
         let policy_type = OrgPolicyType::PersonalOwnership;
-        if OrgPolicy::is_applicable_to_user(user_uuid, policy_type, conn) {
+        if OrgPolicy::is_applicable_to_user(user_uuid, policy_type, conn).await {
             err!("Due to an Enterprise Policy, you are restricted from saving items to your personal vault.")
         }
     }
     Ok(())
 }
 
-pub fn update_cipher_from_data(
+pub async fn update_cipher_from_data(
     cipher: &mut Cipher,
     data: CipherData,
     headers: &Headers,
     shared_to_collection: bool,
     conn: &DbConn,
-    nt: &Notify,
+    nt: &Notify<'_>,
     ut: UpdateType,
 ) -> EmptyResult {
-    enforce_personal_ownership_policy(Some(&data), headers, conn)?;
+    enforce_personal_ownership_policy(Some(&data), headers, conn).await?;
 
     // Check that the client isn't updating an existing cipher with stale data.
     if let Some(dt) = data.LastKnownRevisionDate {
@@ -329,12 +352,12 @@ pub fn update_cipher_from_data(
     }
 
     if let Some(org_id) = data.OrganizationId {
-        match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, conn) {
+        match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, conn).await {
             None => err!("You don't have permission to add item to organization"),
             Some(org_user) => {
                 if shared_to_collection
                     || org_user.has_full_access()
-                    || cipher.is_write_accessible_to_user(&headers.user.uuid, conn)
+                    || cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await
                 {
                     cipher.organization_uuid = Some(org_id);
                     // After some discussion in PR #1329 re-added the user_uuid = None again.
@@ -353,7 +376,7 @@ pub fn update_cipher_from_data(
     }
 
     if let Some(ref folder_id) = data.FolderId {
-        match Folder::find_by_uuid(folder_id, conn) {
+        match Folder::find_by_uuid(folder_id, conn).await {
             Some(folder) => {
                 if folder.user_uuid != headers.user.uuid {
                     err!("Folder is not owned by user")
@@ -366,7 +389,7 @@ pub fn update_cipher_from_data(
     // Modify attachments name and keys when rotating
     if let Some(attachments) = data.Attachments2 {
         for (id, attachment) in attachments {
-            let mut saved_att = match Attachment::find_by_id(&id, conn) {
+            let mut saved_att = match Attachment::find_by_id(&id, conn).await {
                 Some(att) => att,
                 None => err!("Attachment doesn't exist"),
             };
@@ -381,7 +404,7 @@ pub fn update_cipher_from_data(
             saved_att.akey = Some(attachment.Key);
             saved_att.file_name = attachment.FileName;
 
-            saved_att.save(conn)?;
+            saved_att.save(conn).await?;
         }
     }
 
@@ -427,12 +450,12 @@ pub fn update_cipher_from_data(
     cipher.password_history = data.PasswordHistory.map(|f| f.to_string());
     cipher.reprompt = data.Reprompt;
 
-    cipher.save(conn)?;
-    cipher.move_to_folder(data.FolderId, &headers.user.uuid, conn)?;
-    cipher.set_favorite(data.Favorite, &headers.user.uuid, conn)?;
+    cipher.save(conn).await?;
+    cipher.move_to_folder(data.FolderId, &headers.user.uuid, conn).await?;
+    cipher.set_favorite(data.Favorite, &headers.user.uuid, conn).await?;
 
     if ut != UpdateType::None {
-        nt.send_cipher_update(ut, cipher, &cipher.update_users_revision(conn));
+        nt.send_cipher_update(ut, cipher, &cipher.update_users_revision(conn).await);
     }
 
     Ok(())
@@ -458,8 +481,13 @@ struct RelationsData {
 }
 
 #[post("/ciphers/import", data = "<data>")]
-fn post_ciphers_import(data: JsonUpcase<ImportData>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    enforce_personal_ownership_policy(None, &headers, &conn)?;
+async fn post_ciphers_import(
+    data: JsonUpcase<ImportData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    enforce_personal_ownership_policy(None, &headers, &conn).await?;
 
     let data: ImportData = data.into_inner().data;
 
@@ -467,7 +495,7 @@ fn post_ciphers_import(data: JsonUpcase<ImportData>, headers: Headers, conn: DbC
     let mut folders: Vec<_> = Vec::new();
     for folder in data.Folders.into_iter() {
         let mut new_folder = Folder::new(headers.user.uuid.clone(), folder.Name);
-        new_folder.save(&conn)?;
+        new_folder.save(&conn).await?;
 
         folders.push(new_folder);
     }
@@ -485,48 +513,60 @@ fn post_ciphers_import(data: JsonUpcase<ImportData>, headers: Headers, conn: DbC
         cipher_data.FolderId = folder_uuid;
 
         let mut cipher = Cipher::new(cipher_data.Type, cipher_data.Name.clone());
-        update_cipher_from_data(&mut cipher, cipher_data, &headers, false, &conn, &nt, UpdateType::None)?;
+        update_cipher_from_data(&mut cipher, cipher_data, &headers, false, &conn, &nt, UpdateType::None).await?;
     }
 
     let mut user = headers.user;
-    user.update_revision(&conn)?;
+    user.update_revision(&conn).await?;
     nt.send_user_update(UpdateType::Vault, &user);
     Ok(())
 }
 
 /// Called when an org admin modifies an existing org cipher.
 #[put("/ciphers/<uuid>/admin", data = "<data>")]
-fn put_cipher_admin(
+async fn put_cipher_admin(
     uuid: String,
     data: JsonUpcase<CipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
-    put_cipher(uuid, data, headers, conn, nt)
+    put_cipher(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>/admin", data = "<data>")]
-fn post_cipher_admin(
+async fn post_cipher_admin(
     uuid: String,
     data: JsonUpcase<CipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
-    post_cipher(uuid, data, headers, conn, nt)
+    post_cipher(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>", data = "<data>")]
-fn post_cipher(uuid: String, data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    put_cipher(uuid, data, headers, conn, nt)
+async fn post_cipher(
+    uuid: String,
+    data: JsonUpcase<CipherData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    put_cipher(uuid, data, headers, conn, nt).await
 }
 
 #[put("/ciphers/<uuid>", data = "<data>")]
-fn put_cipher(uuid: String, data: JsonUpcase<CipherData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn put_cipher(
+    uuid: String,
+    data: JsonUpcase<CipherData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
     let data: CipherData = data.into_inner().data;
 
-    let mut cipher = match Cipher::find_by_uuid(&uuid, &conn) {
+    let mut cipher = match Cipher::find_by_uuid(&uuid, &conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
@@ -536,13 +576,13 @@ fn put_cipher(uuid: String, data: JsonUpcase<CipherData>, headers: Headers, conn
     // cipher itself, so the user shouldn't need write access to change these.
     // Interestingly, upstream Bitwarden doesn't properly handle this either.
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn).await {
         err!("Cipher is not write accessible")
     }
 
-    update_cipher_from_data(&mut cipher, data, &headers, false, &conn, &nt, UpdateType::CipherUpdate)?;
+    update_cipher_from_data(&mut cipher, data, &headers, false, &conn, &nt, UpdateType::CipherUpdate).await?;
 
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn).await))
 }
 
 #[derive(Deserialize)]
@@ -552,37 +592,37 @@ struct CollectionsAdminData {
 }
 
 #[put("/ciphers/<uuid>/collections", data = "<data>")]
-fn put_collections_update(
+async fn put_collections_update(
     uuid: String,
     data: JsonUpcase<CollectionsAdminData>,
     headers: Headers,
     conn: DbConn,
 ) -> EmptyResult {
-    post_collections_admin(uuid, data, headers, conn)
+    post_collections_admin(uuid, data, headers, conn).await
 }
 
 #[post("/ciphers/<uuid>/collections", data = "<data>")]
-fn post_collections_update(
+async fn post_collections_update(
     uuid: String,
     data: JsonUpcase<CollectionsAdminData>,
     headers: Headers,
     conn: DbConn,
 ) -> EmptyResult {
-    post_collections_admin(uuid, data, headers, conn)
+    post_collections_admin(uuid, data, headers, conn).await
 }
 
 #[put("/ciphers/<uuid>/collections-admin", data = "<data>")]
-fn put_collections_admin(
+async fn put_collections_admin(
     uuid: String,
     data: JsonUpcase<CollectionsAdminData>,
     headers: Headers,
     conn: DbConn,
 ) -> EmptyResult {
-    post_collections_admin(uuid, data, headers, conn)
+    post_collections_admin(uuid, data, headers, conn).await
 }
 
 #[post("/ciphers/<uuid>/collections-admin", data = "<data>")]
-fn post_collections_admin(
+async fn post_collections_admin(
     uuid: String,
     data: JsonUpcase<CollectionsAdminData>,
     headers: Headers,
@@ -590,30 +630,30 @@ fn post_collections_admin(
 ) -> EmptyResult {
     let data: CollectionsAdminData = data.into_inner().data;
 
-    let cipher = match Cipher::find_by_uuid(&uuid, &conn) {
+    let cipher = match Cipher::find_by_uuid(&uuid, &conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn).await {
         err!("Cipher is not write accessible")
     }
 
     let posted_collections: HashSet<String> = data.CollectionIds.iter().cloned().collect();
     let current_collections: HashSet<String> =
-        cipher.get_collections(&headers.user.uuid, &conn).iter().cloned().collect();
+        cipher.get_collections(&headers.user.uuid, &conn).await.iter().cloned().collect();
 
     for collection in posted_collections.symmetric_difference(&current_collections) {
-        match Collection::find_by_uuid(collection, &conn) {
+        match Collection::find_by_uuid(collection, &conn).await {
             None => err!("Invalid collection ID provided"),
             Some(collection) => {
-                if collection.is_writable_by_user(&headers.user.uuid, &conn) {
+                if collection.is_writable_by_user(&headers.user.uuid, &conn).await {
                     if posted_collections.contains(&collection.uuid) {
                         // Add to collection
-                        CollectionCipher::save(&cipher.uuid, &collection.uuid, &conn)?;
+                        CollectionCipher::save(&cipher.uuid, &collection.uuid, &conn).await?;
                     } else {
                         // Remove from collection
-                        CollectionCipher::delete(&cipher.uuid, &collection.uuid, &conn)?;
+                        CollectionCipher::delete(&cipher.uuid, &collection.uuid, &conn).await?;
                     }
                 } else {
                     err!("No rights to modify the collection")
@@ -633,29 +673,29 @@ struct ShareCipherData {
 }
 
 #[post("/ciphers/<uuid>/share", data = "<data>")]
-fn post_cipher_share(
+async fn post_cipher_share(
     uuid: String,
     data: JsonUpcase<ShareCipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
     let data: ShareCipherData = data.into_inner().data;
 
-    share_cipher_by_uuid(&uuid, data, &headers, &conn, &nt)
+    share_cipher_by_uuid(&uuid, data, &headers, &conn, &nt).await
 }
 
 #[put("/ciphers/<uuid>/share", data = "<data>")]
-fn put_cipher_share(
+async fn put_cipher_share(
     uuid: String,
     data: JsonUpcase<ShareCipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> JsonResult {
     let data: ShareCipherData = data.into_inner().data;
 
-    share_cipher_by_uuid(&uuid, data, &headers, &conn, &nt)
+    share_cipher_by_uuid(&uuid, data, &headers, &conn, &nt).await
 }
 
 #[derive(Deserialize)]
@@ -666,11 +706,11 @@ struct ShareSelectedCipherData {
 }
 
 #[put("/ciphers/share", data = "<data>")]
-fn put_cipher_share_selected(
+async fn put_cipher_share_selected(
     data: JsonUpcase<ShareSelectedCipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
     let mut data: ShareSelectedCipherData = data.into_inner().data;
     let mut cipher_ids: Vec<String> = Vec::new();
@@ -697,7 +737,7 @@ fn put_cipher_share_selected(
         };
 
         match shared_cipher_data.Cipher.Id.take() {
-            Some(id) => share_cipher_by_uuid(&id, shared_cipher_data, &headers, &conn, &nt)?,
+            Some(id) => share_cipher_by_uuid(&id, shared_cipher_data, &headers, &conn, &nt).await?,
             None => err!("Request missing ids field"),
         };
     }
@@ -705,16 +745,16 @@ fn put_cipher_share_selected(
     Ok(())
 }
 
-fn share_cipher_by_uuid(
+async fn share_cipher_by_uuid(
     uuid: &str,
     data: ShareCipherData,
     headers: &Headers,
     conn: &DbConn,
-    nt: &Notify,
+    nt: &Notify<'_>,
 ) -> JsonResult {
-    let mut cipher = match Cipher::find_by_uuid(uuid, conn) {
+    let mut cipher = match Cipher::find_by_uuid(uuid, conn).await {
         Some(cipher) => {
-            if cipher.is_write_accessible_to_user(&headers.user.uuid, conn) {
+            if cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
                 cipher
             } else {
                 err!("Cipher is not write accessible")
@@ -731,11 +771,11 @@ fn share_cipher_by_uuid(
         None => {}
         Some(organization_uuid) => {
             for uuid in &data.CollectionIds {
-                match Collection::find_by_uuid_and_org(uuid, &organization_uuid, conn) {
+                match Collection::find_by_uuid_and_org(uuid, &organization_uuid, conn).await {
                     None => err!("Invalid collection ID provided"),
                     Some(collection) => {
-                        if collection.is_writable_by_user(&headers.user.uuid, conn) {
-                            CollectionCipher::save(&cipher.uuid, &collection.uuid, conn)?;
+                        if collection.is_writable_by_user(&headers.user.uuid, conn).await {
+                            CollectionCipher::save(&cipher.uuid, &collection.uuid, conn).await?;
                             shared_to_collection = true;
                         } else {
                             err!("No rights to modify the collection")
@@ -754,9 +794,10 @@ fn share_cipher_by_uuid(
         conn,
         nt,
         UpdateType::CipherUpdate,
-    )?;
+    )
+    .await?;
 
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, conn)))
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, conn).await))
 }
 
 /// v2 API for downloading an attachment. This just redirects the client to
@@ -766,8 +807,8 @@ fn share_cipher_by_uuid(
 /// their object storage service. For self-hosted instances, it basically just
 /// redirects to the same location as before the v2 API.
 #[get("/ciphers/<uuid>/attachment/<attachment_id>")]
-fn get_attachment(uuid: String, attachment_id: String, headers: Headers, conn: DbConn) -> JsonResult {
-    match Attachment::find_by_id(&attachment_id, &conn) {
+async fn get_attachment(uuid: String, attachment_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+    match Attachment::find_by_id(&attachment_id, &conn).await {
         Some(attachment) if uuid == attachment.cipher_uuid => Ok(Json(attachment.to_json(&headers.host))),
         Some(_) => err!("Attachment doesn't belong to cipher"),
         None => err!("Attachment doesn't exist"),
@@ -793,18 +834,18 @@ enum FileUploadType {
 /// For upstream's cloud-hosted service, it's an Azure object storage API.
 /// For self-hosted instances, it's another API on the local instance.
 #[post("/ciphers/<uuid>/attachment/v2", data = "<data>")]
-fn post_attachment_v2(
+async fn post_attachment_v2(
     uuid: String,
     data: JsonUpcase<AttachmentRequestData>,
     headers: Headers,
     conn: DbConn,
 ) -> JsonResult {
-    let cipher = match Cipher::find_by_uuid(&uuid, &conn) {
+    let cipher = match Cipher::find_by_uuid(&uuid, &conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn).await {
         err!("Cipher is not write accessible")
     }
 
@@ -812,7 +853,7 @@ fn post_attachment_v2(
     let data: AttachmentRequestData = data.into_inner().data;
     let attachment =
         Attachment::new(attachment_id.clone(), cipher.uuid.clone(), data.FileName, data.FileSize, Some(data.Key));
-    attachment.save(&conn).expect("Error saving attachment");
+    attachment.save(&conn).await.expect("Error saving attachment");
 
     let url = format!("/ciphers/{}/attachment/{}", cipher.uuid, attachment_id);
     let response_key = match data.AdminRequest {
@@ -825,7 +866,7 @@ fn post_attachment_v2(
         "AttachmentId": attachment_id,
         "Url": url,
         "FileUploadType": FileUploadType::Direct as i32,
-        response_key: cipher.to_json(&headers.host, &headers.user.uuid, &conn),
+        response_key: cipher.to_json(&headers.host, &headers.user.uuid, &conn).await,
     })))
 }
 
@@ -851,12 +892,12 @@ async fn save_attachment(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> Result<(Cipher, DbConn), crate::error::Error> {
-    let cipher = match Cipher::find_by_uuid(&cipher_uuid, &conn) {
+    let cipher = match Cipher::find_by_uuid(&cipher_uuid, &conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, &conn).await {
         err!("Cipher is not write accessible")
     }
 
@@ -871,7 +912,7 @@ async fn save_attachment(
         match CONFIG.user_attachment_limit() {
             Some(0) => err!("Attachments are disabled"),
             Some(limit_kb) => {
-                let left = (limit_kb * 1024) - Attachment::size_by_user(user_uuid, &conn) + size_adjust;
+                let left = (limit_kb * 1024) - Attachment::size_by_user(user_uuid, &conn).await + size_adjust;
                 if left <= 0 {
                     err!("Attachment storage limit reached! Delete some attachments to free up space")
                 }
@@ -883,7 +924,7 @@ async fn save_attachment(
         match CONFIG.org_attachment_limit() {
             Some(0) => err!("Attachments are disabled"),
             Some(limit_kb) => {
-                let left = (limit_kb * 1024) - Attachment::size_by_org(org_uuid, &conn) + size_adjust;
+                let left = (limit_kb * 1024) - Attachment::size_by_org(org_uuid, &conn).await + size_adjust;
                 if left <= 0 {
                     err!("Attachment storage limit reached! Delete some attachments to free up space")
                 }
@@ -927,10 +968,10 @@ async fn save_attachment(
             if size != attachment.file_size {
                 // Update the attachment with the actual file size.
                 attachment.file_size = size;
-                attachment.save(&conn).expect("Error updating attachment");
+                attachment.save(&conn).await.expect("Error updating attachment");
             }
         } else {
-            attachment.delete(&conn).ok();
+            attachment.delete(&conn).await.ok();
 
             err!(format!("Attachment size mismatch (expected within [{}, {}], got {})", min_size, max_size, size));
         }
@@ -945,12 +986,12 @@ async fn save_attachment(
             err!("No attachment key provided")
         }
         let attachment = Attachment::new(file_id, cipher_uuid.clone(), encrypted_filename.unwrap(), size, data.key);
-        attachment.save(&conn).expect("Error saving attachment");
+        attachment.save(&conn).await.expect("Error saving attachment");
     }
 
     data.data.persist_to(file_path).await?;
 
-    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn));
+    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn).await);
 
     Ok((cipher, conn))
 }
@@ -968,7 +1009,7 @@ async fn post_attachment_v2_data(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
-    let attachment = match Attachment::find_by_id(&attachment_id, &conn) {
+    let attachment = match Attachment::find_by_id(&attachment_id, &conn).await {
         Some(attachment) if uuid == attachment.cipher_uuid => Some(attachment),
         Some(_) => err!("Attachment doesn't belong to cipher"),
         None => err!("Attachment doesn't exist"),
@@ -994,7 +1035,7 @@ async fn post_attachment(
 
     let (cipher, conn) = save_attachment(attachment, uuid, data, &headers, conn, nt).await?;
 
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn)))
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, &conn).await))
 }
 
 #[post("/ciphers/<uuid>/attachment-admin", format = "multipart/form-data", data = "<data>")]
@@ -1017,131 +1058,162 @@ async fn post_attachment_share(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
-    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt)?;
+    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt).await?;
     post_attachment(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>/attachment/<attachment_id>/delete-admin")]
-fn delete_attachment_post_admin(
+async fn delete_attachment_post_admin(
     uuid: String,
     attachment_id: String,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    delete_attachment(uuid, attachment_id, headers, conn, nt)
+    delete_attachment(uuid, attachment_id, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>/attachment/<attachment_id>/delete")]
-fn delete_attachment_post(
+async fn delete_attachment_post(
     uuid: String,
     attachment_id: String,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    delete_attachment(uuid, attachment_id, headers, conn, nt)
+    delete_attachment(uuid, attachment_id, headers, conn, nt).await
 }
 
 #[delete("/ciphers/<uuid>/attachment/<attachment_id>")]
-fn delete_attachment(uuid: String, attachment_id: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt)
-}
-
-#[delete("/ciphers/<uuid>/attachment/<attachment_id>/admin")]
-fn delete_attachment_admin(
+async fn delete_attachment(
     uuid: String,
     attachment_id: String,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt)
+    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt).await
+}
+
+#[delete("/ciphers/<uuid>/attachment/<attachment_id>/admin")]
+async fn delete_attachment_admin(
+    uuid: String,
+    attachment_id: String,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    _delete_cipher_attachment_by_id(&uuid, &attachment_id, &headers, &conn, &nt).await
 }
 
 #[post("/ciphers/<uuid>/delete")]
-fn delete_cipher_post(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt)
+async fn delete_cipher_post(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt).await
 }
 
 #[post("/ciphers/<uuid>/delete-admin")]
-fn delete_cipher_post_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt)
+async fn delete_cipher_post_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt).await
 }
 
 #[put("/ciphers/<uuid>/delete")]
-fn delete_cipher_put(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, true, &nt)
+async fn delete_cipher_put(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, true, &nt).await
 }
 
 #[put("/ciphers/<uuid>/delete-admin")]
-fn delete_cipher_put_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, true, &nt)
+async fn delete_cipher_put_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, true, &nt).await
 }
 
 #[delete("/ciphers/<uuid>")]
-fn delete_cipher(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt)
+async fn delete_cipher(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt).await
 }
 
 #[delete("/ciphers/<uuid>/admin")]
-fn delete_cipher_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt)
+async fn delete_cipher_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    _delete_cipher_by_uuid(&uuid, &headers, &conn, false, &nt).await
 }
 
 #[delete("/ciphers", data = "<data>")]
-fn delete_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_multiple_ciphers(data, headers, conn, false, nt)
+async fn delete_cipher_selected(
+    data: JsonUpcase<Value>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    _delete_multiple_ciphers(data, headers, conn, false, nt).await
 }
 
 #[post("/ciphers/delete", data = "<data>")]
-fn delete_cipher_selected_post(data: JsonUpcase<Value>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_multiple_ciphers(data, headers, conn, false, nt)
+async fn delete_cipher_selected_post(
+    data: JsonUpcase<Value>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    _delete_multiple_ciphers(data, headers, conn, false, nt).await
 }
 
 #[put("/ciphers/delete", data = "<data>")]
-fn delete_cipher_selected_put(data: JsonUpcase<Value>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    _delete_multiple_ciphers(data, headers, conn, true, nt) // soft delete
+async fn delete_cipher_selected_put(
+    data: JsonUpcase<Value>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    _delete_multiple_ciphers(data, headers, conn, true, nt).await // soft delete
 }
 
 #[delete("/ciphers/admin", data = "<data>")]
-fn delete_cipher_selected_admin(data: JsonUpcase<Value>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    delete_cipher_selected(data, headers, conn, nt)
+async fn delete_cipher_selected_admin(
+    data: JsonUpcase<Value>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
+    delete_cipher_selected(data, headers, conn, nt).await
 }
 
 #[post("/ciphers/delete-admin", data = "<data>")]
-fn delete_cipher_selected_post_admin(
+async fn delete_cipher_selected_post_admin(
     data: JsonUpcase<Value>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    delete_cipher_selected_post(data, headers, conn, nt)
+    delete_cipher_selected_post(data, headers, conn, nt).await
 }
 
 #[put("/ciphers/delete-admin", data = "<data>")]
-fn delete_cipher_selected_put_admin(
+async fn delete_cipher_selected_put_admin(
     data: JsonUpcase<Value>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    delete_cipher_selected_put(data, headers, conn, nt)
+    delete_cipher_selected_put(data, headers, conn, nt).await
 }
 
 #[put("/ciphers/<uuid>/restore")]
-fn restore_cipher_put(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    _restore_cipher_by_uuid(&uuid, &headers, &conn, &nt)
+async fn restore_cipher_put(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    _restore_cipher_by_uuid(&uuid, &headers, &conn, &nt).await
 }
 
 #[put("/ciphers/<uuid>/restore-admin")]
-fn restore_cipher_put_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    _restore_cipher_by_uuid(&uuid, &headers, &conn, &nt)
+async fn restore_cipher_put_admin(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    _restore_cipher_by_uuid(&uuid, &headers, &conn, &nt).await
 }
 
 #[put("/ciphers/restore", data = "<data>")]
-fn restore_cipher_selected(data: JsonUpcase<Value>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    _restore_multiple_ciphers(data, &headers, &conn, &nt)
+async fn restore_cipher_selected(
+    data: JsonUpcase<Value>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    _restore_multiple_ciphers(data, &headers, &conn, &nt).await
 }
 
 #[derive(Deserialize)]
@@ -1152,12 +1224,17 @@ struct MoveCipherData {
 }
 
 #[post("/ciphers/move", data = "<data>")]
-fn move_cipher_selected(data: JsonUpcase<MoveCipherData>, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
+async fn move_cipher_selected(
+    data: JsonUpcase<MoveCipherData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> EmptyResult {
     let data = data.into_inner().data;
     let user_uuid = headers.user.uuid;
 
     if let Some(ref folder_id) = data.FolderId {
-        match Folder::find_by_uuid(folder_id, &conn) {
+        match Folder::find_by_uuid(folder_id, &conn).await {
             Some(folder) => {
                 if folder.user_uuid != user_uuid {
                     err!("Folder is not owned by user")
@@ -1168,17 +1245,17 @@ fn move_cipher_selected(data: JsonUpcase<MoveCipherData>, headers: Headers, conn
     }
 
     for uuid in data.Ids {
-        let cipher = match Cipher::find_by_uuid(&uuid, &conn) {
+        let cipher = match Cipher::find_by_uuid(&uuid, &conn).await {
             Some(cipher) => cipher,
             None => err!("Cipher doesn't exist"),
         };
 
-        if !cipher.is_accessible_to_user(&user_uuid, &conn) {
+        if !cipher.is_accessible_to_user(&user_uuid, &conn).await {
             err!("Cipher is not accessible by user")
         }
 
         // Move cipher
-        cipher.move_to_folder(data.FolderId.clone(), &user_uuid, &conn)?;
+        cipher.move_to_folder(data.FolderId.clone(), &user_uuid, &conn).await?;
 
         nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &[user_uuid.clone()]);
     }
@@ -1187,13 +1264,13 @@ fn move_cipher_selected(data: JsonUpcase<MoveCipherData>, headers: Headers, conn
 }
 
 #[put("/ciphers/move", data = "<data>")]
-fn move_cipher_selected_put(
+async fn move_cipher_selected_put(
     data: JsonUpcase<MoveCipherData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
-    move_cipher_selected(data, headers, conn, nt)
+    move_cipher_selected(data, headers, conn, nt).await
 }
 
 #[derive(FromForm)]
@@ -1203,12 +1280,12 @@ struct OrganizationId {
 }
 
 #[post("/ciphers/purge?<organization..>", data = "<data>")]
-fn delete_all(
+async fn delete_all(
     organization: Option<OrganizationId>,
     data: JsonUpcase<PasswordData>,
     headers: Headers,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
     let data: PasswordData = data.into_inner().data;
     let password_hash = data.MasterPasswordHash;
@@ -1222,11 +1299,11 @@ fn delete_all(
     match organization {
         Some(org_data) => {
             // Organization ID in query params, purging organization vault
-            match UserOrganization::find_by_user_and_org(&user.uuid, &org_data.org_id, &conn) {
+            match UserOrganization::find_by_user_and_org(&user.uuid, &org_data.org_id, &conn).await {
                 None => err!("You don't have permission to purge the organization vault"),
                 Some(user_org) => {
                     if user_org.atype == UserOrgType::Owner {
-                        Cipher::delete_all_by_organization(&org_data.org_id, &conn)?;
+                        Cipher::delete_all_by_organization(&org_data.org_id, &conn).await?;
                         nt.send_user_update(UpdateType::Vault, &user);
                         Ok(())
                     } else {
@@ -1238,50 +1315,56 @@ fn delete_all(
         None => {
             // No organization ID in query params, purging user vault
             // Delete ciphers and their attachments
-            for cipher in Cipher::find_owned_by_user(&user.uuid, &conn) {
-                cipher.delete(&conn)?;
+            for cipher in Cipher::find_owned_by_user(&user.uuid, &conn).await {
+                cipher.delete(&conn).await?;
             }
 
             // Delete folders
-            for f in Folder::find_by_user(&user.uuid, &conn) {
-                f.delete(&conn)?;
+            for f in Folder::find_by_user(&user.uuid, &conn).await {
+                f.delete(&conn).await?;
             }
 
-            user.update_revision(&conn)?;
+            user.update_revision(&conn).await?;
             nt.send_user_update(UpdateType::Vault, &user);
             Ok(())
         }
     }
 }
 
-fn _delete_cipher_by_uuid(uuid: &str, headers: &Headers, conn: &DbConn, soft_delete: bool, nt: &Notify) -> EmptyResult {
-    let mut cipher = match Cipher::find_by_uuid(uuid, conn) {
+async fn _delete_cipher_by_uuid(
+    uuid: &str,
+    headers: &Headers,
+    conn: &DbConn,
+    soft_delete: bool,
+    nt: &Notify<'_>,
+) -> EmptyResult {
+    let mut cipher = match Cipher::find_by_uuid(uuid, conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
         err!("Cipher can't be deleted by user")
     }
 
     if soft_delete {
         cipher.deleted_at = Some(Utc::now().naive_utc());
-        cipher.save(conn)?;
-        nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn));
+        cipher.save(conn).await?;
+        nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn).await);
     } else {
-        cipher.delete(conn)?;
-        nt.send_cipher_update(UpdateType::CipherDelete, &cipher, &cipher.update_users_revision(conn));
+        cipher.delete(conn).await?;
+        nt.send_cipher_update(UpdateType::CipherDelete, &cipher, &cipher.update_users_revision(conn).await);
     }
 
     Ok(())
 }
 
-fn _delete_multiple_ciphers(
+async fn _delete_multiple_ciphers(
     data: JsonUpcase<Value>,
     headers: Headers,
     conn: DbConn,
     soft_delete: bool,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
     let data: Value = data.into_inner().data;
 
@@ -1294,7 +1377,7 @@ fn _delete_multiple_ciphers(
     };
 
     for uuid in uuids {
-        if let error @ Err(_) = _delete_cipher_by_uuid(uuid, &headers, &conn, soft_delete, &nt) {
+        if let error @ Err(_) = _delete_cipher_by_uuid(uuid, &headers, &conn, soft_delete, &nt).await {
             return error;
         };
     }
@@ -1302,24 +1385,29 @@ fn _delete_multiple_ciphers(
     Ok(())
 }
 
-fn _restore_cipher_by_uuid(uuid: &str, headers: &Headers, conn: &DbConn, nt: &Notify) -> JsonResult {
-    let mut cipher = match Cipher::find_by_uuid(uuid, conn) {
+async fn _restore_cipher_by_uuid(uuid: &str, headers: &Headers, conn: &DbConn, nt: &Notify<'_>) -> JsonResult {
+    let mut cipher = match Cipher::find_by_uuid(uuid, conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
         err!("Cipher can't be restored by user")
     }
 
     cipher.deleted_at = None;
-    cipher.save(conn)?;
+    cipher.save(conn).await?;
 
-    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn));
-    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, conn)))
+    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn).await);
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, conn).await))
 }
 
-fn _restore_multiple_ciphers(data: JsonUpcase<Value>, headers: &Headers, conn: &DbConn, nt: &Notify) -> JsonResult {
+async fn _restore_multiple_ciphers(
+    data: JsonUpcase<Value>,
+    headers: &Headers,
+    conn: &DbConn,
+    nt: &Notify<'_>,
+) -> JsonResult {
     let data: Value = data.into_inner().data;
 
     let uuids = match data.get("Ids") {
@@ -1332,7 +1420,7 @@ fn _restore_multiple_ciphers(data: JsonUpcase<Value>, headers: &Headers, conn: &
 
     let mut ciphers: Vec<Value> = Vec::new();
     for uuid in uuids {
-        match _restore_cipher_by_uuid(uuid, headers, conn, nt) {
+        match _restore_cipher_by_uuid(uuid, headers, conn, nt).await {
             Ok(json) => ciphers.push(json.into_inner()),
             err => return err,
         }
@@ -1345,14 +1433,14 @@ fn _restore_multiple_ciphers(data: JsonUpcase<Value>, headers: &Headers, conn: &
     })))
 }
 
-fn _delete_cipher_attachment_by_id(
+async fn _delete_cipher_attachment_by_id(
     uuid: &str,
     attachment_id: &str,
     headers: &Headers,
     conn: &DbConn,
-    nt: &Notify,
+    nt: &Notify<'_>,
 ) -> EmptyResult {
-    let attachment = match Attachment::find_by_id(attachment_id, conn) {
+    let attachment = match Attachment::find_by_id(attachment_id, conn).await {
         Some(attachment) => attachment,
         None => err!("Attachment doesn't exist"),
     };
@@ -1361,17 +1449,17 @@ fn _delete_cipher_attachment_by_id(
         err!("Attachment from other cipher")
     }
 
-    let cipher = match Cipher::find_by_uuid(uuid, conn) {
+    let cipher = match Cipher::find_by_uuid(uuid, conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn) {
+    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
         err!("Cipher cannot be deleted by user")
     }
 
     // Delete attachment
-    attachment.delete(conn)?;
-    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn));
+    attachment.delete(conn).await?;
+    nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(conn).await);
     Ok(())
 }

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -11,6 +11,8 @@ use crate::{
     mail, CONFIG,
 };
 
+use futures::{stream, stream::StreamExt};
+
 pub fn routes() -> Vec<Route> {
     routes![
         get_contacts,
@@ -36,13 +38,17 @@ pub fn routes() -> Vec<Route> {
 // region get
 
 #[get("/emergency-access/trusted")]
-fn get_contacts(headers: Headers, conn: DbConn) -> JsonResult {
+async fn get_contacts(headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
-    let emergency_access_list = EmergencyAccess::find_all_by_grantor_uuid(&headers.user.uuid, &conn);
-
-    let emergency_access_list_json: Vec<Value> =
-        emergency_access_list.iter().map(|e| e.to_json_grantee_details(&conn)).collect();
+    let emergency_access_list_json =
+        stream::iter(EmergencyAccess::find_all_by_grantor_uuid(&headers.user.uuid, &conn).await)
+            .then(|e| async {
+                let e = e; // Move out this single variable
+                e.to_json_grantee_details(&conn).await
+            })
+            .collect::<Vec<Value>>()
+            .await;
 
     Ok(Json(json!({
       "Data": emergency_access_list_json,
@@ -52,13 +58,17 @@ fn get_contacts(headers: Headers, conn: DbConn) -> JsonResult {
 }
 
 #[get("/emergency-access/granted")]
-fn get_grantees(headers: Headers, conn: DbConn) -> JsonResult {
+async fn get_grantees(headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
-    let emergency_access_list = EmergencyAccess::find_all_by_grantee_uuid(&headers.user.uuid, &conn);
-
-    let emergency_access_list_json: Vec<Value> =
-        emergency_access_list.iter().map(|e| e.to_json_grantor_details(&conn)).collect();
+    let emergency_access_list_json =
+        stream::iter(EmergencyAccess::find_all_by_grantee_uuid(&headers.user.uuid, &conn).await)
+            .then(|e| async {
+                let e = e; // Move out this single variable
+                e.to_json_grantor_details(&conn).await
+            })
+            .collect::<Vec<Value>>()
+            .await;
 
     Ok(Json(json!({
       "Data": emergency_access_list_json,
@@ -68,11 +78,11 @@ fn get_grantees(headers: Headers, conn: DbConn) -> JsonResult {
 }
 
 #[get("/emergency-access/<emer_id>")]
-fn get_emergency_access(emer_id: String, conn: DbConn) -> JsonResult {
+async fn get_emergency_access(emer_id: String, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
-    match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
-        Some(emergency_access) => Ok(Json(emergency_access.to_json_grantee_details(&conn))),
+    match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
+        Some(emergency_access) => Ok(Json(emergency_access.to_json_grantee_details(&conn).await)),
         None => err!("Emergency access not valid."),
     }
 }
@@ -90,17 +100,25 @@ struct EmergencyAccessUpdateData {
 }
 
 #[put("/emergency-access/<emer_id>", data = "<data>")]
-fn put_emergency_access(emer_id: String, data: JsonUpcase<EmergencyAccessUpdateData>, conn: DbConn) -> JsonResult {
-    post_emergency_access(emer_id, data, conn)
+async fn put_emergency_access(
+    emer_id: String,
+    data: JsonUpcase<EmergencyAccessUpdateData>,
+    conn: DbConn,
+) -> JsonResult {
+    post_emergency_access(emer_id, data, conn).await
 }
 
 #[post("/emergency-access/<emer_id>", data = "<data>")]
-fn post_emergency_access(emer_id: String, data: JsonUpcase<EmergencyAccessUpdateData>, conn: DbConn) -> JsonResult {
+async fn post_emergency_access(
+    emer_id: String,
+    data: JsonUpcase<EmergencyAccessUpdateData>,
+    conn: DbConn,
+) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let data: EmergencyAccessUpdateData = data.into_inner().data;
 
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emergency_access) => emergency_access,
         None => err!("Emergency access not valid."),
     };
@@ -114,7 +132,7 @@ fn post_emergency_access(emer_id: String, data: JsonUpcase<EmergencyAccessUpdate
     emergency_access.wait_time_days = data.WaitTimeDays;
     emergency_access.key_encrypted = data.KeyEncrypted;
 
-    emergency_access.save(&conn)?;
+    emergency_access.save(&conn).await?;
     Ok(Json(emergency_access.to_json()))
 }
 
@@ -123,12 +141,12 @@ fn post_emergency_access(emer_id: String, data: JsonUpcase<EmergencyAccessUpdate
 // region delete
 
 #[delete("/emergency-access/<emer_id>")]
-fn delete_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn delete_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
     check_emergency_access_allowed()?;
 
     let grantor_user = headers.user;
 
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => {
             if emer.grantor_uuid != grantor_user.uuid && emer.grantee_uuid != Some(grantor_user.uuid) {
                 err!("Emergency access not valid.")
@@ -137,13 +155,13 @@ fn delete_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> E
         }
         None => err!("Emergency access not valid."),
     };
-    emergency_access.delete(&conn)?;
+    emergency_access.delete(&conn).await?;
     Ok(())
 }
 
 #[post("/emergency-access/<emer_id>/delete")]
-fn post_delete_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
-    delete_emergency_access(emer_id, headers, conn)
+async fn post_delete_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
+    delete_emergency_access(emer_id, headers, conn).await
 }
 
 // endregion
@@ -159,7 +177,7 @@ struct EmergencyAccessInviteData {
 }
 
 #[post("/emergency-access/invite", data = "<data>")]
-fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, conn: DbConn) -> EmptyResult {
     check_emergency_access_allowed()?;
 
     let data: EmergencyAccessInviteData = data.into_inner().data;
@@ -180,7 +198,7 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
         err!("You can not set yourself as an emergency contact.")
     }
 
-    let grantee_user = match User::find_by_mail(&email, &conn) {
+    let grantee_user = match User::find_by_mail(&email, &conn).await {
         None => {
             if !CONFIG.invitations_allowed() {
                 err!(format!("Grantee user does not exist: {}", email))
@@ -192,11 +210,11 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
 
             if !CONFIG.mail_enabled() {
                 let invitation = Invitation::new(email.clone());
-                invitation.save(&conn)?;
+                invitation.save(&conn).await?;
             }
 
             let mut user = User::new(email.clone());
-            user.save(&conn)?;
+            user.save(&conn).await?;
             user
         }
         Some(user) => user,
@@ -208,6 +226,7 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
         &grantee_user.email,
         &conn,
     )
+    .await
     .is_some()
     {
         err!(format!("Grantee user already invited: {}", email))
@@ -220,7 +239,7 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
         new_type,
         wait_time_days,
     );
-    new_emergency_access.save(&conn)?;
+    new_emergency_access.save(&conn).await?;
 
     if CONFIG.mail_enabled() {
         mail::send_emergency_access_invite(
@@ -232,9 +251,9 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
         )?;
     } else {
         // Automatically mark user as accepted if no email invites
-        match User::find_by_mail(&email, &conn) {
+        match User::find_by_mail(&email, &conn).await {
             Some(user) => {
-                match accept_invite_process(user.uuid, new_emergency_access.uuid, Some(email), conn.borrow()) {
+                match accept_invite_process(user.uuid, new_emergency_access.uuid, Some(email), conn.borrow()).await {
                     Ok(v) => (v),
                     Err(e) => err!(e.to_string()),
                 }
@@ -247,10 +266,10 @@ fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Headers, co
 }
 
 #[post("/emergency-access/<emer_id>/reinvite")]
-fn resend_invite(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn resend_invite(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
     check_emergency_access_allowed()?;
 
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -268,7 +287,7 @@ fn resend_invite(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult
         None => err!("Email not valid."),
     };
 
-    let grantee_user = match User::find_by_mail(&email, &conn) {
+    let grantee_user = match User::find_by_mail(&email, &conn).await {
         Some(user) => user,
         None => err!("Grantee user not found."),
     };
@@ -284,13 +303,15 @@ fn resend_invite(emer_id: String, headers: Headers, conn: DbConn) -> EmptyResult
             Some(grantor_user.email),
         )?;
     } else {
-        if Invitation::find_by_mail(&email, &conn).is_none() {
+        if Invitation::find_by_mail(&email, &conn).await.is_none() {
             let invitation = Invitation::new(email);
-            invitation.save(&conn)?;
+            invitation.save(&conn).await?;
         }
 
         // Automatically mark user as accepted if no email invites
-        match accept_invite_process(grantee_user.uuid, emergency_access.uuid, emergency_access.email, conn.borrow()) {
+        match accept_invite_process(grantee_user.uuid, emergency_access.uuid, emergency_access.email, conn.borrow())
+            .await
+        {
             Ok(v) => (v),
             Err(e) => err!(e.to_string()),
         }
@@ -306,28 +327,28 @@ struct AcceptData {
 }
 
 #[post("/emergency-access/<emer_id>/accept", data = "<data>")]
-fn accept_invite(emer_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) -> EmptyResult {
+async fn accept_invite(emer_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) -> EmptyResult {
     check_emergency_access_allowed()?;
 
     let data: AcceptData = data.into_inner().data;
     let token = &data.Token;
     let claims = decode_emergency_access_invite(token)?;
 
-    let grantee_user = match User::find_by_mail(&claims.email, &conn) {
+    let grantee_user = match User::find_by_mail(&claims.email, &conn).await {
         Some(user) => {
-            Invitation::take(&claims.email, &conn);
+            Invitation::take(&claims.email, &conn).await;
             user
         }
         None => err!("Invited user not found"),
     };
 
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
 
     // get grantor user to send Accepted email
-    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
@@ -336,7 +357,7 @@ fn accept_invite(emer_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) ->
         && (claims.grantor_name.is_some() && grantor_user.name == claims.grantor_name.unwrap())
         && (claims.grantor_email.is_some() && grantor_user.email == claims.grantor_email.unwrap())
     {
-        match accept_invite_process(grantee_user.uuid.clone(), emer_id, Some(grantee_user.email.clone()), &conn) {
+        match accept_invite_process(grantee_user.uuid.clone(), emer_id, Some(grantee_user.email.clone()), &conn).await {
             Ok(v) => (v),
             Err(e) => err!(e.to_string()),
         }
@@ -351,8 +372,13 @@ fn accept_invite(emer_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) ->
     }
 }
 
-fn accept_invite_process(grantee_uuid: String, emer_id: String, email: Option<String>, conn: &DbConn) -> EmptyResult {
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, conn) {
+async fn accept_invite_process(
+    grantee_uuid: String,
+    emer_id: String,
+    email: Option<String>,
+    conn: &DbConn,
+) -> EmptyResult {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -369,7 +395,7 @@ fn accept_invite_process(grantee_uuid: String, emer_id: String, email: Option<St
     emergency_access.status = EmergencyAccessStatus::Accepted as i32;
     emergency_access.grantee_uuid = Some(grantee_uuid);
     emergency_access.email = None;
-    emergency_access.save(conn)
+    emergency_access.save(conn).await
 }
 
 #[derive(Deserialize)]
@@ -379,7 +405,7 @@ struct ConfirmData {
 }
 
 #[post("/emergency-access/<emer_id>/confirm", data = "<data>")]
-fn confirm_emergency_access(
+async fn confirm_emergency_access(
     emer_id: String,
     data: JsonUpcase<ConfirmData>,
     headers: Headers,
@@ -391,7 +417,7 @@ fn confirm_emergency_access(
     let data: ConfirmData = data.into_inner().data;
     let key = data.Key;
 
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -402,13 +428,13 @@ fn confirm_emergency_access(
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&confirming_user.uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&confirming_user.uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
 
     if let Some(grantee_uuid) = emergency_access.grantee_uuid.as_ref() {
-        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn) {
+        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn).await {
             Some(user) => user,
             None => err!("Grantee user not found."),
         };
@@ -417,7 +443,7 @@ fn confirm_emergency_access(
         emergency_access.key_encrypted = Some(key);
         emergency_access.email = None;
 
-        emergency_access.save(&conn)?;
+        emergency_access.save(&conn).await?;
 
         if CONFIG.mail_enabled() {
             mail::send_emergency_access_invite_confirmed(&grantee_user.email, &grantor_user.name)?;
@@ -433,11 +459,11 @@ fn confirm_emergency_access(
 // region access emergency access
 
 #[post("/emergency-access/<emer_id>/initiate")]
-fn initiate_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn initiate_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let initiating_user = headers.user;
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -448,7 +474,7 @@ fn initiate_emergency_access(emer_id: String, headers: Headers, conn: DbConn) ->
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
@@ -458,7 +484,7 @@ fn initiate_emergency_access(emer_id: String, headers: Headers, conn: DbConn) ->
     emergency_access.updated_at = now;
     emergency_access.recovery_initiated_at = Some(now);
     emergency_access.last_notification_at = Some(now);
-    emergency_access.save(&conn)?;
+    emergency_access.save(&conn).await?;
 
     if CONFIG.mail_enabled() {
         mail::send_emergency_access_recovery_initiated(
@@ -472,11 +498,11 @@ fn initiate_emergency_access(emer_id: String, headers: Headers, conn: DbConn) ->
 }
 
 #[post("/emergency-access/<emer_id>/approve")]
-fn approve_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn approve_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let approving_user = headers.user;
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -487,19 +513,19 @@ fn approve_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> 
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&approving_user.uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&approving_user.uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
 
     if let Some(grantee_uuid) = emergency_access.grantee_uuid.as_ref() {
-        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn) {
+        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn).await {
             Some(user) => user,
             None => err!("Grantee user not found."),
         };
 
         emergency_access.status = EmergencyAccessStatus::RecoveryApproved as i32;
-        emergency_access.save(&conn)?;
+        emergency_access.save(&conn).await?;
 
         if CONFIG.mail_enabled() {
             mail::send_emergency_access_recovery_approved(&grantee_user.email, &grantor_user.name)?;
@@ -511,11 +537,11 @@ fn approve_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> 
 }
 
 #[post("/emergency-access/<emer_id>/reject")]
-fn reject_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn reject_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let rejecting_user = headers.user;
-    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let mut emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -527,19 +553,19 @@ fn reject_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> J
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&rejecting_user.uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&rejecting_user.uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
 
     if let Some(grantee_uuid) = emergency_access.grantee_uuid.as_ref() {
-        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn) {
+        let grantee_user = match User::find_by_uuid(grantee_uuid, &conn).await {
             Some(user) => user,
             None => err!("Grantee user not found."),
         };
 
         emergency_access.status = EmergencyAccessStatus::Confirmed as i32;
-        emergency_access.save(&conn)?;
+        emergency_access.save(&conn).await?;
 
         if CONFIG.mail_enabled() {
             mail::send_emergency_access_recovery_rejected(&grantee_user.email, &grantor_user.name)?;
@@ -555,12 +581,12 @@ fn reject_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> J
 // region action
 
 #[post("/emergency-access/<emer_id>/view")]
-fn view_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn view_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let requesting_user = headers.user;
     let host = headers.host;
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -569,10 +595,13 @@ fn view_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> Jso
         err!("Emergency access not valid.")
     }
 
-    let ciphers = Cipher::find_owned_by_user(&emergency_access.grantor_uuid, &conn);
-
-    let ciphers_json: Vec<Value> =
-        ciphers.iter().map(|c| c.to_json(&host, &emergency_access.grantor_uuid, &conn)).collect();
+    let ciphers_json = stream::iter(Cipher::find_owned_by_user(&emergency_access.grantor_uuid, &conn).await)
+        .then(|c| async {
+            let c = c; // Move out this single variable
+            c.to_json(&host, &emergency_access.grantor_uuid, &conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     Ok(Json(json!({
       "Ciphers": ciphers_json,
@@ -582,11 +611,11 @@ fn view_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> Jso
 }
 
 #[post("/emergency-access/<emer_id>/takeover")]
-fn takeover_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn takeover_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     check_emergency_access_allowed()?;
 
     let requesting_user = headers.user;
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -595,7 +624,7 @@ fn takeover_emergency_access(emer_id: String, headers: Headers, conn: DbConn) ->
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
@@ -616,7 +645,7 @@ struct EmergencyAccessPasswordData {
 }
 
 #[post("/emergency-access/<emer_id>/password", data = "<data>")]
-fn password_emergency_access(
+async fn password_emergency_access(
     emer_id: String,
     data: JsonUpcase<EmergencyAccessPasswordData>,
     headers: Headers,
@@ -629,7 +658,7 @@ fn password_emergency_access(
     let key = data.Key;
 
     let requesting_user = headers.user;
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -638,7 +667,7 @@ fn password_emergency_access(
         err!("Emergency access not valid.")
     }
 
-    let mut grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn) {
+    let mut grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
@@ -646,18 +675,15 @@ fn password_emergency_access(
     // change grantor_user password
     grantor_user.set_password(new_master_password_hash, None);
     grantor_user.akey = key;
-    grantor_user.save(&conn)?;
+    grantor_user.save(&conn).await?;
 
     // Disable TwoFactor providers since they will otherwise block logins
-    TwoFactor::delete_all_by_user(&grantor_user.uuid, &conn)?;
-
-    // Removing owner, check that there are at least another owner
-    let user_org_grantor = UserOrganization::find_any_state_by_user(&grantor_user.uuid, &conn);
+    TwoFactor::delete_all_by_user(&grantor_user.uuid, &conn).await?;
 
     // Remove grantor from all organisations unless Owner
-    for user_org in user_org_grantor {
+    for user_org in UserOrganization::find_any_state_by_user(&grantor_user.uuid, &conn).await {
         if user_org.atype != UserOrgType::Owner as i32 {
-            user_org.delete(&conn)?;
+            user_org.delete(&conn).await?;
         }
     }
     Ok(())
@@ -666,9 +692,9 @@ fn password_emergency_access(
 // endregion
 
 #[get("/emergency-access/<emer_id>/policies")]
-fn policies_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
+async fn policies_emergency_access(emer_id: String, headers: Headers, conn: DbConn) -> JsonResult {
     let requesting_user = headers.user;
-    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn) {
+    let emergency_access = match EmergencyAccess::find_by_uuid(&emer_id, &conn).await {
         Some(emer) => emer,
         None => err!("Emergency access not valid."),
     };
@@ -677,13 +703,13 @@ fn policies_emergency_access(emer_id: String, headers: Headers, conn: DbConn) ->
         err!("Emergency access not valid.")
     }
 
-    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn) {
+    let grantor_user = match User::find_by_uuid(&emergency_access.grantor_uuid, &conn).await {
         Some(user) => user,
         None => err!("Grantor user not found."),
     };
 
     let policies = OrgPolicy::find_confirmed_by_user(&grantor_user.uuid, &conn);
-    let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
+    let policies_json: Vec<Value> = policies.await.iter().map(OrgPolicy::to_json).collect();
 
     Ok(Json(json!({
         "Data": policies_json,
@@ -716,7 +742,7 @@ pub async fn emergency_request_timeout_job(pool: DbPool) {
     }
 
     if let Ok(conn) = pool.get().await {
-        let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn);
+        let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn).await;
 
         if emergency_access_list.is_empty() {
             debug!("No emergency request timeout to approve");
@@ -728,15 +754,17 @@ pub async fn emergency_request_timeout_job(pool: DbPool) {
                     >= emer.recovery_initiated_at.unwrap() + Duration::days(emer.wait_time_days as i64)
             {
                 emer.status = EmergencyAccessStatus::RecoveryApproved as i32;
-                emer.save(&conn).expect("Cannot save emergency access on job");
+                emer.save(&conn).await.expect("Cannot save emergency access on job");
 
                 if CONFIG.mail_enabled() {
                     // get grantor user to send Accepted email
-                    let grantor_user = User::find_by_uuid(&emer.grantor_uuid, &conn).expect("Grantor user not found.");
+                    let grantor_user =
+                        User::find_by_uuid(&emer.grantor_uuid, &conn).await.expect("Grantor user not found.");
 
                     // get grantee user to send Accepted email
                     let grantee_user =
                         User::find_by_uuid(&emer.grantee_uuid.clone().expect("Grantee user invalid."), &conn)
+                            .await
                             .expect("Grantee user not found.");
 
                     mail::send_emergency_access_recovery_timed_out(
@@ -763,7 +791,7 @@ pub async fn emergency_notification_reminder_job(pool: DbPool) {
     }
 
     if let Ok(conn) = pool.get().await {
-        let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn);
+        let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn).await;
 
         if emergency_access_list.is_empty() {
             debug!("No emergency request reminder notification to send");
@@ -777,15 +805,17 @@ pub async fn emergency_notification_reminder_job(pool: DbPool) {
                     || (emer.last_notification_at.is_some()
                         && Utc::now().naive_utc() >= emer.last_notification_at.unwrap() + Duration::days(1)))
             {
-                emer.save(&conn).expect("Cannot save emergency access on job");
+                emer.save(&conn).await.expect("Cannot save emergency access on job");
 
                 if CONFIG.mail_enabled() {
                     // get grantor user to send Accepted email
-                    let grantor_user = User::find_by_uuid(&emer.grantor_uuid, &conn).expect("Grantor user not found.");
+                    let grantor_user =
+                        User::find_by_uuid(&emer.grantor_uuid, &conn).await.expect("Grantor user not found.");
 
                     // get grantee user to send Accepted email
                     let grantee_user =
                         User::find_by_uuid(&emer.grantee_uuid.clone().expect("Grantee user invalid."), &conn)
+                            .await
                             .expect("Grantee user not found.");
 
                     mail::send_emergency_access_recovery_reminder(

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, Utc};
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 use std::borrow::Borrow;
 
@@ -709,13 +709,13 @@ fn check_emergency_access_allowed() -> EmptyResult {
     Ok(())
 }
 
-pub fn emergency_request_timeout_job(pool: DbPool) {
+pub async fn emergency_request_timeout_job(pool: DbPool) {
     debug!("Start emergency_request_timeout_job");
     if !CONFIG.emergency_access_allowed() {
         return;
     }
 
-    if let Ok(conn) = pool.get() {
+    if let Ok(conn) = pool.get().await {
         let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn);
 
         if emergency_access_list.is_empty() {
@@ -756,13 +756,13 @@ pub fn emergency_request_timeout_job(pool: DbPool) {
     }
 }
 
-pub fn emergency_notification_reminder_job(pool: DbPool) {
+pub async fn emergency_notification_reminder_job(pool: DbPool) {
     debug!("Start emergency_notification_reminder_job");
     if !CONFIG.emergency_access_allowed() {
         return;
     }
 
-    if let Ok(conn) = pool.get() {
+    if let Ok(conn) = pool.get().await {
         let emergency_access_list = EmergencyAccess::find_all_recoveries(&conn);
 
         if emergency_access_list.is_empty() {

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -12,9 +12,8 @@ pub fn routes() -> Vec<rocket::Route> {
 }
 
 #[get("/folders")]
-fn get_folders(headers: Headers, conn: DbConn) -> Json<Value> {
-    let folders = Folder::find_by_user(&headers.user.uuid, &conn);
-
+async fn get_folders(headers: Headers, conn: DbConn) -> Json<Value> {
+    let folders = Folder::find_by_user(&headers.user.uuid, &conn).await;
     let folders_json: Vec<Value> = folders.iter().map(Folder::to_json).collect();
 
     Json(json!({
@@ -25,8 +24,8 @@ fn get_folders(headers: Headers, conn: DbConn) -> Json<Value> {
 }
 
 #[get("/folders/<uuid>")]
-fn get_folder(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
-    let folder = match Folder::find_by_uuid(&uuid, &conn) {
+async fn get_folder(uuid: String, headers: Headers, conn: DbConn) -> JsonResult {
+    let folder = match Folder::find_by_uuid(&uuid, &conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };
@@ -45,27 +44,39 @@ pub struct FolderData {
 }
 
 #[post("/folders", data = "<data>")]
-fn post_folders(data: JsonUpcase<FolderData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn post_folders(data: JsonUpcase<FolderData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
     let data: FolderData = data.into_inner().data;
 
     let mut folder = Folder::new(headers.user.uuid, data.Name);
 
-    folder.save(&conn)?;
+    folder.save(&conn).await?;
     nt.send_folder_update(UpdateType::FolderCreate, &folder);
 
     Ok(Json(folder.to_json()))
 }
 
 #[post("/folders/<uuid>", data = "<data>")]
-fn post_folder(uuid: String, data: JsonUpcase<FolderData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
-    put_folder(uuid, data, headers, conn, nt)
+async fn post_folder(
+    uuid: String,
+    data: JsonUpcase<FolderData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    put_folder(uuid, data, headers, conn, nt).await
 }
 
 #[put("/folders/<uuid>", data = "<data>")]
-fn put_folder(uuid: String, data: JsonUpcase<FolderData>, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn put_folder(
+    uuid: String,
+    data: JsonUpcase<FolderData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
     let data: FolderData = data.into_inner().data;
 
-    let mut folder = match Folder::find_by_uuid(&uuid, &conn) {
+    let mut folder = match Folder::find_by_uuid(&uuid, &conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };
@@ -76,20 +87,20 @@ fn put_folder(uuid: String, data: JsonUpcase<FolderData>, headers: Headers, conn
 
     folder.name = data.Name;
 
-    folder.save(&conn)?;
+    folder.save(&conn).await?;
     nt.send_folder_update(UpdateType::FolderUpdate, &folder);
 
     Ok(Json(folder.to_json()))
 }
 
 #[post("/folders/<uuid>/delete")]
-fn delete_folder_post(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    delete_folder(uuid, headers, conn, nt)
+async fn delete_folder_post(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    delete_folder(uuid, headers, conn, nt).await
 }
 
 #[delete("/folders/<uuid>")]
-fn delete_folder(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> EmptyResult {
-    let folder = match Folder::find_by_uuid(&uuid, &conn) {
+async fn delete_folder(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    let folder = match Folder::find_by_uuid(&uuid, &conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };
@@ -99,7 +110,7 @@ fn delete_folder(uuid: String, headers: Headers, conn: DbConn, nt: Notify) -> Em
     }
 
     // Delete the actual folder entry
-    folder.delete(&conn)?;
+    folder.delete(&conn).await?;
 
     nt.send_folder_update(UpdateType::FolderDelete, &folder);
     Ok(())

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -1,4 +1,4 @@
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
 use serde_json::Value;
 
 use crate::{

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -31,8 +31,8 @@ pub fn routes() -> Vec<Route> {
 //
 // Move this somewhere else
 //
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 
 use crate::{
@@ -144,7 +144,7 @@ fn put_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: DbC
 }
 
 #[get("/hibp/breach?<username>")]
-fn hibp_breach(username: String) -> JsonResult {
+async fn hibp_breach(username: String) -> JsonResult {
     let url = format!(
         "https://haveibeenpwned.com/api/v3/breachedaccount/{}?truncateResponse=false&includeUnverified=false",
         username
@@ -153,14 +153,14 @@ fn hibp_breach(username: String) -> JsonResult {
     if let Some(api_key) = crate::CONFIG.hibp_api_key() {
         let hibp_client = get_reqwest_client();
 
-        let res = hibp_client.get(&url).header("hibp-api-key", api_key).send()?;
+        let res = hibp_client.get(&url).header("hibp-api-key", api_key).send().await?;
 
         // If we get a 404, return a 404, it means no breached accounts
         if res.status() == 404 {
             return Err(Error::empty().with_code(404));
         }
 
-        let value: Value = res.error_for_status()?.json()?;
+        let value: Value = res.error_for_status()?.json().await?;
         Ok(Json(value))
     } else {
         Ok(Json(json!([{

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -121,7 +121,7 @@ struct EquivDomainData {
 }
 
 #[post("/settings/domains", data = "<data>")]
-fn post_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn post_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: EquivDomainData = data.into_inner().data;
 
     let excluded_globals = data.ExcludedGlobalEquivalentDomains.unwrap_or_default();
@@ -133,14 +133,14 @@ fn post_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: Db
     user.excluded_globals = to_string(&excluded_globals).unwrap_or_else(|_| "[]".to_string());
     user.equivalent_domains = to_string(&equivalent_domains).unwrap_or_else(|_| "[]".to_string());
 
-    user.save(&conn)?;
+    user.save(&conn).await?;
 
     Ok(Json(json!({})))
 }
 
 #[put("/settings/domains", data = "<data>")]
-fn put_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: DbConn) -> JsonResult {
-    post_eq_domains(data, headers, conn)
+async fn put_eq_domains(data: JsonUpcase<EquivDomainData>, headers: Headers, conn: DbConn) -> JsonResult {
+    post_eq_domains(data, headers, conn).await
 }
 
 #[get("/hibp/breach?<username>")]

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1,6 +1,6 @@
 use num_traits::FromPrimitive;
-use rocket::{request::Form, Route};
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
+use rocket::Route;
 use serde_json::Value;
 
 use crate::{
@@ -469,12 +469,12 @@ fn put_collection_users(
 
 #[derive(FromForm)]
 struct OrgIdData {
-    #[form(field = "organizationId")]
+    #[field(name = "organizationId")]
     organization_id: String,
 }
 
 #[get("/ciphers/organization-details?<data..>")]
-fn get_org_details(data: Form<OrgIdData>, headers: Headers, conn: DbConn) -> Json<Value> {
+fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> Json<Value> {
     let ciphers = Cipher::find_by_org(&data.organization_id, &conn);
     let ciphers_json: Vec<Value> =
         ciphers.iter().map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn)).collect();
@@ -1097,14 +1097,14 @@ struct RelationsData {
 
 #[post("/ciphers/import-organization?<query..>", data = "<data>")]
 fn post_org_import(
-    query: Form<OrgIdData>,
+    query: OrgIdData,
     data: JsonUpcase<ImportData>,
     headers: AdminHeaders,
     conn: DbConn,
     nt: Notify,
 ) -> EmptyResult {
     let data: ImportData = data.into_inner().data;
-    let org_id = query.into_inner().organization_id;
+    let org_id = query.organization_id;
 
     // Read and create the collections
     let collections: Vec<_> = data

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -10,6 +10,8 @@ use crate::{
     mail, CONFIG,
 };
 
+use futures::{stream, stream::StreamExt};
+
 pub fn routes() -> Vec<Route> {
     routes![
         get_organization,
@@ -98,11 +100,11 @@ struct OrgBulkIds {
 }
 
 #[post("/organizations", data = "<data>")]
-fn create_organization(headers: Headers, data: JsonUpcase<OrgData>, conn: DbConn) -> JsonResult {
+async fn create_organization(headers: Headers, data: JsonUpcase<OrgData>, conn: DbConn) -> JsonResult {
     if !CONFIG.is_org_creation_allowed(&headers.user.email) {
         err!("User not allowed to create organizations")
     }
-    if OrgPolicy::is_applicable_to_user(&headers.user.uuid, OrgPolicyType::SingleOrg, &conn) {
+    if OrgPolicy::is_applicable_to_user(&headers.user.uuid, OrgPolicyType::SingleOrg, &conn).await {
         err!(
             "You may not create an organization. You belong to an organization which has a policy that prohibits you from being a member of any other organization."
         )
@@ -125,15 +127,15 @@ fn create_organization(headers: Headers, data: JsonUpcase<OrgData>, conn: DbConn
     user_org.atype = UserOrgType::Owner as i32;
     user_org.status = UserOrgStatus::Confirmed as i32;
 
-    org.save(&conn)?;
-    user_org.save(&conn)?;
-    collection.save(&conn)?;
+    org.save(&conn).await?;
+    user_org.save(&conn).await?;
+    collection.save(&conn).await?;
 
     Ok(Json(org.to_json()))
 }
 
 #[delete("/organizations/<org_id>", data = "<data>")]
-fn delete_organization(
+async fn delete_organization(
     org_id: String,
     data: JsonUpcase<PasswordData>,
     headers: OwnerHeaders,
@@ -146,61 +148,61 @@ fn delete_organization(
         err!("Invalid password")
     }
 
-    match Organization::find_by_uuid(&org_id, &conn) {
+    match Organization::find_by_uuid(&org_id, &conn).await {
         None => err!("Organization not found"),
-        Some(org) => org.delete(&conn),
+        Some(org) => org.delete(&conn).await,
     }
 }
 
 #[post("/organizations/<org_id>/delete", data = "<data>")]
-fn post_delete_organization(
+async fn post_delete_organization(
     org_id: String,
     data: JsonUpcase<PasswordData>,
     headers: OwnerHeaders,
     conn: DbConn,
 ) -> EmptyResult {
-    delete_organization(org_id, data, headers, conn)
+    delete_organization(org_id, data, headers, conn).await
 }
 
 #[post("/organizations/<org_id>/leave")]
-fn leave_organization(org_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
-    match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn) {
+async fn leave_organization(org_id: String, headers: Headers, conn: DbConn) -> EmptyResult {
+    match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn).await {
         None => err!("User not part of organization"),
         Some(user_org) => {
             if user_org.atype == UserOrgType::Owner {
                 let num_owners =
-                    UserOrganization::find_by_org_and_type(&org_id, UserOrgType::Owner as i32, &conn).len();
+                    UserOrganization::find_by_org_and_type(&org_id, UserOrgType::Owner as i32, &conn).await.len();
 
                 if num_owners <= 1 {
                     err!("The last owner can't leave")
                 }
             }
 
-            user_org.delete(&conn)
+            user_org.delete(&conn).await
         }
     }
 }
 
 #[get("/organizations/<org_id>")]
-fn get_organization(org_id: String, _headers: OwnerHeaders, conn: DbConn) -> JsonResult {
-    match Organization::find_by_uuid(&org_id, &conn) {
+async fn get_organization(org_id: String, _headers: OwnerHeaders, conn: DbConn) -> JsonResult {
+    match Organization::find_by_uuid(&org_id, &conn).await {
         Some(organization) => Ok(Json(organization.to_json())),
         None => err!("Can't find organization details"),
     }
 }
 
 #[put("/organizations/<org_id>", data = "<data>")]
-fn put_organization(
+async fn put_organization(
     org_id: String,
     headers: OwnerHeaders,
     data: JsonUpcase<OrganizationUpdateData>,
     conn: DbConn,
 ) -> JsonResult {
-    post_organization(org_id, headers, data, conn)
+    post_organization(org_id, headers, data, conn).await
 }
 
 #[post("/organizations/<org_id>", data = "<data>")]
-fn post_organization(
+async fn post_organization(
     org_id: String,
     _headers: OwnerHeaders,
     data: JsonUpcase<OrganizationUpdateData>,
@@ -208,7 +210,7 @@ fn post_organization(
 ) -> JsonResult {
     let data: OrganizationUpdateData = data.into_inner().data;
 
-    let mut org = match Organization::find_by_uuid(&org_id, &conn) {
+    let mut org = match Organization::find_by_uuid(&org_id, &conn).await {
         Some(organization) => organization,
         None => err!("Can't find organization details"),
     };
@@ -216,16 +218,16 @@ fn post_organization(
     org.name = data.Name;
     org.billing_email = data.BillingEmail;
 
-    org.save(&conn)?;
+    org.save(&conn).await?;
     Ok(Json(org.to_json()))
 }
 
 // GET /api/collections?writeOnly=false
 #[get("/collections")]
-fn get_user_collections(headers: Headers, conn: DbConn) -> Json<Value> {
+async fn get_user_collections(headers: Headers, conn: DbConn) -> Json<Value> {
     Json(json!({
         "Data":
-            Collection::find_by_user_uuid(&headers.user.uuid, &conn)
+            Collection::find_by_user_uuid(&headers.user.uuid, &conn).await
             .iter()
             .map(Collection::to_json)
             .collect::<Value>(),
@@ -235,10 +237,10 @@ fn get_user_collections(headers: Headers, conn: DbConn) -> Json<Value> {
 }
 
 #[get("/organizations/<org_id>/collections")]
-fn get_org_collections(org_id: String, _headers: ManagerHeadersLoose, conn: DbConn) -> Json<Value> {
+async fn get_org_collections(org_id: String, _headers: ManagerHeadersLoose, conn: DbConn) -> Json<Value> {
     Json(json!({
         "Data":
-            Collection::find_by_organization(&org_id, &conn)
+            Collection::find_by_organization(&org_id, &conn).await
             .iter()
             .map(Collection::to_json)
             .collect::<Value>(),
@@ -248,7 +250,7 @@ fn get_org_collections(org_id: String, _headers: ManagerHeadersLoose, conn: DbCo
 }
 
 #[post("/organizations/<org_id>/collections", data = "<data>")]
-fn post_organization_collections(
+async fn post_organization_collections(
     org_id: String,
     headers: ManagerHeadersLoose,
     data: JsonUpcase<NewCollectionData>,
@@ -256,43 +258,43 @@ fn post_organization_collections(
 ) -> JsonResult {
     let data: NewCollectionData = data.into_inner().data;
 
-    let org = match Organization::find_by_uuid(&org_id, &conn) {
+    let org = match Organization::find_by_uuid(&org_id, &conn).await {
         Some(organization) => organization,
         None => err!("Can't find organization details"),
     };
 
     // Get the user_organization record so that we can check if the user has access to all collections.
-    let user_org = match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn) {
+    let user_org = match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn).await {
         Some(u) => u,
         None => err!("User is not part of organization"),
     };
 
     let collection = Collection::new(org.uuid, data.Name);
-    collection.save(&conn)?;
+    collection.save(&conn).await?;
 
     // If the user doesn't have access to all collections, only in case of a Manger,
     // then we need to save the creating user uuid (Manager) to the users_collection table.
     // Else the user will not have access to his own created collection.
     if !user_org.access_all {
-        CollectionUser::save(&headers.user.uuid, &collection.uuid, false, false, &conn)?;
+        CollectionUser::save(&headers.user.uuid, &collection.uuid, false, false, &conn).await?;
     }
 
     Ok(Json(collection.to_json()))
 }
 
 #[put("/organizations/<org_id>/collections/<col_id>", data = "<data>")]
-fn put_organization_collection_update(
+async fn put_organization_collection_update(
     org_id: String,
     col_id: String,
     headers: ManagerHeaders,
     data: JsonUpcase<NewCollectionData>,
     conn: DbConn,
 ) -> JsonResult {
-    post_organization_collection_update(org_id, col_id, headers, data, conn)
+    post_organization_collection_update(org_id, col_id, headers, data, conn).await
 }
 
 #[post("/organizations/<org_id>/collections/<col_id>", data = "<data>")]
-fn post_organization_collection_update(
+async fn post_organization_collection_update(
     org_id: String,
     col_id: String,
     _headers: ManagerHeaders,
@@ -301,12 +303,12 @@ fn post_organization_collection_update(
 ) -> JsonResult {
     let data: NewCollectionData = data.into_inner().data;
 
-    let org = match Organization::find_by_uuid(&org_id, &conn) {
+    let org = match Organization::find_by_uuid(&org_id, &conn).await {
         Some(organization) => organization,
         None => err!("Can't find organization details"),
     };
 
-    let mut collection = match Collection::find_by_uuid(&col_id, &conn) {
+    let mut collection = match Collection::find_by_uuid(&col_id, &conn).await {
         Some(collection) => collection,
         None => err!("Collection not found"),
     };
@@ -316,20 +318,20 @@ fn post_organization_collection_update(
     }
 
     collection.name = data.Name;
-    collection.save(&conn)?;
+    collection.save(&conn).await?;
 
     Ok(Json(collection.to_json()))
 }
 
 #[delete("/organizations/<org_id>/collections/<col_id>/user/<org_user_id>")]
-fn delete_organization_collection_user(
+async fn delete_organization_collection_user(
     org_id: String,
     col_id: String,
     org_user_id: String,
     _headers: AdminHeaders,
     conn: DbConn,
 ) -> EmptyResult {
-    let collection = match Collection::find_by_uuid(&col_id, &conn) {
+    let collection = match Collection::find_by_uuid(&col_id, &conn).await {
         None => err!("Collection not found"),
         Some(collection) => {
             if collection.org_uuid == org_id {
@@ -340,40 +342,40 @@ fn delete_organization_collection_user(
         }
     };
 
-    match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn) {
+    match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn).await {
         None => err!("User not found in organization"),
         Some(user_org) => {
-            match CollectionUser::find_by_collection_and_user(&collection.uuid, &user_org.user_uuid, &conn) {
+            match CollectionUser::find_by_collection_and_user(&collection.uuid, &user_org.user_uuid, &conn).await {
                 None => err!("User not assigned to collection"),
-                Some(col_user) => col_user.delete(&conn),
+                Some(col_user) => col_user.delete(&conn).await,
             }
         }
     }
 }
 
 #[post("/organizations/<org_id>/collections/<col_id>/delete-user/<org_user_id>")]
-fn post_organization_collection_delete_user(
+async fn post_organization_collection_delete_user(
     org_id: String,
     col_id: String,
     org_user_id: String,
     headers: AdminHeaders,
     conn: DbConn,
 ) -> EmptyResult {
-    delete_organization_collection_user(org_id, col_id, org_user_id, headers, conn)
+    delete_organization_collection_user(org_id, col_id, org_user_id, headers, conn).await
 }
 
 #[delete("/organizations/<org_id>/collections/<col_id>")]
-fn delete_organization_collection(
+async fn delete_organization_collection(
     org_id: String,
     col_id: String,
     _headers: ManagerHeaders,
     conn: DbConn,
 ) -> EmptyResult {
-    match Collection::find_by_uuid(&col_id, &conn) {
+    match Collection::find_by_uuid(&col_id, &conn).await {
         None => err!("Collection not found"),
         Some(collection) => {
             if collection.org_uuid == org_id {
-                collection.delete(&conn)
+                collection.delete(&conn).await
             } else {
                 err!("Collection and Organization id do not match")
             }
@@ -389,19 +391,24 @@ struct DeleteCollectionData {
 }
 
 #[post("/organizations/<org_id>/collections/<col_id>/delete", data = "<_data>")]
-fn post_organization_collection_delete(
+async fn post_organization_collection_delete(
     org_id: String,
     col_id: String,
     headers: ManagerHeaders,
     _data: JsonUpcase<DeleteCollectionData>,
     conn: DbConn,
 ) -> EmptyResult {
-    delete_organization_collection(org_id, col_id, headers, conn)
+    delete_organization_collection(org_id, col_id, headers, conn).await
 }
 
 #[get("/organizations/<org_id>/collections/<coll_id>/details")]
-fn get_org_collection_detail(org_id: String, coll_id: String, headers: ManagerHeaders, conn: DbConn) -> JsonResult {
-    match Collection::find_by_uuid_and_user(&coll_id, &headers.user.uuid, &conn) {
+async fn get_org_collection_detail(
+    org_id: String,
+    coll_id: String,
+    headers: ManagerHeaders,
+    conn: DbConn,
+) -> JsonResult {
+    match Collection::find_by_uuid_and_user(&coll_id, &headers.user.uuid, &conn).await {
         None => err!("Collection not found"),
         Some(collection) => {
             if collection.org_uuid != org_id {
@@ -414,28 +421,29 @@ fn get_org_collection_detail(org_id: String, coll_id: String, headers: ManagerHe
 }
 
 #[get("/organizations/<org_id>/collections/<coll_id>/users")]
-fn get_collection_users(org_id: String, coll_id: String, _headers: ManagerHeaders, conn: DbConn) -> JsonResult {
+async fn get_collection_users(org_id: String, coll_id: String, _headers: ManagerHeaders, conn: DbConn) -> JsonResult {
     // Get org and collection, check that collection is from org
-    let collection = match Collection::find_by_uuid_and_org(&coll_id, &org_id, &conn) {
+    let collection = match Collection::find_by_uuid_and_org(&coll_id, &org_id, &conn).await {
         None => err!("Collection not found in Organization"),
         Some(collection) => collection,
     };
 
-    // Get the users from collection
-    let user_list: Vec<Value> = CollectionUser::find_by_collection(&collection.uuid, &conn)
-        .iter()
-        .map(|col_user| {
+    let user_list = stream::iter(CollectionUser::find_by_collection(&collection.uuid, &conn).await)
+        .then(|col_user| async {
+            let col_user = col_user; // Move out this single variable
             UserOrganization::find_by_user_and_org(&col_user.user_uuid, &org_id, &conn)
+                .await
                 .unwrap()
-                .to_json_user_access_restrictions(col_user)
+                .to_json_user_access_restrictions(&col_user)
         })
-        .collect();
+        .collect::<Vec<Value>>()
+        .await;
 
     Ok(Json(json!(user_list)))
 }
 
 #[put("/organizations/<org_id>/collections/<coll_id>/users", data = "<data>")]
-fn put_collection_users(
+async fn put_collection_users(
     org_id: String,
     coll_id: String,
     data: JsonUpcaseVec<CollectionData>,
@@ -443,16 +451,16 @@ fn put_collection_users(
     conn: DbConn,
 ) -> EmptyResult {
     // Get org and collection, check that collection is from org
-    if Collection::find_by_uuid_and_org(&coll_id, &org_id, &conn).is_none() {
+    if Collection::find_by_uuid_and_org(&coll_id, &org_id, &conn).await.is_none() {
         err!("Collection not found in Organization")
     }
 
     // Delete all the user-collections
-    CollectionUser::delete_all_by_collection(&coll_id, &conn)?;
+    CollectionUser::delete_all_by_collection(&coll_id, &conn).await?;
 
     // And then add all the received ones (except if the user has access_all)
     for d in data.iter().map(|d| &d.data) {
-        let user = match UserOrganization::find_by_uuid(&d.Id, &conn) {
+        let user = match UserOrganization::find_by_uuid(&d.Id, &conn).await {
             Some(u) => u,
             None => err!("User is not part of organization"),
         };
@@ -461,7 +469,7 @@ fn put_collection_users(
             continue;
         }
 
-        CollectionUser::save(&user.user_uuid, &coll_id, d.ReadOnly, d.HidePasswords, &conn)?;
+        CollectionUser::save(&user.user_uuid, &coll_id, d.ReadOnly, d.HidePasswords, &conn).await?;
     }
 
     Ok(())
@@ -474,10 +482,14 @@ struct OrgIdData {
 }
 
 #[get("/ciphers/organization-details?<data..>")]
-fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> Json<Value> {
-    let ciphers = Cipher::find_by_org(&data.organization_id, &conn);
-    let ciphers_json: Vec<Value> =
-        ciphers.iter().map(|c| c.to_json(&headers.host, &headers.user.uuid, &conn)).collect();
+async fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> Json<Value> {
+    let ciphers_json = stream::iter(Cipher::find_by_org(&data.organization_id, &conn).await)
+        .then(|c| async {
+            let c = c; // Move out this single variable
+            c.to_json(&headers.host, &headers.user.uuid, &conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     Json(json!({
       "Data": ciphers_json,
@@ -487,9 +499,14 @@ fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> Json<Valu
 }
 
 #[get("/organizations/<org_id>/users")]
-fn get_org_users(org_id: String, _headers: ManagerHeadersLoose, conn: DbConn) -> Json<Value> {
-    let users = UserOrganization::find_by_org(&org_id, &conn);
-    let users_json: Vec<Value> = users.iter().map(|c| c.to_json_user_details(&conn)).collect();
+async fn get_org_users(org_id: String, _headers: ManagerHeadersLoose, conn: DbConn) -> Json<Value> {
+    let users_json = stream::iter(UserOrganization::find_by_org(&org_id, &conn).await)
+        .then(|u| async {
+            let u = u; // Move out this single variable
+            u.to_json_user_details(&conn).await
+        })
+        .collect::<Vec<Value>>()
+        .await;
 
     Json(json!({
         "Data": users_json,
@@ -499,10 +516,15 @@ fn get_org_users(org_id: String, _headers: ManagerHeadersLoose, conn: DbConn) ->
 }
 
 #[post("/organizations/<org_id>/keys", data = "<data>")]
-fn post_org_keys(org_id: String, data: JsonUpcase<OrgKeyData>, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
+async fn post_org_keys(
+    org_id: String,
+    data: JsonUpcase<OrgKeyData>,
+    _headers: AdminHeaders,
+    conn: DbConn,
+) -> JsonResult {
     let data: OrgKeyData = data.into_inner().data;
 
-    let mut org = match Organization::find_by_uuid(&org_id, &conn) {
+    let mut org = match Organization::find_by_uuid(&org_id, &conn).await {
         Some(organization) => {
             if organization.private_key.is_some() && organization.public_key.is_some() {
                 err!("Organization Keys already exist")
@@ -515,7 +537,7 @@ fn post_org_keys(org_id: String, data: JsonUpcase<OrgKeyData>, _headers: AdminHe
     org.private_key = Some(data.EncryptedPrivateKey);
     org.public_key = Some(data.PublicKey);
 
-    org.save(&conn)?;
+    org.save(&conn).await?;
 
     Ok(Json(json!({
         "Object": "organizationKeys",
@@ -542,7 +564,7 @@ struct InviteData {
 }
 
 #[post("/organizations/<org_id>/users/invite", data = "<data>")]
-fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+async fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
     let data: InviteData = data.into_inner().data;
 
     let new_type = match UserOrgType::from_str(&data.Type.into_string()) {
@@ -561,7 +583,7 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
         } else {
             UserOrgStatus::Accepted as i32 // Automatically mark user as accepted if no email invites
         };
-        let user = match User::find_by_mail(&email, &conn) {
+        let user = match User::find_by_mail(&email, &conn).await {
             None => {
                 if !CONFIG.invitations_allowed() {
                     err!(format!("User does not exist: {}", email))
@@ -573,16 +595,16 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
 
                 if !CONFIG.mail_enabled() {
                     let invitation = Invitation::new(email.clone());
-                    invitation.save(&conn)?;
+                    invitation.save(&conn).await?;
                 }
 
                 let mut user = User::new(email.clone());
-                user.save(&conn)?;
+                user.save(&conn).await?;
                 user_org_status = UserOrgStatus::Invited as i32;
                 user
             }
             Some(user) => {
-                if UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn).is_some() {
+                if UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn).await.is_some() {
                     err!(format!("User already in organization: {}", email))
                 } else {
                     user
@@ -599,19 +621,20 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
         // If no accessAll, add the collections received
         if !access_all {
             for col in data.Collections.iter().flatten() {
-                match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn) {
+                match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn).await {
                     None => err!("Collection not found in Organization"),
                     Some(collection) => {
-                        CollectionUser::save(&user.uuid, &collection.uuid, col.ReadOnly, col.HidePasswords, &conn)?;
+                        CollectionUser::save(&user.uuid, &collection.uuid, col.ReadOnly, col.HidePasswords, &conn)
+                            .await?;
                     }
                 }
             }
         }
 
-        new_user.save(&conn)?;
+        new_user.save(&conn).await?;
 
         if CONFIG.mail_enabled() {
-            let org_name = match Organization::find_by_uuid(&org_id, &conn) {
+            let org_name = match Organization::find_by_uuid(&org_id, &conn).await {
                 Some(org) => org.name,
                 None => err!("Error looking up organization"),
             };
@@ -631,7 +654,7 @@ fn send_invite(org_id: String, data: JsonUpcase<InviteData>, headers: AdminHeade
 }
 
 #[post("/organizations/<org_id>/users/reinvite", data = "<data>")]
-fn bulk_reinvite_user(
+async fn bulk_reinvite_user(
     org_id: String,
     data: JsonUpcase<OrgBulkIds>,
     headers: AdminHeaders,
@@ -641,7 +664,7 @@ fn bulk_reinvite_user(
 
     let mut bulk_response = Vec::new();
     for org_user_id in data.Ids {
-        let err_msg = match _reinvite_user(&org_id, &org_user_id, &headers.user.email, &conn) {
+        let err_msg = match _reinvite_user(&org_id, &org_user_id, &headers.user.email, &conn).await {
             Ok(_) => String::from(""),
             Err(e) => format!("{:?}", e),
         };
@@ -663,11 +686,11 @@ fn bulk_reinvite_user(
 }
 
 #[post("/organizations/<org_id>/users/<user_org>/reinvite")]
-fn reinvite_user(org_id: String, user_org: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    _reinvite_user(&org_id, &user_org, &headers.user.email, &conn)
+async fn reinvite_user(org_id: String, user_org: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    _reinvite_user(&org_id, &user_org, &headers.user.email, &conn).await
 }
 
-fn _reinvite_user(org_id: &str, user_org: &str, invited_by_email: &str, conn: &DbConn) -> EmptyResult {
+async fn _reinvite_user(org_id: &str, user_org: &str, invited_by_email: &str, conn: &DbConn) -> EmptyResult {
     if !CONFIG.invitations_allowed() {
         err!("Invitations are not allowed.")
     }
@@ -676,7 +699,7 @@ fn _reinvite_user(org_id: &str, user_org: &str, invited_by_email: &str, conn: &D
         err!("SMTP is not configured.")
     }
 
-    let user_org = match UserOrganization::find_by_uuid(user_org, conn) {
+    let user_org = match UserOrganization::find_by_uuid(user_org, conn).await {
         Some(user_org) => user_org,
         None => err!("The user hasn't been invited to the organization."),
     };
@@ -685,12 +708,12 @@ fn _reinvite_user(org_id: &str, user_org: &str, invited_by_email: &str, conn: &D
         err!("The user is already accepted or confirmed to the organization")
     }
 
-    let user = match User::find_by_uuid(&user_org.user_uuid, conn) {
+    let user = match User::find_by_uuid(&user_org.user_uuid, conn).await {
         Some(user) => user,
         None => err!("User not found."),
     };
 
-    let org_name = match Organization::find_by_uuid(org_id, conn) {
+    let org_name = match Organization::find_by_uuid(org_id, conn).await {
         Some(org) => org.name,
         None => err!("Error looking up organization."),
     };
@@ -706,7 +729,7 @@ fn _reinvite_user(org_id: &str, user_org: &str, invited_by_email: &str, conn: &D
         )?;
     } else {
         let invitation = Invitation::new(user.email);
-        invitation.save(conn)?;
+        invitation.save(conn).await?;
     }
 
     Ok(())
@@ -719,18 +742,23 @@ struct AcceptData {
 }
 
 #[post("/organizations/<_org_id>/users/<_org_user_id>/accept", data = "<data>")]
-fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptData>, conn: DbConn) -> EmptyResult {
+async fn accept_invite(
+    _org_id: String,
+    _org_user_id: String,
+    data: JsonUpcase<AcceptData>,
+    conn: DbConn,
+) -> EmptyResult {
     // The web-vault passes org_id and org_user_id in the URL, but we are just reading them from the JWT instead
     let data: AcceptData = data.into_inner().data;
     let token = &data.Token;
     let claims = decode_invite(token)?;
 
-    match User::find_by_mail(&claims.email, &conn) {
+    match User::find_by_mail(&claims.email, &conn).await {
         Some(_) => {
-            Invitation::take(&claims.email, &conn);
+            Invitation::take(&claims.email, &conn).await;
 
             if let (Some(user_org), Some(org)) = (&claims.user_org_id, &claims.org_id) {
-                let mut user_org = match UserOrganization::find_by_uuid_and_org(user_org, org, &conn) {
+                let mut user_org = match UserOrganization::find_by_uuid_and_org(user_org, org, &conn).await {
                     Some(user_org) => user_org,
                     None => err!("Error accepting the invitation"),
                 };
@@ -739,11 +767,11 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
                     err!("User already accepted the invitation")
                 }
 
-                let user_twofactor_disabled = TwoFactor::find_by_user(&user_org.user_uuid, &conn).is_empty();
+                let user_twofactor_disabled = TwoFactor::find_by_user(&user_org.user_uuid, &conn).await.is_empty();
 
                 let policy = OrgPolicyType::TwoFactorAuthentication as i32;
                 let org_twofactor_policy_enabled =
-                    match OrgPolicy::find_by_org_and_type(&user_org.org_uuid, policy, &conn) {
+                    match OrgPolicy::find_by_org_and_type(&user_org.org_uuid, policy, &conn).await {
                         Some(p) => p.enabled,
                         None => false,
                     };
@@ -754,12 +782,15 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
 
                 // Enforce Single Organization Policy of organization user is trying to join
                 let single_org_policy_enabled =
-                    match OrgPolicy::find_by_org_and_type(&user_org.org_uuid, OrgPolicyType::SingleOrg as i32, &conn) {
+                    match OrgPolicy::find_by_org_and_type(&user_org.org_uuid, OrgPolicyType::SingleOrg as i32, &conn)
+                        .await
+                    {
                         Some(p) => p.enabled,
                         None => false,
                     };
                 if single_org_policy_enabled && user_org.atype < UserOrgType::Admin {
                     let is_member_of_another_org = UserOrganization::find_any_state_by_user(&user_org.user_uuid, &conn)
+                        .await
                         .into_iter()
                         .filter(|uo| uo.org_uuid != user_org.org_uuid)
                         .count()
@@ -770,14 +801,14 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
                 }
 
                 // Enforce Single Organization Policy of other organizations user is a member of
-                if OrgPolicy::is_applicable_to_user(&user_org.user_uuid, OrgPolicyType::SingleOrg, &conn) {
+                if OrgPolicy::is_applicable_to_user(&user_org.user_uuid, OrgPolicyType::SingleOrg, &conn).await {
                     err!(
                         "You cannot join this organization because you are a member of an organization which forbids it"
                     )
                 }
 
                 user_org.status = UserOrgStatus::Accepted as i32;
-                user_org.save(&conn)?;
+                user_org.save(&conn).await?;
             }
         }
         None => err!("Invited user not found"),
@@ -786,7 +817,7 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
     if CONFIG.mail_enabled() {
         let mut org_name = CONFIG.invitation_org_name();
         if let Some(org_id) = &claims.org_id {
-            org_name = match Organization::find_by_uuid(org_id, &conn) {
+            org_name = match Organization::find_by_uuid(org_id, &conn).await {
                 Some(org) => org.name,
                 None => err!("Organization not found."),
             };
@@ -804,7 +835,12 @@ fn accept_invite(_org_id: String, _org_user_id: String, data: JsonUpcase<AcceptD
 }
 
 #[post("/organizations/<org_id>/users/confirm", data = "<data>")]
-fn bulk_confirm_invite(org_id: String, data: JsonUpcase<Value>, headers: AdminHeaders, conn: DbConn) -> Json<Value> {
+async fn bulk_confirm_invite(
+    org_id: String,
+    data: JsonUpcase<Value>,
+    headers: AdminHeaders,
+    conn: DbConn,
+) -> Json<Value> {
     let data = data.into_inner().data;
 
     let mut bulk_response = Vec::new();
@@ -813,7 +849,7 @@ fn bulk_confirm_invite(org_id: String, data: JsonUpcase<Value>, headers: AdminHe
             for invite in keys {
                 let org_user_id = invite["Id"].as_str().unwrap_or_default();
                 let user_key = invite["Key"].as_str().unwrap_or_default();
-                let err_msg = match _confirm_invite(&org_id, org_user_id, user_key, &headers, &conn) {
+                let err_msg = match _confirm_invite(&org_id, org_user_id, user_key, &headers, &conn).await {
                     Ok(_) => String::from(""),
                     Err(e) => format!("{:?}", e),
                 };
@@ -838,7 +874,7 @@ fn bulk_confirm_invite(org_id: String, data: JsonUpcase<Value>, headers: AdminHe
 }
 
 #[post("/organizations/<org_id>/users/<org_user_id>/confirm", data = "<data>")]
-fn confirm_invite(
+async fn confirm_invite(
     org_id: String,
     org_user_id: String,
     data: JsonUpcase<Value>,
@@ -847,15 +883,21 @@ fn confirm_invite(
 ) -> EmptyResult {
     let data = data.into_inner().data;
     let user_key = data["Key"].as_str().unwrap_or_default();
-    _confirm_invite(&org_id, &org_user_id, user_key, &headers, &conn)
+    _confirm_invite(&org_id, &org_user_id, user_key, &headers, &conn).await
 }
 
-fn _confirm_invite(org_id: &str, org_user_id: &str, key: &str, headers: &AdminHeaders, conn: &DbConn) -> EmptyResult {
+async fn _confirm_invite(
+    org_id: &str,
+    org_user_id: &str,
+    key: &str,
+    headers: &AdminHeaders,
+    conn: &DbConn,
+) -> EmptyResult {
     if key.is_empty() || org_user_id.is_empty() {
         err!("Key or UserId is not set, unable to process request");
     }
 
-    let mut user_to_confirm = match UserOrganization::find_by_uuid_and_org(org_user_id, org_id, conn) {
+    let mut user_to_confirm = match UserOrganization::find_by_uuid_and_org(org_user_id, org_id, conn).await {
         Some(user) => user,
         None => err!("The specified user isn't a member of the organization"),
     };
@@ -872,28 +914,28 @@ fn _confirm_invite(org_id: &str, org_user_id: &str, key: &str, headers: &AdminHe
     user_to_confirm.akey = key.to_string();
 
     if CONFIG.mail_enabled() {
-        let org_name = match Organization::find_by_uuid(org_id, conn) {
+        let org_name = match Organization::find_by_uuid(org_id, conn).await {
             Some(org) => org.name,
             None => err!("Error looking up organization."),
         };
-        let address = match User::find_by_uuid(&user_to_confirm.user_uuid, conn) {
+        let address = match User::find_by_uuid(&user_to_confirm.user_uuid, conn).await {
             Some(user) => user.email,
             None => err!("Error looking up user."),
         };
         mail::send_invite_confirmed(&address, &org_name)?;
     }
 
-    user_to_confirm.save(conn)
+    user_to_confirm.save(conn).await
 }
 
 #[get("/organizations/<org_id>/users/<org_user_id>")]
-fn get_user(org_id: String, org_user_id: String, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
-    let user = match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn) {
+async fn get_user(org_id: String, org_user_id: String, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
+    let user = match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn).await {
         Some(user) => user,
         None => err!("The specified user isn't a member of the organization"),
     };
 
-    Ok(Json(user.to_json_details(&conn)))
+    Ok(Json(user.to_json_details(&conn).await))
 }
 
 #[derive(Deserialize)]
@@ -905,18 +947,18 @@ struct EditUserData {
 }
 
 #[put("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
-fn put_organization_user(
+async fn put_organization_user(
     org_id: String,
     org_user_id: String,
     data: JsonUpcase<EditUserData>,
     headers: AdminHeaders,
     conn: DbConn,
 ) -> EmptyResult {
-    edit_user(org_id, org_user_id, data, headers, conn)
+    edit_user(org_id, org_user_id, data, headers, conn).await
 }
 
 #[post("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
-fn edit_user(
+async fn edit_user(
     org_id: String,
     org_user_id: String,
     data: JsonUpcase<EditUserData>,
@@ -930,7 +972,7 @@ fn edit_user(
         None => err!("Invalid type"),
     };
 
-    let mut user_to_edit = match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn) {
+    let mut user_to_edit = match UserOrganization::find_by_uuid_and_org(&org_user_id, &org_id, &conn).await {
         Some(user) => user,
         None => err!("The specified user isn't member of the organization"),
     };
@@ -948,7 +990,7 @@ fn edit_user(
 
     if user_to_edit.atype == UserOrgType::Owner && new_type != UserOrgType::Owner {
         // Removing owner permmission, check that there are at least another owner
-        let num_owners = UserOrganization::find_by_org_and_type(&org_id, UserOrgType::Owner as i32, &conn).len();
+        let num_owners = UserOrganization::find_by_org_and_type(&org_id, UserOrgType::Owner as i32, &conn).await.len();
 
         if num_owners <= 1 {
             err!("Can't delete the last owner")
@@ -959,14 +1001,14 @@ fn edit_user(
     user_to_edit.atype = new_type as i32;
 
     // Delete all the odd collections
-    for c in CollectionUser::find_by_organization_and_user_uuid(&org_id, &user_to_edit.user_uuid, &conn) {
-        c.delete(&conn)?;
+    for c in CollectionUser::find_by_organization_and_user_uuid(&org_id, &user_to_edit.user_uuid, &conn).await {
+        c.delete(&conn).await?;
     }
 
     // If no accessAll, add the collections received
     if !data.AccessAll {
         for col in data.Collections.iter().flatten() {
-            match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn) {
+            match Collection::find_by_uuid_and_org(&col.Id, &org_id, &conn).await {
                 None => err!("Collection not found in Organization"),
                 Some(collection) => {
                     CollectionUser::save(
@@ -975,22 +1017,28 @@ fn edit_user(
                         col.ReadOnly,
                         col.HidePasswords,
                         &conn,
-                    )?;
+                    )
+                    .await?;
                 }
             }
         }
     }
 
-    user_to_edit.save(&conn)
+    user_to_edit.save(&conn).await
 }
 
 #[delete("/organizations/<org_id>/users", data = "<data>")]
-fn bulk_delete_user(org_id: String, data: JsonUpcase<OrgBulkIds>, headers: AdminHeaders, conn: DbConn) -> Json<Value> {
+async fn bulk_delete_user(
+    org_id: String,
+    data: JsonUpcase<OrgBulkIds>,
+    headers: AdminHeaders,
+    conn: DbConn,
+) -> Json<Value> {
     let data: OrgBulkIds = data.into_inner().data;
 
     let mut bulk_response = Vec::new();
     for org_user_id in data.Ids {
-        let err_msg = match _delete_user(&org_id, &org_user_id, &headers, &conn) {
+        let err_msg = match _delete_user(&org_id, &org_user_id, &headers, &conn).await {
             Ok(_) => String::from(""),
             Err(e) => format!("{:?}", e),
         };
@@ -1012,12 +1060,12 @@ fn bulk_delete_user(org_id: String, data: JsonUpcase<OrgBulkIds>, headers: Admin
 }
 
 #[delete("/organizations/<org_id>/users/<org_user_id>")]
-fn delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    _delete_user(&org_id, &org_user_id, &headers, &conn)
+async fn delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    _delete_user(&org_id, &org_user_id, &headers, &conn).await
 }
 
-fn _delete_user(org_id: &str, org_user_id: &str, headers: &AdminHeaders, conn: &DbConn) -> EmptyResult {
-    let user_to_delete = match UserOrganization::find_by_uuid_and_org(org_user_id, org_id, conn) {
+async fn _delete_user(org_id: &str, org_user_id: &str, headers: &AdminHeaders, conn: &DbConn) -> EmptyResult {
+    let user_to_delete = match UserOrganization::find_by_uuid_and_org(org_user_id, org_id, conn).await {
         Some(user) => user,
         None => err!("User to delete isn't member of the organization"),
     };
@@ -1028,23 +1076,28 @@ fn _delete_user(org_id: &str, org_user_id: &str, headers: &AdminHeaders, conn: &
 
     if user_to_delete.atype == UserOrgType::Owner {
         // Removing owner, check that there are at least another owner
-        let num_owners = UserOrganization::find_by_org_and_type(org_id, UserOrgType::Owner as i32, conn).len();
+        let num_owners = UserOrganization::find_by_org_and_type(org_id, UserOrgType::Owner as i32, conn).await.len();
 
         if num_owners <= 1 {
             err!("Can't delete the last owner")
         }
     }
 
-    user_to_delete.delete(conn)
+    user_to_delete.delete(conn).await
 }
 
 #[post("/organizations/<org_id>/users/<org_user_id>/delete")]
-fn post_delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
-    delete_user(org_id, org_user_id, headers, conn)
+async fn post_delete_user(org_id: String, org_user_id: String, headers: AdminHeaders, conn: DbConn) -> EmptyResult {
+    delete_user(org_id, org_user_id, headers, conn).await
 }
 
 #[post("/organizations/<org_id>/users/public-keys", data = "<data>")]
-fn bulk_public_keys(org_id: String, data: JsonUpcase<OrgBulkIds>, _headers: AdminHeaders, conn: DbConn) -> Json<Value> {
+async fn bulk_public_keys(
+    org_id: String,
+    data: JsonUpcase<OrgBulkIds>,
+    _headers: AdminHeaders,
+    conn: DbConn,
+) -> Json<Value> {
     let data: OrgBulkIds = data.into_inner().data;
 
     let mut bulk_response = Vec::new();
@@ -1052,8 +1105,8 @@ fn bulk_public_keys(org_id: String, data: JsonUpcase<OrgBulkIds>, _headers: Admi
     // If the user does not exists, just ignore it, and do not return any information regarding that UserOrg UUID.
     // The web-vault will then ignore that user for the folowing steps.
     for user_org_id in data.Ids {
-        match UserOrganization::find_by_uuid_and_org(&user_org_id, &org_id, &conn) {
-            Some(user_org) => match User::find_by_uuid(&user_org.user_uuid, &conn) {
+        match UserOrganization::find_by_uuid_and_org(&user_org_id, &org_id, &conn).await {
+            Some(user_org) => match User::find_by_uuid(&user_org.user_uuid, &conn).await {
                 Some(user) => bulk_response.push(json!(
                     {
                         "Object": "organizationUserPublicKeyResponseModel",
@@ -1096,29 +1149,27 @@ struct RelationsData {
 }
 
 #[post("/ciphers/import-organization?<query..>", data = "<data>")]
-fn post_org_import(
+async fn post_org_import(
     query: OrgIdData,
     data: JsonUpcase<ImportData>,
     headers: AdminHeaders,
     conn: DbConn,
-    nt: Notify,
+    nt: Notify<'_>,
 ) -> EmptyResult {
     let data: ImportData = data.into_inner().data;
     let org_id = query.organization_id;
 
-    // Read and create the collections
-    let collections: Vec<_> = data
-        .Collections
-        .into_iter()
-        .map(|coll| {
+    let collections = stream::iter(data.Collections)
+        .then(|coll| async {
             let collection = Collection::new(org_id.clone(), coll.Name);
-            if collection.save(&conn).is_err() {
+            if collection.save(&conn).await.is_err() {
                 err!("Failed to create Collection");
             }
 
             Ok(collection)
         })
-        .collect();
+        .collect::<Vec<_>>()
+        .await;
 
     // Read the relations between collections and ciphers
     let mut relations = Vec::new();
@@ -1128,17 +1179,16 @@ fn post_org_import(
 
     let headers: Headers = headers.into();
 
-    // Read and create the ciphers
-    let ciphers: Vec<_> = data
-        .Ciphers
-        .into_iter()
-        .map(|cipher_data| {
+    let ciphers = stream::iter(data.Ciphers)
+        .then(|cipher_data| async {
             let mut cipher = Cipher::new(cipher_data.Type, cipher_data.Name.clone());
             update_cipher_from_data(&mut cipher, cipher_data, &headers, false, &conn, &nt, UpdateType::CipherCreate)
+                .await
                 .ok();
             cipher
         })
-        .collect();
+        .collect::<Vec<Cipher>>()
+        .await;
 
     // Assign the collections
     for (cipher_index, coll_index) in relations {
@@ -1149,16 +1199,16 @@ fn post_org_import(
             Err(_) => err!("Failed to assign to collection"),
         };
 
-        CollectionCipher::save(cipher_id, coll_id, &conn)?;
+        CollectionCipher::save(cipher_id, coll_id, &conn).await?;
     }
 
     let mut user = headers.user;
-    user.update_revision(&conn)
+    user.update_revision(&conn).await
 }
 
 #[get("/organizations/<org_id>/policies")]
-fn list_policies(org_id: String, _headers: AdminHeaders, conn: DbConn) -> Json<Value> {
-    let policies = OrgPolicy::find_by_org(&org_id, &conn);
+async fn list_policies(org_id: String, _headers: AdminHeaders, conn: DbConn) -> Json<Value> {
+    let policies = OrgPolicy::find_by_org(&org_id, &conn).await;
     let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
 
     Json(json!({
@@ -1169,7 +1219,7 @@ fn list_policies(org_id: String, _headers: AdminHeaders, conn: DbConn) -> Json<V
 }
 
 #[get("/organizations/<org_id>/policies/token?<token>")]
-fn list_policies_token(org_id: String, token: String, conn: DbConn) -> JsonResult {
+async fn list_policies_token(org_id: String, token: String, conn: DbConn) -> JsonResult {
     let invite = crate::auth::decode_invite(&token)?;
 
     let invite_org_id = match invite.org_id {
@@ -1182,7 +1232,7 @@ fn list_policies_token(org_id: String, token: String, conn: DbConn) -> JsonResul
     }
 
     // TODO: We receive the invite token as ?token=<>, validate it contains the org id
-    let policies = OrgPolicy::find_by_org(&org_id, &conn);
+    let policies = OrgPolicy::find_by_org(&org_id, &conn).await;
     let policies_json: Vec<Value> = policies.iter().map(OrgPolicy::to_json).collect();
 
     Ok(Json(json!({
@@ -1193,13 +1243,13 @@ fn list_policies_token(org_id: String, token: String, conn: DbConn) -> JsonResul
 }
 
 #[get("/organizations/<org_id>/policies/<pol_type>")]
-fn get_policy(org_id: String, pol_type: i32, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
+async fn get_policy(org_id: String, pol_type: i32, _headers: AdminHeaders, conn: DbConn) -> JsonResult {
     let pol_type_enum = match OrgPolicyType::from_i32(pol_type) {
         Some(pt) => pt,
         None => err!("Invalid or unsupported policy type"),
     };
 
-    let policy = match OrgPolicy::find_by_org_and_type(&org_id, pol_type, &conn) {
+    let policy = match OrgPolicy::find_by_org_and_type(&org_id, pol_type, &conn).await {
         Some(p) => p,
         None => OrgPolicy::new(org_id, pol_type_enum, "{}".to_string()),
     };
@@ -1216,7 +1266,7 @@ struct PolicyData {
 }
 
 #[put("/organizations/<org_id>/policies/<pol_type>", data = "<data>")]
-fn put_policy(
+async fn put_policy(
     org_id: String,
     pol_type: i32,
     data: Json<PolicyData>,
@@ -1232,10 +1282,8 @@ fn put_policy(
 
     // If enabling the TwoFactorAuthentication policy, remove this org's members that do have 2FA
     if pol_type_enum == OrgPolicyType::TwoFactorAuthentication && data.enabled {
-        let org_members = UserOrganization::find_by_org(&org_id, &conn);
-
-        for member in org_members.into_iter() {
-            let user_twofactor_disabled = TwoFactor::find_by_user(&member.user_uuid, &conn).is_empty();
+        for member in UserOrganization::find_by_org(&org_id, &conn).await.into_iter() {
+            let user_twofactor_disabled = TwoFactor::find_by_user(&member.user_uuid, &conn).await.is_empty();
 
             // Policy only applies to non-Owner/non-Admin members who have accepted joining the org
             if user_twofactor_disabled
@@ -1243,24 +1291,23 @@ fn put_policy(
                 && member.status != UserOrgStatus::Invited as i32
             {
                 if CONFIG.mail_enabled() {
-                    let org = Organization::find_by_uuid(&member.org_uuid, &conn).unwrap();
-                    let user = User::find_by_uuid(&member.user_uuid, &conn).unwrap();
+                    let org = Organization::find_by_uuid(&member.org_uuid, &conn).await.unwrap();
+                    let user = User::find_by_uuid(&member.user_uuid, &conn).await.unwrap();
 
                     mail::send_2fa_removed_from_org(&user.email, &org.name)?;
                 }
-                member.delete(&conn)?;
+                member.delete(&conn).await?;
             }
         }
     }
 
     // If enabling the SingleOrg policy, remove this org's members that are members of other orgs
     if pol_type_enum == OrgPolicyType::SingleOrg && data.enabled {
-        let org_members = UserOrganization::find_by_org(&org_id, &conn);
-
-        for member in org_members.into_iter() {
+        for member in UserOrganization::find_by_org(&org_id, &conn).await.into_iter() {
             // Policy only applies to non-Owner/non-Admin members who have accepted joining the org
             if member.atype < UserOrgType::Admin && member.status != UserOrgStatus::Invited as i32 {
                 let is_member_of_another_org = UserOrganization::find_any_state_by_user(&member.user_uuid, &conn)
+                    .await
                     .into_iter()
                     // Other UserOrganization's where they have accepted being a member of
                     .filter(|uo| uo.uuid != member.uuid && uo.status != UserOrgStatus::Invited as i32)
@@ -1269,25 +1316,25 @@ fn put_policy(
 
                 if is_member_of_another_org {
                     if CONFIG.mail_enabled() {
-                        let org = Organization::find_by_uuid(&member.org_uuid, &conn).unwrap();
-                        let user = User::find_by_uuid(&member.user_uuid, &conn).unwrap();
+                        let org = Organization::find_by_uuid(&member.org_uuid, &conn).await.unwrap();
+                        let user = User::find_by_uuid(&member.user_uuid, &conn).await.unwrap();
 
                         mail::send_single_org_removed_from_org(&user.email, &org.name)?;
                     }
-                    member.delete(&conn)?;
+                    member.delete(&conn).await?;
                 }
             }
         }
     }
 
-    let mut policy = match OrgPolicy::find_by_org_and_type(&org_id, pol_type, &conn) {
+    let mut policy = match OrgPolicy::find_by_org_and_type(&org_id, pol_type, &conn).await {
         Some(p) => p,
         None => OrgPolicy::new(org_id, pol_type_enum, "{}".to_string()),
     };
 
     policy.enabled = data.enabled;
     policy.data = serde_json::to_string(&data.data)?;
-    policy.save(&conn)?;
+    policy.save(&conn).await?;
 
     Ok(Json(policy.to_json()))
 }
@@ -1360,7 +1407,7 @@ struct OrgImportData {
 }
 
 #[post("/organizations/<org_id>/import", data = "<data>")]
-fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data = data.into_inner().data;
 
     // TODO: Currently we aren't storing the externalId's anywhere, so we also don't have a way
@@ -1369,7 +1416,7 @@ fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, con
     // as opposed to upstream which only removes auto-imported users.
 
     // User needs to be admin or owner to use the Directry Connector
-    match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn) {
+    match UserOrganization::find_by_user_and_org(&headers.user.uuid, &org_id, &conn).await {
         Some(user_org) if user_org.atype >= UserOrgType::Admin => { /* Okay, nothing to do */ }
         Some(_) => err!("User has insufficient permissions to use Directory Connector"),
         None => err!("User not part of organization"),
@@ -1378,13 +1425,13 @@ fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, con
     for user_data in &data.Users {
         if user_data.Deleted {
             // If user is marked for deletion and it exists, delete it
-            if let Some(user_org) = UserOrganization::find_by_email_and_org(&user_data.Email, &org_id, &conn) {
-                user_org.delete(&conn)?;
+            if let Some(user_org) = UserOrganization::find_by_email_and_org(&user_data.Email, &org_id, &conn).await {
+                user_org.delete(&conn).await?;
             }
 
         // If user is not part of the organization, but it exists
-        } else if UserOrganization::find_by_email_and_org(&user_data.Email, &org_id, &conn).is_none() {
-            if let Some(user) = User::find_by_mail(&user_data.Email, &conn) {
+        } else if UserOrganization::find_by_email_and_org(&user_data.Email, &org_id, &conn).await.is_none() {
+            if let Some(user) = User::find_by_mail(&user_data.Email, &conn).await {
                 let user_org_status = if CONFIG.mail_enabled() {
                     UserOrgStatus::Invited as i32
                 } else {
@@ -1396,10 +1443,10 @@ fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, con
                 new_org_user.atype = UserOrgType::User as i32;
                 new_org_user.status = user_org_status;
 
-                new_org_user.save(&conn)?;
+                new_org_user.save(&conn).await?;
 
                 if CONFIG.mail_enabled() {
-                    let org_name = match Organization::find_by_uuid(&org_id, &conn) {
+                    let org_name = match Organization::find_by_uuid(&org_id, &conn).await {
                         Some(org) => org.name,
                         None => err!("Error looking up organization"),
                     };
@@ -1419,10 +1466,10 @@ fn import(org_id: String, data: JsonUpcase<OrgImportData>, headers: Headers, con
 
     // If this flag is enabled, any user that isn't provided in the Users list will be removed (by default they will be kept unless they have Deleted == true)
     if data.OverwriteExisting {
-        for user_org in UserOrganization::find_by_org_and_type(&org_id, UserOrgType::User as i32, &conn) {
-            if let Some(user_email) = User::find_by_uuid(&user_org.user_uuid, &conn).map(|u| u.email) {
+        for user_org in UserOrganization::find_by_org_and_type(&org_id, UserOrgType::User as i32, &conn).await {
+            if let Some(user_email) = User::find_by_uuid(&user_org.user_uuid, &conn).await.map(|u| u.email) {
                 if !data.Users.iter().any(|u| u.Email == user_email) {
-                    user_org.delete(&conn)?;
+                    user_org.delete(&conn).await?;
                 }
             }
         }

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -1,9 +1,10 @@
-use std::{io::Read, path::Path};
+use std::path::Path;
 
 use chrono::{DateTime, Duration, Utc};
-use multipart::server::{save::SavedData, Multipart, SaveResult};
-use rocket::{http::ContentType, response::NamedFile, Data};
-use rocket_contrib::json::Json;
+use rocket::form::Form;
+use rocket::fs::NamedFile;
+use rocket::fs::TempFile;
+use rocket::serde::json::Json;
 use serde_json::Value;
 
 use crate::{
@@ -31,9 +32,9 @@ pub fn routes() -> Vec<rocket::Route> {
     ]
 }
 
-pub fn purge_sends(pool: DbPool) {
+pub async fn purge_sends(pool: DbPool) {
     debug!("Purging sends");
-    if let Ok(conn) = pool.get() {
+    if let Ok(conn) = pool.get().await {
         Send::purge(&conn);
     } else {
         error!("Failed to get DB connection while purging sends")
@@ -177,25 +178,23 @@ fn post_send(data: JsonUpcase<SendData>, headers: Headers, conn: DbConn, nt: Not
     Ok(Json(send.to_json()))
 }
 
+#[derive(FromForm)]
+struct UploadData<'f> {
+    model: Json<crate::util::UpCase<SendData>>,
+    data: TempFile<'f>,
+}
+
 #[post("/sends/file", format = "multipart/form-data", data = "<data>")]
-fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn: DbConn, nt: Notify) -> JsonResult {
+async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
     enforce_disable_send_policy(&headers, &conn)?;
 
-    let boundary = content_type.params().next().expect("No boundary provided").1;
+    let UploadData {
+        model,
+        mut data,
+    } = data.into_inner();
+    let model = model.into_inner().data;
 
-    let mut mpart = Multipart::with_body(data.open(), boundary);
-
-    // First entry is the SendData JSON
-    let mut model_entry = match mpart.read_entry()? {
-        Some(e) if &*e.headers.name == "model" => e,
-        Some(_) => err!("Invalid entry name"),
-        None => err!("No model entry present"),
-    };
-
-    let mut buf = String::new();
-    model_entry.data.read_to_string(&mut buf)?;
-    let data = serde_json::from_str::<crate::util::UpCase<SendData>>(&buf)?;
-    enforce_disable_hide_email_policy(&data.data, &headers, &conn)?;
+    enforce_disable_hide_email_policy(&model, &headers, &conn)?;
 
     // Get the file length and add an extra 5% to avoid issues
     const SIZE_525_MB: u64 = 550_502_400;
@@ -212,45 +211,27 @@ fn post_send_file(data: Data, content_type: &ContentType, headers: Headers, conn
         None => SIZE_525_MB,
     };
 
-    // Create the Send
-    let mut send = create_send(data.data, headers.user.uuid)?;
-    let file_id = crate::crypto::generate_send_id();
-
+    let mut send = create_send(model, headers.user.uuid)?;
     if send.atype != SendType::File as i32 {
         err!("Send content is not a file");
     }
 
-    let file_path = Path::new(&CONFIG.sends_folder()).join(&send.uuid).join(&file_id);
+    let size = data.len();
+    if size > size_limit {
+        err!("Attachment storage limit exceeded with this file");
+    }
 
-    // Read the data entry and save the file
-    let mut data_entry = match mpart.read_entry()? {
-        Some(e) if &*e.headers.name == "data" => e,
-        Some(_) => err!("Invalid entry name"),
-        None => err!("No model entry present"),
-    };
+    let file_id = crate::crypto::generate_send_id();
+    let folder_path = tokio::fs::canonicalize(&CONFIG.sends_folder()).await?.join(&send.uuid);
+    let file_path = folder_path.join(&file_id);
+    tokio::fs::create_dir_all(&folder_path).await?;
+    data.persist_to(&file_path).await?;
 
-    let size = match data_entry.data.save().memory_threshold(0).size_limit(size_limit).with_path(&file_path) {
-        SaveResult::Full(SavedData::File(_, size)) => size as i32,
-        SaveResult::Full(other) => {
-            std::fs::remove_file(&file_path).ok();
-            err!(format!("Attachment is not a file: {:?}", other));
-        }
-        SaveResult::Partial(_, reason) => {
-            std::fs::remove_file(&file_path).ok();
-            err!(format!("Attachment storage limit exceeded with this file: {:?}", reason));
-        }
-        SaveResult::Error(e) => {
-            std::fs::remove_file(&file_path).ok();
-            err!(format!("Error: {:?}", e));
-        }
-    };
-
-    // Set ID and sizes
     let mut data_value: Value = serde_json::from_str(&send.data)?;
     if let Some(o) = data_value.as_object_mut() {
         o.insert(String::from("Id"), Value::String(file_id));
         o.insert(String::from("Size"), Value::Number(size.into()));
-        o.insert(String::from("SizeName"), Value::String(crate::util::get_display_size(size)));
+        o.insert(String::from("SizeName"), Value::String(crate::util::get_display_size(size as i32)));
     }
     send.data = serde_json::to_string(&data_value)?;
 
@@ -367,10 +348,10 @@ fn post_access_file(
 }
 
 #[get("/sends/<send_id>/<file_id>?<t>")]
-fn download_send(send_id: SafeString, file_id: SafeString, t: String) -> Option<NamedFile> {
+async fn download_send(send_id: SafeString, file_id: SafeString, t: String) -> Option<NamedFile> {
     if let Ok(claims) = crate::auth::decode_send(&t) {
         if claims.sub == format!("{}/{}", send_id, file_id) {
-            return NamedFile::open(Path::new(&CONFIG.sends_folder()).join(send_id).join(file_id)).ok();
+            return NamedFile::open(Path::new(&CONFIG.sends_folder()).join(send_id).join(file_id)).await.ok();
         }
     }
     None

--- a/src/api/core/two_factor/authenticator.rs
+++ b/src/api/core/two_factor/authenticator.rs
@@ -21,7 +21,7 @@ pub fn routes() -> Vec<Route> {
 }
 
 #[post("/two-factor/get-authenticator", data = "<data>")]
-fn generate_authenticator(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn generate_authenticator(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: PasswordData = data.into_inner().data;
     let user = headers.user;
 
@@ -30,7 +30,7 @@ fn generate_authenticator(data: JsonUpcase<PasswordData>, headers: Headers, conn
     }
 
     let type_ = TwoFactorType::Authenticator as i32;
-    let twofactor = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn);
+    let twofactor = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).await;
 
     let (enabled, key) = match twofactor {
         Some(tf) => (true, tf.data),
@@ -53,7 +53,7 @@ struct EnableAuthenticatorData {
 }
 
 #[post("/two-factor/authenticator", data = "<data>")]
-fn activate_authenticator(
+async fn activate_authenticator(
     data: JsonUpcase<EnableAuthenticatorData>,
     headers: Headers,
     ip: ClientIp,
@@ -81,9 +81,9 @@ fn activate_authenticator(
     }
 
     // Validate the token provided with the key, and save new twofactor
-    validate_totp_code(&user.uuid, &token, &key.to_uppercase(), &ip, &conn)?;
+    validate_totp_code(&user.uuid, &token, &key.to_uppercase(), &ip, &conn).await?;
 
-    _generate_recover_code(&mut user, &conn);
+    _generate_recover_code(&mut user, &conn).await;
 
     Ok(Json(json!({
         "Enabled": true,
@@ -93,16 +93,16 @@ fn activate_authenticator(
 }
 
 #[put("/two-factor/authenticator", data = "<data>")]
-fn activate_authenticator_put(
+async fn activate_authenticator_put(
     data: JsonUpcase<EnableAuthenticatorData>,
     headers: Headers,
     ip: ClientIp,
     conn: DbConn,
 ) -> JsonResult {
-    activate_authenticator(data, headers, ip, conn)
+    activate_authenticator(data, headers, ip, conn).await
 }
 
-pub fn validate_totp_code_str(
+pub async fn validate_totp_code_str(
     user_uuid: &str,
     totp_code: &str,
     secret: &str,
@@ -113,10 +113,16 @@ pub fn validate_totp_code_str(
         err!("TOTP code is not a number");
     }
 
-    validate_totp_code(user_uuid, totp_code, secret, ip, conn)
+    validate_totp_code(user_uuid, totp_code, secret, ip, conn).await
 }
 
-pub fn validate_totp_code(user_uuid: &str, totp_code: &str, secret: &str, ip: &ClientIp, conn: &DbConn) -> EmptyResult {
+pub async fn validate_totp_code(
+    user_uuid: &str,
+    totp_code: &str,
+    secret: &str,
+    ip: &ClientIp,
+    conn: &DbConn,
+) -> EmptyResult {
     use totp_lite::{totp_custom, Sha1};
 
     let decoded_secret = match BASE32.decode(secret.as_bytes()) {
@@ -124,10 +130,11 @@ pub fn validate_totp_code(user_uuid: &str, totp_code: &str, secret: &str, ip: &C
         Err(_) => err!("Invalid TOTP secret"),
     };
 
-    let mut twofactor = match TwoFactor::find_by_user_and_type(user_uuid, TwoFactorType::Authenticator as i32, conn) {
-        Some(tf) => tf,
-        _ => TwoFactor::new(user_uuid.to_string(), TwoFactorType::Authenticator, secret.to_string()),
-    };
+    let mut twofactor =
+        match TwoFactor::find_by_user_and_type(user_uuid, TwoFactorType::Authenticator as i32, conn).await {
+            Some(tf) => tf,
+            _ => TwoFactor::new(user_uuid.to_string(), TwoFactorType::Authenticator, secret.to_string()),
+        };
 
     // The amount of steps back and forward in time
     // Also check if we need to disable time drifted TOTP codes.
@@ -156,7 +163,7 @@ pub fn validate_totp_code(user_uuid: &str, totp_code: &str, secret: &str, ip: &C
             // Save the last used time step so only totp time steps higher then this one are allowed.
             // This will also save a newly created twofactor if the code is correct.
             twofactor.last_used = time_step as i32;
-            twofactor.save(conn)?;
+            twofactor.save(conn).await?;
             return Ok(());
         } else if generated == totp_code && time_step <= twofactor.last_used as i64 {
             warn!("This TOTP or a TOTP code within {} steps back or forward has already been used!", steps);

--- a/src/api/core/two_factor/authenticator.rs
+++ b/src/api/core/two_factor/authenticator.rs
@@ -1,6 +1,6 @@
 use data_encoding::BASE32;
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 
 use crate::{
     api::{

--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use data_encoding::BASE64;
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 
 use crate::{
     api::{core::two_factor::_generate_recover_code, ApiResult, EmptyResult, JsonResult, JsonUpcase, PasswordData},
@@ -152,7 +152,7 @@ fn check_duo_fields_custom(data: &EnableDuoData) -> bool {
 }
 
 #[post("/two-factor/duo", data = "<data>")]
-fn activate_duo(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn activate_duo(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: EnableDuoData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -163,7 +163,7 @@ fn activate_duo(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn)
     let (data, data_str) = if check_duo_fields_custom(&data) {
         let data_req: DuoData = data.into();
         let data_str = serde_json::to_string(&data_req)?;
-        duo_api_request("GET", "/auth/v2/check", "", &data_req).map_res("Failed to validate Duo credentials")?;
+        duo_api_request("GET", "/auth/v2/check", "", &data_req).await.map_res("Failed to validate Duo credentials")?;
         (data_req.obscure(), data_str)
     } else {
         (DuoData::secret(), String::new())
@@ -185,11 +185,11 @@ fn activate_duo(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn)
 }
 
 #[put("/two-factor/duo", data = "<data>")]
-fn activate_duo_put(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn) -> JsonResult {
-    activate_duo(data, headers, conn)
+async fn activate_duo_put(data: JsonUpcase<EnableDuoData>, headers: Headers, conn: DbConn) -> JsonResult {
+    activate_duo(data, headers, conn).await
 }
 
-fn duo_api_request(method: &str, path: &str, params: &str, data: &DuoData) -> EmptyResult {
+async fn duo_api_request(method: &str, path: &str, params: &str, data: &DuoData) -> EmptyResult {
     use reqwest::{header, Method};
     use std::str::FromStr;
 
@@ -209,7 +209,8 @@ fn duo_api_request(method: &str, path: &str, params: &str, data: &DuoData) -> Em
         .basic_auth(username, Some(password))
         .header(header::USER_AGENT, "vaultwarden:Duo/1.0 (Rust)")
         .header(header::DATE, date)
-        .send()?
+        .send()
+        .await?
         .error_for_status()?;
 
     Ok(())

--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, NaiveDateTime, Utc};
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 
 use crate::{
     api::{core::two_factor::_generate_recover_code, EmptyResult, JsonResult, JsonUpcase, PasswordData},

--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -28,13 +28,13 @@ struct SendEmailLoginData {
 /// User is trying to login and wants to use email 2FA.
 /// Does not require Bearer token
 #[post("/two-factor/send-email-login", data = "<data>")] // JsonResult
-fn send_email_login(data: JsonUpcase<SendEmailLoginData>, conn: DbConn) -> EmptyResult {
+async fn send_email_login(data: JsonUpcase<SendEmailLoginData>, conn: DbConn) -> EmptyResult {
     let data: SendEmailLoginData = data.into_inner().data;
 
     use crate::db::models::User;
 
     // Get the user
-    let user = match User::find_by_mail(&data.Email, &conn) {
+    let user = match User::find_by_mail(&data.Email, &conn).await {
         Some(user) => user,
         None => err!("Username or password is incorrect. Try again."),
     };
@@ -48,22 +48,23 @@ fn send_email_login(data: JsonUpcase<SendEmailLoginData>, conn: DbConn) -> Empty
         err!("Email 2FA is disabled")
     }
 
-    send_token(&user.uuid, &conn)?;
+    send_token(&user.uuid, &conn).await?;
 
     Ok(())
 }
 
 /// Generate the token, save the data for later verification and send email to user
-pub fn send_token(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+pub async fn send_token(user_uuid: &str, conn: &DbConn) -> EmptyResult {
     let type_ = TwoFactorType::Email as i32;
-    let mut twofactor = TwoFactor::find_by_user_and_type(user_uuid, type_, conn).map_res("Two factor not found")?;
+    let mut twofactor =
+        TwoFactor::find_by_user_and_type(user_uuid, type_, conn).await.map_res("Two factor not found")?;
 
     let generated_token = crypto::generate_email_token(CONFIG.email_token_size());
 
     let mut twofactor_data = EmailTokenData::from_json(&twofactor.data)?;
     twofactor_data.set_token(generated_token);
     twofactor.data = twofactor_data.to_json();
-    twofactor.save(conn)?;
+    twofactor.save(conn).await?;
 
     mail::send_token(&twofactor_data.email, &twofactor_data.last_token.map_res("Token is empty")?)?;
 
@@ -72,7 +73,7 @@ pub fn send_token(user_uuid: &str, conn: &DbConn) -> EmptyResult {
 
 /// When user clicks on Manage email 2FA show the user the related information
 #[post("/two-factor/get-email", data = "<data>")]
-fn get_email(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn get_email(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: PasswordData = data.into_inner().data;
     let user = headers.user;
 
@@ -80,13 +81,14 @@ fn get_email(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> 
         err!("Invalid password");
     }
 
-    let (enabled, mfa_email) = match TwoFactor::find_by_user_and_type(&user.uuid, TwoFactorType::Email as i32, &conn) {
-        Some(x) => {
-            let twofactor_data = EmailTokenData::from_json(&x.data)?;
-            (true, json!(twofactor_data.email))
-        }
-        _ => (false, json!(null)),
-    };
+    let (enabled, mfa_email) =
+        match TwoFactor::find_by_user_and_type(&user.uuid, TwoFactorType::Email as i32, &conn).await {
+            Some(x) => {
+                let twofactor_data = EmailTokenData::from_json(&x.data)?;
+                (true, json!(twofactor_data.email))
+            }
+            _ => (false, json!(null)),
+        };
 
     Ok(Json(json!({
         "Email": mfa_email,
@@ -105,7 +107,7 @@ struct SendEmailData {
 
 /// Send a verification email to the specified email address to check whether it exists/belongs to user.
 #[post("/two-factor/send-email", data = "<data>")]
-fn send_email(data: JsonUpcase<SendEmailData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn send_email(data: JsonUpcase<SendEmailData>, headers: Headers, conn: DbConn) -> EmptyResult {
     let data: SendEmailData = data.into_inner().data;
     let user = headers.user;
 
@@ -119,8 +121,8 @@ fn send_email(data: JsonUpcase<SendEmailData>, headers: Headers, conn: DbConn) -
 
     let type_ = TwoFactorType::Email as i32;
 
-    if let Some(tf) = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn) {
-        tf.delete(&conn)?;
+    if let Some(tf) = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).await {
+        tf.delete(&conn).await?;
     }
 
     let generated_token = crypto::generate_email_token(CONFIG.email_token_size());
@@ -128,7 +130,7 @@ fn send_email(data: JsonUpcase<SendEmailData>, headers: Headers, conn: DbConn) -
 
     // Uses EmailVerificationChallenge as type to show that it's not verified yet.
     let twofactor = TwoFactor::new(user.uuid, TwoFactorType::EmailVerificationChallenge, twofactor_data.to_json());
-    twofactor.save(&conn)?;
+    twofactor.save(&conn).await?;
 
     mail::send_token(&twofactor_data.email, &twofactor_data.last_token.map_res("Token is empty")?)?;
 
@@ -145,7 +147,7 @@ struct EmailData {
 
 /// Verify email belongs to user and can be used for 2FA email codes.
 #[put("/two-factor/email", data = "<data>")]
-fn email(data: JsonUpcase<EmailData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn email(data: JsonUpcase<EmailData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: EmailData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -154,7 +156,8 @@ fn email(data: JsonUpcase<EmailData>, headers: Headers, conn: DbConn) -> JsonRes
     }
 
     let type_ = TwoFactorType::EmailVerificationChallenge as i32;
-    let mut twofactor = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).map_res("Two factor not found")?;
+    let mut twofactor =
+        TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).await.map_res("Two factor not found")?;
 
     let mut email_data = EmailTokenData::from_json(&twofactor.data)?;
 
@@ -170,9 +173,9 @@ fn email(data: JsonUpcase<EmailData>, headers: Headers, conn: DbConn) -> JsonRes
     email_data.reset_token();
     twofactor.atype = TwoFactorType::Email as i32;
     twofactor.data = email_data.to_json();
-    twofactor.save(&conn)?;
+    twofactor.save(&conn).await?;
 
-    _generate_recover_code(&mut user, &conn);
+    _generate_recover_code(&mut user, &conn).await;
 
     Ok(Json(json!({
         "Email": email_data.email,
@@ -182,9 +185,10 @@ fn email(data: JsonUpcase<EmailData>, headers: Headers, conn: DbConn) -> JsonRes
 }
 
 /// Validate the email code when used as TwoFactor token mechanism
-pub fn validate_email_code_str(user_uuid: &str, token: &str, data: &str, conn: &DbConn) -> EmptyResult {
+pub async fn validate_email_code_str(user_uuid: &str, token: &str, data: &str, conn: &DbConn) -> EmptyResult {
     let mut email_data = EmailTokenData::from_json(data)?;
     let mut twofactor = TwoFactor::find_by_user_and_type(user_uuid, TwoFactorType::Email as i32, conn)
+        .await
         .map_res("Two factor not found")?;
     let issued_token = match &email_data.last_token {
         Some(t) => t,
@@ -197,14 +201,14 @@ pub fn validate_email_code_str(user_uuid: &str, token: &str, data: &str, conn: &
             email_data.reset_token();
         }
         twofactor.data = email_data.to_json();
-        twofactor.save(conn)?;
+        twofactor.save(conn).await?;
 
         err!("Token is invalid")
     }
 
     email_data.reset_token();
     twofactor.data = email_data.to_json();
-    twofactor.save(conn)?;
+    twofactor.save(conn).await?;
 
     let date = NaiveDateTime::from_timestamp(email_data.token_sent, 0);
     let max_time = CONFIG.email_expiration_time() as i64;

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -1,7 +1,7 @@
 use chrono::{Duration, Utc};
 use data_encoding::BASE32;
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 
 use crate::{
@@ -158,14 +158,14 @@ fn disable_twofactor_put(data: JsonUpcase<DisableTwoFactorData>, headers: Header
     disable_twofactor(data, headers, conn)
 }
 
-pub fn send_incomplete_2fa_notifications(pool: DbPool) {
+pub async fn send_incomplete_2fa_notifications(pool: DbPool) {
     debug!("Sending notifications for incomplete 2FA logins");
 
     if CONFIG.incomplete_2fa_time_limit() <= 0 || !CONFIG.mail_enabled() {
         return;
     }
 
-    let conn = match pool.get() {
+    let conn = match pool.get().await {
         Ok(conn) => conn,
         _ => {
             error!("Failed to get DB connection in send_incomplete_2fa_notifications()");

--- a/src/api/core/two_factor/u2f.rs
+++ b/src/api/core/two_factor/u2f.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 use u2f::{
     messages::{RegisterResponse, SignResponse, U2fSignRequest},

--- a/src/api/core/two_factor/webauthn.rs
+++ b/src/api/core/two_factor/webauthn.rs
@@ -80,7 +80,7 @@ impl WebauthnRegistration {
 }
 
 #[post("/two-factor/get-webauthn", data = "<data>")]
-fn get_webauthn(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn get_webauthn(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
     if !CONFIG.domain_set() {
         err!("`DOMAIN` environment variable is not set. Webauthn disabled")
     }
@@ -89,7 +89,7 @@ fn get_webauthn(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) 
         err!("Invalid password");
     }
 
-    let (enabled, registrations) = get_webauthn_registrations(&headers.user.uuid, &conn)?;
+    let (enabled, registrations) = get_webauthn_registrations(&headers.user.uuid, &conn).await?;
     let registrations_json: Vec<Value> = registrations.iter().map(WebauthnRegistration::to_json).collect();
 
     Ok(Json(json!({
@@ -100,12 +100,13 @@ fn get_webauthn(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) 
 }
 
 #[post("/two-factor/get-webauthn-challenge", data = "<data>")]
-fn generate_webauthn_challenge(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn generate_webauthn_challenge(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
     if !headers.user.check_valid_password(&data.data.MasterPasswordHash) {
         err!("Invalid password");
     }
 
-    let registrations = get_webauthn_registrations(&headers.user.uuid, &conn)?
+    let registrations = get_webauthn_registrations(&headers.user.uuid, &conn)
+        .await?
         .1
         .into_iter()
         .map(|r| r.credential.cred_id) // We return the credentialIds to the clients to avoid double registering
@@ -121,7 +122,7 @@ fn generate_webauthn_challenge(data: JsonUpcase<PasswordData>, headers: Headers,
     )?;
 
     let type_ = TwoFactorType::WebauthnRegisterChallenge;
-    TwoFactor::new(headers.user.uuid, type_, serde_json::to_string(&state)?).save(&conn)?;
+    TwoFactor::new(headers.user.uuid, type_, serde_json::to_string(&state)?).save(&conn).await?;
 
     let mut challenge_value = serde_json::to_value(challenge.public_key)?;
     challenge_value["status"] = "ok".into();
@@ -218,7 +219,7 @@ impl From<PublicKeyCredentialCopy> for PublicKeyCredential {
 }
 
 #[post("/two-factor/webauthn", data = "<data>")]
-fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: EnableWebauthnData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -228,10 +229,10 @@ fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, con
 
     // Retrieve and delete the saved challenge state
     let type_ = TwoFactorType::WebauthnRegisterChallenge as i32;
-    let state = match TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn) {
+    let state = match TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).await {
         Some(tf) => {
             let state: RegistrationState = serde_json::from_str(&tf.data)?;
-            tf.delete(&conn)?;
+            tf.delete(&conn).await?;
             state
         }
         None => err!("Can't recover challenge"),
@@ -241,7 +242,7 @@ fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, con
     let (credential, _data) =
         WebauthnConfig::load().register_credential(&data.DeviceResponse.into(), &state, |_| Ok(false))?;
 
-    let mut registrations: Vec<_> = get_webauthn_registrations(&user.uuid, &conn)?.1;
+    let mut registrations: Vec<_> = get_webauthn_registrations(&user.uuid, &conn).await?.1;
     // TODO: Check for repeated ID's
     registrations.push(WebauthnRegistration {
         id: data.Id.into_i32()?,
@@ -252,8 +253,10 @@ fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, con
     });
 
     // Save the registrations and return them
-    TwoFactor::new(user.uuid.clone(), TwoFactorType::Webauthn, serde_json::to_string(&registrations)?).save(&conn)?;
-    _generate_recover_code(&mut user, &conn);
+    TwoFactor::new(user.uuid.clone(), TwoFactorType::Webauthn, serde_json::to_string(&registrations)?)
+        .save(&conn)
+        .await?;
+    _generate_recover_code(&mut user, &conn).await;
 
     let keys_json: Vec<Value> = registrations.iter().map(WebauthnRegistration::to_json).collect();
     Ok(Json(json!({
@@ -264,8 +267,8 @@ fn activate_webauthn(data: JsonUpcase<EnableWebauthnData>, headers: Headers, con
 }
 
 #[put("/two-factor/webauthn", data = "<data>")]
-fn activate_webauthn_put(data: JsonUpcase<EnableWebauthnData>, headers: Headers, conn: DbConn) -> JsonResult {
-    activate_webauthn(data, headers, conn)
+async fn activate_webauthn_put(data: JsonUpcase<EnableWebauthnData>, headers: Headers, conn: DbConn) -> JsonResult {
+    activate_webauthn(data, headers, conn).await
 }
 
 #[derive(Deserialize, Debug)]
@@ -276,13 +279,14 @@ struct DeleteU2FData {
 }
 
 #[delete("/two-factor/webauthn", data = "<data>")]
-fn delete_webauthn(data: JsonUpcase<DeleteU2FData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn delete_webauthn(data: JsonUpcase<DeleteU2FData>, headers: Headers, conn: DbConn) -> JsonResult {
     let id = data.data.Id.into_i32()?;
     if !headers.user.check_valid_password(&data.data.MasterPasswordHash) {
         err!("Invalid password");
     }
 
-    let mut tf = match TwoFactor::find_by_user_and_type(&headers.user.uuid, TwoFactorType::Webauthn as i32, &conn) {
+    let mut tf = match TwoFactor::find_by_user_and_type(&headers.user.uuid, TwoFactorType::Webauthn as i32, &conn).await
+    {
         Some(tf) => tf,
         None => err!("Webauthn data not found!"),
     };
@@ -296,11 +300,12 @@ fn delete_webauthn(data: JsonUpcase<DeleteU2FData>, headers: Headers, conn: DbCo
 
     let removed_item = data.remove(item_pos);
     tf.data = serde_json::to_string(&data)?;
-    tf.save(&conn)?;
+    tf.save(&conn).await?;
     drop(tf);
 
     // If entry is migrated from u2f, delete the u2f entry as well
-    if let Some(mut u2f) = TwoFactor::find_by_user_and_type(&headers.user.uuid, TwoFactorType::U2f as i32, &conn) {
+    if let Some(mut u2f) = TwoFactor::find_by_user_and_type(&headers.user.uuid, TwoFactorType::U2f as i32, &conn).await
+    {
         use crate::api::core::two_factor::u2f::U2FRegistration;
         let mut data: Vec<U2FRegistration> = match serde_json::from_str(&u2f.data) {
             Ok(d) => d,
@@ -311,7 +316,7 @@ fn delete_webauthn(data: JsonUpcase<DeleteU2FData>, headers: Headers, conn: DbCo
         let new_data_str = serde_json::to_string(&data)?;
 
         u2f.data = new_data_str;
-        u2f.save(&conn)?;
+        u2f.save(&conn).await?;
     }
 
     let keys_json: Vec<Value> = data.iter().map(WebauthnRegistration::to_json).collect();
@@ -323,18 +328,21 @@ fn delete_webauthn(data: JsonUpcase<DeleteU2FData>, headers: Headers, conn: DbCo
     })))
 }
 
-pub fn get_webauthn_registrations(user_uuid: &str, conn: &DbConn) -> Result<(bool, Vec<WebauthnRegistration>), Error> {
+pub async fn get_webauthn_registrations(
+    user_uuid: &str,
+    conn: &DbConn,
+) -> Result<(bool, Vec<WebauthnRegistration>), Error> {
     let type_ = TwoFactorType::Webauthn as i32;
-    match TwoFactor::find_by_user_and_type(user_uuid, type_, conn) {
+    match TwoFactor::find_by_user_and_type(user_uuid, type_, conn).await {
         Some(tf) => Ok((tf.enabled, serde_json::from_str(&tf.data)?)),
         None => Ok((false, Vec::new())), // If no data, return empty list
     }
 }
 
-pub fn generate_webauthn_login(user_uuid: &str, conn: &DbConn) -> JsonResult {
+pub async fn generate_webauthn_login(user_uuid: &str, conn: &DbConn) -> JsonResult {
     // Load saved credentials
     let creds: Vec<Credential> =
-        get_webauthn_registrations(user_uuid, conn)?.1.into_iter().map(|r| r.credential).collect();
+        get_webauthn_registrations(user_uuid, conn).await?.1.into_iter().map(|r| r.credential).collect();
 
     if creds.is_empty() {
         err!("No Webauthn devices registered")
@@ -346,18 +354,19 @@ pub fn generate_webauthn_login(user_uuid: &str, conn: &DbConn) -> JsonResult {
 
     // Save the challenge state for later validation
     TwoFactor::new(user_uuid.into(), TwoFactorType::WebauthnLoginChallenge, serde_json::to_string(&state)?)
-        .save(conn)?;
+        .save(conn)
+        .await?;
 
     // Return challenge to the clients
     Ok(Json(serde_json::to_value(response.public_key)?))
 }
 
-pub fn validate_webauthn_login(user_uuid: &str, response: &str, conn: &DbConn) -> EmptyResult {
+pub async fn validate_webauthn_login(user_uuid: &str, response: &str, conn: &DbConn) -> EmptyResult {
     let type_ = TwoFactorType::WebauthnLoginChallenge as i32;
-    let state = match TwoFactor::find_by_user_and_type(user_uuid, type_, conn) {
+    let state = match TwoFactor::find_by_user_and_type(user_uuid, type_, conn).await {
         Some(tf) => {
             let state: AuthenticationState = serde_json::from_str(&tf.data)?;
-            tf.delete(conn)?;
+            tf.delete(conn).await?;
             state
         }
         None => err!("Can't recover login challenge"),
@@ -366,7 +375,7 @@ pub fn validate_webauthn_login(user_uuid: &str, response: &str, conn: &DbConn) -
     let rsp: crate::util::UpCase<PublicKeyCredentialCopy> = serde_json::from_str(response)?;
     let rsp: PublicKeyCredential = rsp.data.into();
 
-    let mut registrations = get_webauthn_registrations(user_uuid, conn)?.1;
+    let mut registrations = get_webauthn_registrations(user_uuid, conn).await?.1;
 
     // If the credential we received is migrated from U2F, enable the U2F compatibility
     //let use_u2f = registrations.iter().any(|r| r.migrated && r.credential.cred_id == rsp.raw_id.0);
@@ -377,7 +386,8 @@ pub fn validate_webauthn_login(user_uuid: &str, response: &str, conn: &DbConn) -
             reg.credential.counter = auth_data.counter;
 
             TwoFactor::new(user_uuid.to_string(), TwoFactorType::Webauthn, serde_json::to_string(&registrations)?)
-                .save(conn)?;
+                .save(conn)
+                .await?;
             return Ok(());
         }
     }

--- a/src/api/core/two_factor/webauthn.rs
+++ b/src/api/core/two_factor/webauthn.rs
@@ -1,5 +1,5 @@
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 use url::Url;
 use webauthn_rs::{base64_data::Base64UrlSafeData, proto::*, AuthenticationState, RegistrationState, Webauthn};

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -78,7 +78,7 @@ fn verify_yubikey_otp(otp: String) -> EmptyResult {
 }
 
 #[post("/two-factor/get-yubikey", data = "<data>")]
-fn generate_yubikey(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn generate_yubikey(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> JsonResult {
     // Make sure the credentials are set
     get_yubico_credentials()?;
 
@@ -92,7 +92,7 @@ fn generate_yubikey(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbCo
     let user_uuid = &user.uuid;
     let yubikey_type = TwoFactorType::YubiKey as i32;
 
-    let r = TwoFactor::find_by_user_and_type(user_uuid, yubikey_type, &conn);
+    let r = TwoFactor::find_by_user_and_type(user_uuid, yubikey_type, &conn).await;
 
     if let Some(r) = r {
         let yubikey_metadata: YubikeyMetadata = serde_json::from_str(&r.data)?;
@@ -113,7 +113,7 @@ fn generate_yubikey(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbCo
 }
 
 #[post("/two-factor/yubikey", data = "<data>")]
-fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn: DbConn) -> JsonResult {
     let data: EnableYubikeyData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -122,10 +122,11 @@ fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn:
     }
 
     // Check if we already have some data
-    let mut yubikey_data = match TwoFactor::find_by_user_and_type(&user.uuid, TwoFactorType::YubiKey as i32, &conn) {
-        Some(data) => data,
-        None => TwoFactor::new(user.uuid.clone(), TwoFactorType::YubiKey, String::new()),
-    };
+    let mut yubikey_data =
+        match TwoFactor::find_by_user_and_type(&user.uuid, TwoFactorType::YubiKey as i32, &conn).await {
+            Some(data) => data,
+            None => TwoFactor::new(user.uuid.clone(), TwoFactorType::YubiKey, String::new()),
+        };
 
     let yubikeys = parse_yubikeys(&data);
 
@@ -154,9 +155,9 @@ fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn:
     };
 
     yubikey_data.data = serde_json::to_string(&yubikey_metadata).unwrap();
-    yubikey_data.save(&conn)?;
+    yubikey_data.save(&conn).await?;
 
-    _generate_recover_code(&mut user, &conn);
+    _generate_recover_code(&mut user, &conn).await;
 
     let mut result = jsonify_yubikeys(yubikey_metadata.Keys);
 
@@ -168,8 +169,8 @@ fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn:
 }
 
 #[put("/two-factor/yubikey", data = "<data>")]
-fn activate_yubikey_put(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn: DbConn) -> JsonResult {
-    activate_yubikey(data, headers, conn)
+async fn activate_yubikey_put(data: JsonUpcase<EnableYubikeyData>, headers: Headers, conn: DbConn) -> JsonResult {
+    activate_yubikey(data, headers, conn).await
 }
 
 pub fn validate_yubikey_login(response: &str, twofactor_data: &str) -> EmptyResult {

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -1,5 +1,5 @@
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value;
 use yubico::{config::Config, verify};
 

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -745,6 +745,7 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
                     buffer = stream_to_bytes_limit(res, 512 * 1024).await?; // 512 KB for each icon max
                                                                             // Check if the icon type is allowed, else try an icon from the list.
                     icon_type = get_icon_type(&buffer);
+                    // Check if the icon type is allowed, else try an icon from the list.
                     if icon_type.is_none() {
                         buffer.clear();
                         debug!("Icon from {}, is not a valid image type", icon.href);

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -1,19 +1,19 @@
 use std::{
     collections::HashMap,
-    fs::{create_dir_all, remove_file, symlink_metadata, File},
-    io::prelude::*,
     net::{IpAddr, ToSocketAddrs},
     sync::{Arc, RwLock},
     time::{Duration, SystemTime},
 };
 
+use bytes::{Buf, Bytes, BytesMut};
+use futures::{stream::StreamExt, TryFutureExt};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use reqwest::{blocking::Client, blocking::Response, header};
-use rocket::{
-    http::ContentType,
-    response::{Content, Redirect},
-    Route,
+use reqwest::{header, Client, Response};
+use rocket::{http::ContentType, response::Redirect, Route};
+use tokio::{
+    fs::{create_dir_all, remove_file, symlink_metadata, File},
+    io::{AsyncReadExt, AsyncWriteExt},
 };
 
 use crate::{
@@ -104,27 +104,23 @@ fn icon_google(domain: String) -> Option<Redirect> {
 }
 
 #[get("/<domain>/icon.png")]
-fn icon_internal(domain: String) -> Cached<Content<Vec<u8>>> {
+async fn icon_internal(domain: String) -> Cached<(ContentType, Vec<u8>)> {
     const FALLBACK_ICON: &[u8] = include_bytes!("../static/images/fallback-icon.png");
 
     if !is_valid_domain(&domain) {
         warn!("Invalid domain: {}", domain);
         return Cached::ttl(
-            Content(ContentType::new("image", "png"), FALLBACK_ICON.to_vec()),
+            (ContentType::new("image", "png"), FALLBACK_ICON.to_vec()),
             CONFIG.icon_cache_negttl(),
             true,
         );
     }
 
-    match get_icon(&domain) {
+    match get_icon(&domain).await {
         Some((icon, icon_type)) => {
-            Cached::ttl(Content(ContentType::new("image", icon_type), icon), CONFIG.icon_cache_ttl(), true)
+            Cached::ttl((ContentType::new("image", icon_type), icon), CONFIG.icon_cache_ttl(), true)
         }
-        _ => Cached::ttl(
-            Content(ContentType::new("image", "png"), FALLBACK_ICON.to_vec()),
-            CONFIG.icon_cache_negttl(),
-            true,
-        ),
+        _ => Cached::ttl((ContentType::new("image", "png"), FALLBACK_ICON.to_vec()), CONFIG.icon_cache_negttl(), true),
     }
 }
 
@@ -317,15 +313,15 @@ fn is_domain_blacklisted(domain: &str) -> bool {
     is_blacklisted
 }
 
-fn get_icon(domain: &str) -> Option<(Vec<u8>, String)> {
+async fn get_icon(domain: &str) -> Option<(Vec<u8>, String)> {
     let path = format!("{}/{}.png", CONFIG.icon_cache_folder(), domain);
 
     // Check for expiration of negatively cached copy
-    if icon_is_negcached(&path) {
+    if icon_is_negcached(&path).await {
         return None;
     }
 
-    if let Some(icon) = get_cached_icon(&path) {
+    if let Some(icon) = get_cached_icon(&path).await {
         let icon_type = match get_icon_type(&icon) {
             Some(x) => x,
             _ => "x-icon",
@@ -338,31 +334,31 @@ fn get_icon(domain: &str) -> Option<(Vec<u8>, String)> {
     }
 
     // Get the icon, or None in case of error
-    match download_icon(domain) {
+    match download_icon(domain).await {
         Ok((icon, icon_type)) => {
-            save_icon(&path, &icon);
-            Some((icon, icon_type.unwrap_or("x-icon").to_string()))
+            save_icon(&path, &icon).await;
+            Some((icon.to_vec(), icon_type.unwrap_or("x-icon").to_string()))
         }
         Err(e) => {
             warn!("Unable to download icon: {:?}", e);
             let miss_indicator = path + ".miss";
-            save_icon(&miss_indicator, &[]);
+            save_icon(&miss_indicator, &[]).await;
             None
         }
     }
 }
 
-fn get_cached_icon(path: &str) -> Option<Vec<u8>> {
+async fn get_cached_icon(path: &str) -> Option<Vec<u8>> {
     // Check for expiration of successfully cached copy
-    if icon_is_expired(path) {
+    if icon_is_expired(path).await {
         return None;
     }
 
     // Try to read the cached icon, and return it if it exists
-    if let Ok(mut f) = File::open(path) {
+    if let Ok(mut f) = File::open(path).await {
         let mut buffer = Vec::new();
 
-        if f.read_to_end(&mut buffer).is_ok() {
+        if f.read_to_end(&mut buffer).await.is_ok() {
             return Some(buffer);
         }
     }
@@ -370,22 +366,22 @@ fn get_cached_icon(path: &str) -> Option<Vec<u8>> {
     None
 }
 
-fn file_is_expired(path: &str, ttl: u64) -> Result<bool, Error> {
-    let meta = symlink_metadata(path)?;
+async fn file_is_expired(path: &str, ttl: u64) -> Result<bool, Error> {
+    let meta = symlink_metadata(path).await?;
     let modified = meta.modified()?;
     let age = SystemTime::now().duration_since(modified)?;
 
     Ok(ttl > 0 && ttl <= age.as_secs())
 }
 
-fn icon_is_negcached(path: &str) -> bool {
+async fn icon_is_negcached(path: &str) -> bool {
     let miss_indicator = path.to_owned() + ".miss";
-    let expired = file_is_expired(&miss_indicator, CONFIG.icon_cache_negttl());
+    let expired = file_is_expired(&miss_indicator, CONFIG.icon_cache_negttl()).await;
 
     match expired {
         // No longer negatively cached, drop the marker
         Ok(true) => {
-            if let Err(e) = remove_file(&miss_indicator) {
+            if let Err(e) = remove_file(&miss_indicator).await {
                 error!("Could not remove negative cache indicator for icon {:?}: {:?}", path, e);
             }
             false
@@ -397,8 +393,8 @@ fn icon_is_negcached(path: &str) -> bool {
     }
 }
 
-fn icon_is_expired(path: &str) -> bool {
-    let expired = file_is_expired(path, CONFIG.icon_cache_ttl());
+async fn icon_is_expired(path: &str) -> bool {
+    let expired = file_is_expired(path, CONFIG.icon_cache_ttl()).await;
     expired.unwrap_or(true)
 }
 
@@ -521,13 +517,13 @@ struct IconUrlResult {
 /// let icon_result = get_icon_url("github.com")?;
 /// let icon_result = get_icon_url("vaultwarden.discourse.group")?;
 /// ```
-fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
+async fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
     // Default URL with secure and insecure schemes
     let ssldomain = format!("https://{}", domain);
     let httpdomain = format!("http://{}", domain);
 
     // First check the domain as given during the request for both HTTPS and HTTP.
-    let resp = match get_page(&ssldomain).or_else(|_| get_page(&httpdomain)) {
+    let resp = match get_page(&ssldomain).or_else(|_| get_page(&httpdomain)).await {
         Ok(c) => Ok(c),
         Err(e) => {
             let mut sub_resp = Err(e);
@@ -546,7 +542,7 @@ fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
                     let httpbase = format!("http://{}", base_domain);
                     debug!("[get_icon_url]: Trying without subdomains '{}'", base_domain);
 
-                    sub_resp = get_page(&sslbase).or_else(|_| get_page(&httpbase));
+                    sub_resp = get_page(&sslbase).or_else(|_| get_page(&httpbase)).await;
                 }
 
             // When the domain is not an IP, and has less then 2 dots, try to add www. infront of it.
@@ -557,7 +553,7 @@ fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
                     let httpwww = format!("http://{}", www_domain);
                     debug!("[get_icon_url]: Trying with www. prefix '{}'", www_domain);
 
-                    sub_resp = get_page(&sslwww).or_else(|_| get_page(&httpwww));
+                    sub_resp = get_page(&sslwww).or_else(|_| get_page(&httpwww)).await;
                 }
             }
 
@@ -581,7 +577,7 @@ fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
         iconlist.push(Icon::new(35, String::from(url.join("/favicon.ico").unwrap())));
 
         // 384KB should be more than enough for the HTML, though as we only really need the HTML header.
-        let mut limited_reader = content.take(384 * 1024);
+        let mut limited_reader = stream_to_bytes_limit(content, 384 * 1024).await?.reader();
 
         use html5ever::tendril::TendrilSink;
         let dom = html5ever::parse_document(markup5ever_rcdom::RcDom::default(), Default::default())
@@ -607,11 +603,11 @@ fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
     })
 }
 
-fn get_page(url: &str) -> Result<Response, Error> {
-    get_page_with_referer(url, "")
+async fn get_page(url: &str) -> Result<Response, Error> {
+    get_page_with_referer(url, "").await
 }
 
-fn get_page_with_referer(url: &str, referer: &str) -> Result<Response, Error> {
+async fn get_page_with_referer(url: &str, referer: &str) -> Result<Response, Error> {
     if is_domain_blacklisted(url::Url::parse(url).unwrap().host_str().unwrap_or_default()) {
         warn!("Favicon '{}' resolves to a blacklisted domain or IP!", url);
     }
@@ -621,7 +617,7 @@ fn get_page_with_referer(url: &str, referer: &str) -> Result<Response, Error> {
         client = client.header("Referer", referer)
     }
 
-    match client.send() {
+    match client.send().await {
         Ok(c) => c.error_for_status().map_err(Into::into),
         Err(e) => err_silent!(format!("{}", e)),
     }
@@ -706,14 +702,14 @@ fn parse_sizes(sizes: Option<&str>) -> (u16, u16) {
     (width, height)
 }
 
-fn download_icon(domain: &str) -> Result<(Vec<u8>, Option<&str>), Error> {
+async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
     if is_domain_blacklisted(domain) {
         err_silent!("Domain is blacklisted", domain)
     }
 
-    let icon_result = get_icon_url(domain)?;
+    let icon_result = get_icon_url(domain).await?;
 
-    let mut buffer = Vec::new();
+    let mut buffer = Bytes::new();
     let mut icon_type: Option<&str> = None;
 
     use data_url::DataUrl;
@@ -722,8 +718,12 @@ fn download_icon(domain: &str) -> Result<(Vec<u8>, Option<&str>), Error> {
         if icon.href.starts_with("data:image") {
             let datauri = DataUrl::process(&icon.href).unwrap();
             // Check if we are able to decode the data uri
-            match datauri.decode_to_vec() {
-                Ok((body, _fragment)) => {
+            let mut body = BytesMut::new();
+            match datauri.decode::<_, ()>(|bytes| {
+                body.extend_from_slice(bytes);
+                Ok(())
+            }) {
+                Ok(_) => {
                     // Also check if the size is atleast 67 bytes, which seems to be the smallest png i could create
                     if body.len() >= 67 {
                         // Check if the icon type is allowed, else try an icon from the list.
@@ -733,17 +733,17 @@ fn download_icon(domain: &str) -> Result<(Vec<u8>, Option<&str>), Error> {
                             continue;
                         }
                         info!("Extracted icon from data:image uri for {}", domain);
-                        buffer = body;
+                        buffer = body.freeze();
                         break;
                     }
                 }
                 _ => debug!("Extracted icon from data:image uri is invalid"),
             };
         } else {
-            match get_page_with_referer(&icon.href, &icon_result.referer) {
-                Ok(mut res) => {
-                    res.copy_to(&mut buffer)?;
-                    // Check if the icon type is allowed, else try an icon from the list.
+            match get_page_with_referer(&icon.href, &icon_result.referer).await {
+                Ok(res) => {
+                    buffer = stream_to_bytes_limit(res, 512 * 1024).await?; // 512 KB for each icon max
+                                                                            // Check if the icon type is allowed, else try an icon from the list.
                     icon_type = get_icon_type(&buffer);
                     if icon_type.is_none() {
                         buffer.clear();
@@ -765,13 +765,13 @@ fn download_icon(domain: &str) -> Result<(Vec<u8>, Option<&str>), Error> {
     Ok((buffer, icon_type))
 }
 
-fn save_icon(path: &str, icon: &[u8]) {
-    match File::create(path) {
+async fn save_icon(path: &str, icon: &[u8]) {
+    match File::create(path).await {
         Ok(mut f) => {
-            f.write_all(icon).expect("Error writing icon file");
+            f.write_all(icon).await.expect("Error writing icon file");
         }
         Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
-            create_dir_all(&CONFIG.icon_cache_folder()).expect("Error creating icon cache folder");
+            create_dir_all(&CONFIG.icon_cache_folder()).await.expect("Error creating icon cache folder");
         }
         Err(e) => {
             warn!("Unable to save icon: {:?}", e);
@@ -820,8 +820,6 @@ impl reqwest::cookie::CookieStore for Jar {
     }
 
     fn cookies(&self, url: &url::Url) -> Option<header::HeaderValue> {
-        use bytes::Bytes;
-
         let cookie_store = self.0.read().unwrap();
         let s = cookie_store
             .get_request_values(url)
@@ -835,4 +833,13 @@ impl reqwest::cookie::CookieStore for Jar {
 
         header::HeaderValue::from_maybe_shared(Bytes::from(s)).ok()
     }
+}
+
+async fn stream_to_bytes_limit(res: Response, max_size: usize) -> Result<Bytes, reqwest::Error> {
+    let mut stream = res.bytes_stream().take(max_size);
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = stream.next().await {
+        buf.extend(chunk?);
+    }
+    Ok(buf.freeze())
 }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -1,10 +1,10 @@
 use chrono::Utc;
 use num_traits::FromPrimitive;
+use rocket::serde::json::Json;
 use rocket::{
-    request::{Form, FormItems, FromForm},
+    form::{Form, FromForm},
     Route,
 };
-use rocket_contrib::json::Json;
 use serde_json::Value;
 
 use crate::{
@@ -455,64 +455,55 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
 
 // https://github.com/bitwarden/jslib/blob/master/common/src/models/request/tokenRequest.ts
 // https://github.com/bitwarden/mobile/blob/master/src/Core/Models/Request/TokenRequest.cs
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, FromForm)]
 #[allow(non_snake_case)]
 struct ConnectData {
-    // refresh_token, password, client_credentials (API key)
-    grant_type: String,
+    #[field(name = uncased("grant_type"))]
+    #[field(name = uncased("granttype"))]
+    grant_type: String, // refresh_token, password, client_credentials (API key)
 
     // Needed for grant_type="refresh_token"
+    #[field(name = uncased("refresh_token"))]
+    #[field(name = uncased("refreshtoken"))]
     refresh_token: Option<String>,
 
     // Needed for grant_type = "password" | "client_credentials"
-    client_id: Option<String>,     // web, cli, desktop, browser, mobile
-    client_secret: Option<String>, // API key login (cli only)
+    #[field(name = uncased("client_id"))]
+    #[field(name = uncased("clientid"))]
+    client_id: Option<String>, // web, cli, desktop, browser, mobile
+    #[field(name = uncased("client_secret"))]
+    #[field(name = uncased("clientsecret"))]
+    client_secret: Option<String>,
+    #[field(name = uncased("password"))]
     password: Option<String>,
+    #[field(name = uncased("scope"))]
     scope: Option<String>,
+    #[field(name = uncased("username"))]
     username: Option<String>,
 
+    #[field(name = uncased("device_identifier"))]
+    #[field(name = uncased("deviceidentifier"))]
     device_identifier: Option<String>,
+    #[field(name = uncased("device_name"))]
+    #[field(name = uncased("devicename"))]
     device_name: Option<String>,
+    #[field(name = uncased("device_type"))]
+    #[field(name = uncased("devicetype"))]
     device_type: Option<String>,
+    #[field(name = uncased("device_push_token"))]
+    #[field(name = uncased("devicepushtoken"))]
     device_push_token: Option<String>, // Unused; mobile device push not yet supported.
 
     // Needed for two-factor auth
+    #[field(name = uncased("two_factor_provider"))]
+    #[field(name = uncased("twofactorprovider"))]
     two_factor_provider: Option<i32>,
+    #[field(name = uncased("two_factor_token"))]
+    #[field(name = uncased("twofactortoken"))]
     two_factor_token: Option<String>,
+    #[field(name = uncased("two_factor_remember"))]
+    #[field(name = uncased("twofactorremember"))]
     two_factor_remember: Option<i32>,
-}
-
-impl<'f> FromForm<'f> for ConnectData {
-    type Error = String;
-
-    fn from_form(items: &mut FormItems<'f>, _strict: bool) -> Result<Self, Self::Error> {
-        let mut form = Self::default();
-        for item in items {
-            let (key, value) = item.key_value_decoded();
-            let mut normalized_key = key.to_lowercase();
-            normalized_key.retain(|c| c != '_'); // Remove '_'
-
-            match normalized_key.as_ref() {
-                "granttype" => form.grant_type = value,
-                "refreshtoken" => form.refresh_token = Some(value),
-                "clientid" => form.client_id = Some(value),
-                "clientsecret" => form.client_secret = Some(value),
-                "password" => form.password = Some(value),
-                "scope" => form.scope = Some(value),
-                "username" => form.username = Some(value),
-                "deviceidentifier" => form.device_identifier = Some(value),
-                "devicename" => form.device_name = Some(value),
-                "devicetype" => form.device_type = Some(value),
-                "devicepushtoken" => form.device_push_token = Some(value),
-                "twofactorprovider" => form.two_factor_provider = value.parse().ok(),
-                "twofactortoken" => form.two_factor_token = Some(value),
-                "twofactorremember" => form.two_factor_remember = value.parse().ok(),
-                key => warn!("Detected unexpected parameter during login: {}", key),
-            }
-        }
-
-        Ok(form)
-    }
 }
 
 fn _check_is_some<T>(value: &Option<T>, msg: &str) -> EmptyResult {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -495,6 +495,7 @@ struct ConnectData {
     #[field(name = uncased("device_type"))]
     #[field(name = uncased("devicetype"))]
     device_type: Option<String>,
+    #[allow(unused)]
     #[field(name = uncased("device_push_token"))]
     #[field(name = uncased("devicepushtoken"))]
     _device_push_token: Option<String>, // Unused; mobile device push not yet supported.

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -23,13 +23,13 @@ pub fn routes() -> Vec<Route> {
 }
 
 #[post("/connect/token", data = "<data>")]
-fn login(data: Form<ConnectData>, conn: DbConn, ip: ClientIp) -> JsonResult {
+async fn login(data: Form<ConnectData>, conn: DbConn, ip: ClientIp) -> JsonResult {
     let data: ConnectData = data.into_inner();
 
     match data.grant_type.as_ref() {
         "refresh_token" => {
             _check_is_some(&data.refresh_token, "refresh_token cannot be blank")?;
-            _refresh_login(data, conn)
+            _refresh_login(data, conn).await
         }
         "password" => {
             _check_is_some(&data.client_id, "client_id cannot be blank")?;
@@ -41,34 +41,34 @@ fn login(data: Form<ConnectData>, conn: DbConn, ip: ClientIp) -> JsonResult {
             _check_is_some(&data.device_name, "device_name cannot be blank")?;
             _check_is_some(&data.device_type, "device_type cannot be blank")?;
 
-            _password_login(data, conn, &ip)
+            _password_login(data, conn, &ip).await
         }
         "client_credentials" => {
             _check_is_some(&data.client_id, "client_id cannot be blank")?;
             _check_is_some(&data.client_secret, "client_secret cannot be blank")?;
             _check_is_some(&data.scope, "scope cannot be blank")?;
 
-            _api_key_login(data, conn, &ip)
+            _api_key_login(data, conn, &ip).await
         }
         t => err!("Invalid type", t),
     }
 }
 
-fn _refresh_login(data: ConnectData, conn: DbConn) -> JsonResult {
+async fn _refresh_login(data: ConnectData, conn: DbConn) -> JsonResult {
     // Extract token
     let token = data.refresh_token.unwrap();
 
     // Get device by refresh token
-    let mut device = Device::find_by_refresh_token(&token, &conn).map_res("Invalid refresh token")?;
+    let mut device = Device::find_by_refresh_token(&token, &conn).await.map_res("Invalid refresh token")?;
 
     let scope = "api offline_access";
     let scope_vec = vec!["api".into(), "offline_access".into()];
 
     // Common
-    let user = User::find_by_uuid(&device.user_uuid, &conn).unwrap();
-    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn);
+    let user = User::find_by_uuid(&device.user_uuid, &conn).await.unwrap();
+    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn).await;
     let (access_token, expires_in) = device.refresh_tokens(&user, orgs, scope_vec);
-    device.save(&conn)?;
+    device.save(&conn).await?;
 
     Ok(Json(json!({
         "access_token": access_token,
@@ -86,7 +86,7 @@ fn _refresh_login(data: ConnectData, conn: DbConn) -> JsonResult {
     })))
 }
 
-fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult {
+async fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult {
     // Validate scope
     let scope = data.scope.as_ref().unwrap();
     if scope != "api offline_access" {
@@ -99,7 +99,7 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult
 
     // Get the user
     let username = data.username.as_ref().unwrap();
-    let user = match User::find_by_mail(username, &conn) {
+    let user = match User::find_by_mail(username, &conn).await {
         Some(user) => user,
         None => err!("Username or password is incorrect. Try again", format!("IP: {}. Username: {}.", ip.ip, username)),
     };
@@ -130,7 +130,7 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult
                 user.last_verifying_at = Some(now);
                 user.login_verify_count += 1;
 
-                if let Err(e) = user.save(&conn) {
+                if let Err(e) = user.save(&conn).await {
                     error!("Error updating user: {:#?}", e);
                 }
 
@@ -144,9 +144,9 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult
         err!("Please verify your email before trying again.", format!("IP: {}. Username: {}.", ip.ip, username))
     }
 
-    let (mut device, new_device) = get_device(&data, &conn, &user);
+    let (mut device, new_device) = get_device(&data, &conn, &user).await;
 
-    let twofactor_token = twofactor_auth(&user.uuid, &data, &mut device, ip, &conn)?;
+    let twofactor_token = twofactor_auth(&user.uuid, &data, &mut device, ip, &conn).await?;
 
     if CONFIG.mail_enabled() && new_device {
         if let Err(e) = mail::send_new_device_logged_in(&user.email, &ip.ip.to_string(), &now, &device.name) {
@@ -159,9 +159,9 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult
     }
 
     // Common
-    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn);
+    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn).await;
     let (access_token, expires_in) = device.refresh_tokens(&user, orgs, scope_vec);
-    device.save(&conn)?;
+    device.save(&conn).await?;
 
     let mut result = json!({
         "access_token": access_token,
@@ -187,7 +187,7 @@ fn _password_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult
     Ok(Json(result))
 }
 
-fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult {
+async fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult {
     // Validate scope
     let scope = data.scope.as_ref().unwrap();
     if scope != "api" {
@@ -204,7 +204,7 @@ fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult 
         Some(uuid) => uuid,
         None => err!("Malformed client_id", format!("IP: {}.", ip.ip)),
     };
-    let user = match User::find_by_uuid(user_uuid, &conn) {
+    let user = match User::find_by_uuid(user_uuid, &conn).await {
         Some(user) => user,
         None => err!("Invalid client_id", format!("IP: {}.", ip.ip)),
     };
@@ -220,7 +220,7 @@ fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult 
         err!("Incorrect client_secret", format!("IP: {}. Username: {}.", ip.ip, user.email))
     }
 
-    let (mut device, new_device) = get_device(&data, &conn, &user);
+    let (mut device, new_device) = get_device(&data, &conn, &user).await;
 
     if CONFIG.mail_enabled() && new_device {
         let now = Utc::now().naive_utc();
@@ -234,9 +234,9 @@ fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult 
     }
 
     // Common
-    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn);
+    let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, &conn).await;
     let (access_token, expires_in) = device.refresh_tokens(&user, orgs, scope_vec);
-    device.save(&conn)?;
+    device.save(&conn).await?;
 
     info!("User {} logged in successfully via API key. IP: {}", user.email, ip.ip);
 
@@ -258,7 +258,7 @@ fn _api_key_login(data: ConnectData, conn: DbConn, ip: &ClientIp) -> JsonResult 
 }
 
 /// Retrieves an existing device or creates a new device from ConnectData and the User
-fn get_device(data: &ConnectData, conn: &DbConn, user: &User) -> (Device, bool) {
+async fn get_device(data: &ConnectData, conn: &DbConn, user: &User) -> (Device, bool) {
     // On iOS, device_type sends "iOS", on others it sends a number
     let device_type = util::try_parse_string(data.device_type.as_ref()).unwrap_or(0);
     let device_id = data.device_identifier.clone().expect("No device id provided");
@@ -266,7 +266,7 @@ fn get_device(data: &ConnectData, conn: &DbConn, user: &User) -> (Device, bool) 
 
     let mut new_device = false;
     // Find device or create new
-    let device = match Device::find_by_uuid(&device_id, conn) {
+    let device = match Device::find_by_uuid(&device_id, conn).await {
         Some(device) => {
             // Check if owned device, and recreate if not
             if device.user_uuid != user.uuid {
@@ -286,28 +286,28 @@ fn get_device(data: &ConnectData, conn: &DbConn, user: &User) -> (Device, bool) 
     (device, new_device)
 }
 
-fn twofactor_auth(
+async fn twofactor_auth(
     user_uuid: &str,
     data: &ConnectData,
     device: &mut Device,
     ip: &ClientIp,
     conn: &DbConn,
 ) -> ApiResult<Option<String>> {
-    let twofactors = TwoFactor::find_by_user(user_uuid, conn);
+    let twofactors = TwoFactor::find_by_user(user_uuid, conn).await;
 
     // No twofactor token if twofactor is disabled
     if twofactors.is_empty() {
         return Ok(None);
     }
 
-    TwoFactorIncomplete::mark_incomplete(user_uuid, &device.uuid, &device.name, ip, conn)?;
+    TwoFactorIncomplete::mark_incomplete(user_uuid, &device.uuid, &device.name, ip, conn).await?;
 
     let twofactor_ids: Vec<_> = twofactors.iter().map(|tf| tf.atype).collect();
     let selected_id = data.two_factor_provider.unwrap_or(twofactor_ids[0]); // If we aren't given a two factor provider, asume the first one
 
     let twofactor_code = match data.two_factor_token {
         Some(ref code) => code,
-        None => err_json!(_json_err_twofactor(&twofactor_ids, user_uuid, conn)?, "2FA token not provided"),
+        None => err_json!(_json_err_twofactor(&twofactor_ids, user_uuid, conn).await?, "2FA token not provided"),
     };
 
     let selected_twofactor = twofactors.into_iter().find(|tf| tf.atype == selected_id && tf.enabled);
@@ -320,16 +320,18 @@ fn twofactor_auth(
 
     match TwoFactorType::from_i32(selected_id) {
         Some(TwoFactorType::Authenticator) => {
-            _tf::authenticator::validate_totp_code_str(user_uuid, twofactor_code, &selected_data?, ip, conn)?
+            _tf::authenticator::validate_totp_code_str(user_uuid, twofactor_code, &selected_data?, ip, conn).await?
         }
-        Some(TwoFactorType::U2f) => _tf::u2f::validate_u2f_login(user_uuid, twofactor_code, conn)?,
-        Some(TwoFactorType::Webauthn) => _tf::webauthn::validate_webauthn_login(user_uuid, twofactor_code, conn)?,
+        Some(TwoFactorType::U2f) => _tf::u2f::validate_u2f_login(user_uuid, twofactor_code, conn).await?,
+        Some(TwoFactorType::Webauthn) => {
+            _tf::webauthn::validate_webauthn_login(user_uuid, twofactor_code, conn).await?
+        }
         Some(TwoFactorType::YubiKey) => _tf::yubikey::validate_yubikey_login(twofactor_code, &selected_data?)?,
         Some(TwoFactorType::Duo) => {
-            _tf::duo::validate_duo_login(data.username.as_ref().unwrap(), twofactor_code, conn)?
+            _tf::duo::validate_duo_login(data.username.as_ref().unwrap(), twofactor_code, conn).await?
         }
         Some(TwoFactorType::Email) => {
-            _tf::email::validate_email_code_str(user_uuid, twofactor_code, &selected_data?, conn)?
+            _tf::email::validate_email_code_str(user_uuid, twofactor_code, &selected_data?, conn).await?
         }
 
         Some(TwoFactorType::Remember) => {
@@ -338,14 +340,17 @@ fn twofactor_auth(
                     remember = 1; // Make sure we also return the token here, otherwise it will only remember the first time
                 }
                 _ => {
-                    err_json!(_json_err_twofactor(&twofactor_ids, user_uuid, conn)?, "2FA Remember token not provided")
+                    err_json!(
+                        _json_err_twofactor(&twofactor_ids, user_uuid, conn).await?,
+                        "2FA Remember token not provided"
+                    )
                 }
             }
         }
         _ => err!("Invalid two factor provider"),
     }
 
-    TwoFactorIncomplete::mark_complete(user_uuid, &device.uuid, conn)?;
+    TwoFactorIncomplete::mark_complete(user_uuid, &device.uuid, conn).await?;
 
     if !CONFIG.disable_2fa_remember() && remember == 1 {
         Ok(Some(device.refresh_twofactor_remember()))
@@ -359,7 +364,7 @@ fn _selected_data(tf: Option<TwoFactor>) -> ApiResult<String> {
     tf.map(|t| t.data).map_res("Two factor doesn't exist")
 }
 
-fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> ApiResult<Value> {
+async fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> ApiResult<Value> {
     use crate::api::core::two_factor;
 
     let mut result = json!({
@@ -376,7 +381,7 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             Some(TwoFactorType::Authenticator) => { /* Nothing to do for TOTP */ }
 
             Some(TwoFactorType::U2f) if CONFIG.domain_set() => {
-                let request = two_factor::u2f::generate_u2f_login(user_uuid, conn)?;
+                let request = two_factor::u2f::generate_u2f_login(user_uuid, conn).await?;
                 let mut challenge_list = Vec::new();
 
                 for key in request.registered_keys {
@@ -396,17 +401,17 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             }
 
             Some(TwoFactorType::Webauthn) if CONFIG.domain_set() => {
-                let request = two_factor::webauthn::generate_webauthn_login(user_uuid, conn)?;
+                let request = two_factor::webauthn::generate_webauthn_login(user_uuid, conn).await?;
                 result["TwoFactorProviders2"][provider.to_string()] = request.0;
             }
 
             Some(TwoFactorType::Duo) => {
-                let email = match User::find_by_uuid(user_uuid, conn) {
+                let email = match User::find_by_uuid(user_uuid, conn).await {
                     Some(u) => u.email,
                     None => err!("User does not exist"),
                 };
 
-                let (signature, host) = duo::generate_duo_signature(&email, conn)?;
+                let (signature, host) = duo::generate_duo_signature(&email, conn).await?;
 
                 result["TwoFactorProviders2"][provider.to_string()] = json!({
                     "Host": host,
@@ -415,7 +420,7 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             }
 
             Some(tf_type @ TwoFactorType::YubiKey) => {
-                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, conn) {
+                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, conn).await {
                     Some(tf) => tf,
                     None => err!("No YubiKey devices registered"),
                 };
@@ -430,14 +435,14 @@ fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &DbConn) -> Api
             Some(tf_type @ TwoFactorType::Email) => {
                 use crate::api::core::two_factor as _tf;
 
-                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, conn) {
+                let twofactor = match TwoFactor::find_by_user_and_type(user_uuid, tf_type as i32, conn).await {
                     Some(tf) => tf,
                     None => err!("No twofactor email registered"),
                 };
 
                 // Send email immediately if email is the only 2FA option
                 if providers.len() == 1 {
-                    _tf::email::send_token(user_uuid, conn)?
+                    _tf::email::send_token(user_uuid, conn).await?
                 }
 
                 let email_data = EmailTokenData::from_json(&twofactor.data)?;
@@ -492,7 +497,7 @@ struct ConnectData {
     device_type: Option<String>,
     #[field(name = uncased("device_push_token"))]
     #[field(name = uncased("devicepushtoken"))]
-    device_push_token: Option<String>, // Unused; mobile device push not yet supported.
+    _device_push_token: Option<String>, // Unused; mobile device push not yet supported.
 
     // Needed for two-factor auth
     #[field(name = uncased("two_factor_provider"))]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,7 +5,7 @@ mod identity;
 mod notifications;
 mod web;
 
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
 use serde_json::Value;
 
 pub use crate::api::{

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use rocket::serde::json::Json;
 use rocket::Route;
-use rocket_contrib::json::Json;
 use serde_json::Value as JsonValue;
 
 use crate::{api::EmptyResult, auth::Headers, Error, CONFIG};
@@ -417,7 +417,7 @@ pub enum UpdateType {
 }
 
 use rocket::State;
-pub type Notify<'a> = State<'a, WebSocketUsers>;
+pub type Notify<'a> = &'a State<WebSocketUsers>;
 
 pub fn start_notification_server() -> WebSocketUsers {
     let factory = WsFactory::init();
@@ -430,12 +430,11 @@ pub fn start_notification_server() -> WebSocketUsers {
             settings.queue_size = 2;
             settings.panic_on_internal = false;
 
-            ws::Builder::new()
-                .with_settings(settings)
-                .build(factory)
-                .unwrap()
-                .listen((CONFIG.websocket_address().as_str(), CONFIG.websocket_port()))
-                .unwrap();
+            let ws = ws::Builder::new().with_settings(settings).build(factory).unwrap();
+            CONFIG.set_ws_shutdown_handle(ws.broadcaster());
+            ws.listen((CONFIG.websocket_address().as_str(), CONFIG.websocket_port())).unwrap();
+
+            warn!("WS Server stopped!");
         });
     }
 

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use rocket::{http::ContentType, response::content::Content, response::NamedFile, Route};
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
+use rocket::{fs::NamedFile, http::ContentType, Route};
 use serde_json::Value;
 
 use crate::{
@@ -21,16 +21,16 @@ pub fn routes() -> Vec<Route> {
 }
 
 #[get("/")]
-fn web_index() -> Cached<Option<NamedFile>> {
-    Cached::short(NamedFile::open(Path::new(&CONFIG.web_vault_folder()).join("index.html")).ok(), false)
+async fn web_index() -> Cached<Option<NamedFile>> {
+    Cached::short(NamedFile::open(Path::new(&CONFIG.web_vault_folder()).join("index.html")).await.ok(), false)
 }
 
 #[get("/app-id.json")]
-fn app_id() -> Cached<Content<Json<Value>>> {
+fn app_id() -> Cached<(ContentType, Json<Value>)> {
     let content_type = ContentType::new("application", "fido.trusted-apps+json");
 
     Cached::long(
-        Content(
+        (
             content_type,
             Json(json!({
             "trustedFacets": [
@@ -58,13 +58,13 @@ fn app_id() -> Cached<Content<Json<Value>>> {
 }
 
 #[get("/<p..>", rank = 10)] // Only match this if the other routes don't match
-fn web_files(p: PathBuf) -> Cached<Option<NamedFile>> {
-    Cached::long(NamedFile::open(Path::new(&CONFIG.web_vault_folder()).join(p)).ok(), true)
+async fn web_files(p: PathBuf) -> Cached<Option<NamedFile>> {
+    Cached::long(NamedFile::open(Path::new(&CONFIG.web_vault_folder()).join(p)).await.ok(), true)
 }
 
 #[get("/attachments/<uuid>/<file_id>")]
-fn attachments(uuid: SafeString, file_id: SafeString) -> Option<NamedFile> {
-    NamedFile::open(Path::new(&CONFIG.attachments_folder()).join(uuid).join(file_id)).ok()
+async fn attachments(uuid: SafeString, file_id: SafeString) -> Option<NamedFile> {
+    NamedFile::open(Path::new(&CONFIG.attachments_folder()).join(uuid).join(file_id)).await.ok()
 }
 
 // We use DbConn here to let the alive healthcheck also verify the database connection.
@@ -78,25 +78,20 @@ fn alive(_conn: DbConn) -> Json<String> {
 }
 
 #[get("/vw_static/<filename>")]
-fn static_files(filename: String) -> Result<Content<&'static [u8]>, Error> {
+fn static_files(filename: String) -> Result<(ContentType, &'static [u8]), Error> {
     match filename.as_ref() {
-        "mail-github.png" => Ok(Content(ContentType::PNG, include_bytes!("../static/images/mail-github.png"))),
-        "logo-gray.png" => Ok(Content(ContentType::PNG, include_bytes!("../static/images/logo-gray.png"))),
-        "error-x.svg" => Ok(Content(ContentType::SVG, include_bytes!("../static/images/error-x.svg"))),
-        "hibp.png" => Ok(Content(ContentType::PNG, include_bytes!("../static/images/hibp.png"))),
-        "vaultwarden-icon.png" => {
-            Ok(Content(ContentType::PNG, include_bytes!("../static/images/vaultwarden-icon.png")))
-        }
-
-        "bootstrap.css" => Ok(Content(ContentType::CSS, include_bytes!("../static/scripts/bootstrap.css"))),
-        "bootstrap-native.js" => {
-            Ok(Content(ContentType::JavaScript, include_bytes!("../static/scripts/bootstrap-native.js")))
-        }
-        "identicon.js" => Ok(Content(ContentType::JavaScript, include_bytes!("../static/scripts/identicon.js"))),
-        "datatables.js" => Ok(Content(ContentType::JavaScript, include_bytes!("../static/scripts/datatables.js"))),
-        "datatables.css" => Ok(Content(ContentType::CSS, include_bytes!("../static/scripts/datatables.css"))),
+        "mail-github.png" => Ok((ContentType::PNG, include_bytes!("../static/images/mail-github.png"))),
+        "logo-gray.png" => Ok((ContentType::PNG, include_bytes!("../static/images/logo-gray.png"))),
+        "error-x.svg" => Ok((ContentType::SVG, include_bytes!("../static/images/error-x.svg"))),
+        "hibp.png" => Ok((ContentType::PNG, include_bytes!("../static/images/hibp.png"))),
+        "vaultwarden-icon.png" => Ok((ContentType::PNG, include_bytes!("../static/images/vaultwarden-icon.png"))),
+        "bootstrap.css" => Ok((ContentType::CSS, include_bytes!("../static/scripts/bootstrap.css"))),
+        "bootstrap-native.js" => Ok((ContentType::JavaScript, include_bytes!("../static/scripts/bootstrap-native.js"))),
+        "identicon.js" => Ok((ContentType::JavaScript, include_bytes!("../static/scripts/identicon.js"))),
+        "datatables.js" => Ok((ContentType::JavaScript, include_bytes!("../static/scripts/datatables.js"))),
+        "datatables.css" => Ok((ContentType::CSS, include_bytes!("../static/scripts/datatables.css"))),
         "jquery-3.6.0.slim.js" => {
-            Ok(Content(ContentType::JavaScript, include_bytes!("../static/scripts/jquery-3.6.0.slim.js")))
+            Ok((ContentType::JavaScript, include_bytes!("../static/scripts/jquery-3.6.0.slim.js")))
         }
         _ => err!(format!("Static file not found: {}", filename)),
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -257,7 +257,10 @@ pub fn generate_send_claims(send_id: &str, file_id: &str) -> BasicJwtClaims {
 //
 // Bearer token authentication
 //
-use rocket::request::{FromRequest, Outcome, Request};
+use rocket::{
+    outcome::try_outcome,
+    request::{FromRequest, Outcome, Request},
+};
 
 use crate::db::{
     models::{CollectionUser, Device, User, UserOrgStatus, UserOrgType, UserOrganization, UserStampException},
@@ -268,10 +271,11 @@ pub struct Host {
     pub host: String,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for Host {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for Host {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let headers = request.headers();
 
         // Get host
@@ -314,17 +318,14 @@ pub struct Headers {
     pub user: User,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for Headers {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for Headers {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let headers = request.headers();
 
-        let host = match Host::from_request(request) {
-            Outcome::Forward(_) => return Outcome::Forward(()),
-            Outcome::Failure(f) => return Outcome::Failure(f),
-            Outcome::Success(host) => host.host,
-        };
+        let host = try_outcome!(Host::from_request(request).await).host;
 
         // Get access_token
         let access_token: &str = match headers.get_one("Authorization") {
@@ -344,7 +345,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Headers {
         let device_uuid = claims.device;
         let user_uuid = claims.sub;
 
-        let conn = match request.guard::<DbConn>() {
+        let conn = match DbConn::from_request(request).await {
             Outcome::Success(conn) => conn,
             _ => err_handler!("Error getting DB"),
         };
@@ -363,7 +364,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Headers {
             if let Some(stamp_exception) =
                 user.stamp_exception.as_deref().and_then(|s| serde_json::from_str::<UserStampException>(s).ok())
             {
-                let current_route = match request.route().and_then(|r| r.name) {
+                let current_route = match request.route().and_then(|r| r.name.as_deref()) {
                     Some(name) => name,
                     _ => err_handler!("Error getting current route for stamp exception"),
                 };
@@ -411,13 +412,13 @@ pub struct OrgHeaders {
 // but there are cases where it is a query value.
 // First check the path, if this is not a valid uuid, try the query values.
 fn get_org_id(request: &Request) -> Option<String> {
-    if let Some(Ok(org_id)) = request.get_param::<String>(1) {
+    if let Some(Ok(org_id)) = request.param::<String>(1) {
         if uuid::Uuid::parse_str(&org_id).is_ok() {
             return Some(org_id);
         }
     }
 
-    if let Some(Ok(org_id)) = request.get_query_value::<String>("organizationId") {
+    if let Some(Ok(org_id)) = request.query_value::<String>("organizationId") {
         if uuid::Uuid::parse_str(&org_id).is_ok() {
             return Some(org_id);
         }
@@ -426,52 +427,48 @@ fn get_org_id(request: &Request) -> Option<String> {
     None
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for OrgHeaders {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for OrgHeaders {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        match request.guard::<Headers>() {
-            Outcome::Forward(_) => Outcome::Forward(()),
-            Outcome::Failure(f) => Outcome::Failure(f),
-            Outcome::Success(headers) => {
-                match get_org_id(request) {
-                    Some(org_id) => {
-                        let conn = match request.guard::<DbConn>() {
-                            Outcome::Success(conn) => conn,
-                            _ => err_handler!("Error getting DB"),
-                        };
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = try_outcome!(Headers::from_request(request).await);
+        match get_org_id(request) {
+            Some(org_id) => {
+                let conn = match DbConn::from_request(request).await {
+                    Outcome::Success(conn) => conn,
+                    _ => err_handler!("Error getting DB"),
+                };
 
-                        let user = headers.user;
-                        let org_user = match UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn) {
-                            Some(user) => {
-                                if user.status == UserOrgStatus::Confirmed as i32 {
-                                    user
-                                } else {
-                                    err_handler!("The current user isn't confirmed member of the organization")
-                                }
-                            }
-                            None => err_handler!("The current user isn't member of the organization"),
-                        };
-
-                        Outcome::Success(Self {
-                            host: headers.host,
-                            device: headers.device,
-                            user,
-                            org_user_type: {
-                                if let Some(org_usr_type) = UserOrgType::from_i32(org_user.atype) {
-                                    org_usr_type
-                                } else {
-                                    // This should only happen if the DB is corrupted
-                                    err_handler!("Unknown user type in the database")
-                                }
-                            },
-                            org_user,
-                            org_id,
-                        })
+                let user = headers.user;
+                let org_user = match UserOrganization::find_by_user_and_org(&user.uuid, &org_id, &conn) {
+                    Some(user) => {
+                        if user.status == UserOrgStatus::Confirmed as i32 {
+                            user
+                        } else {
+                            err_handler!("The current user isn't confirmed member of the organization")
+                        }
                     }
-                    _ => err_handler!("Error getting the organization id"),
-                }
+                    None => err_handler!("The current user isn't member of the organization"),
+                };
+
+                Outcome::Success(Self {
+                    host: headers.host,
+                    device: headers.device,
+                    user,
+                    org_user_type: {
+                        if let Some(org_usr_type) = UserOrgType::from_i32(org_user.atype) {
+                            org_usr_type
+                        } else {
+                            // This should only happen if the DB is corrupted
+                            err_handler!("Unknown user type in the database")
+                        }
+                    },
+                    org_user,
+                    org_id,
+                })
             }
+            _ => err_handler!("Error getting the organization id"),
         }
     }
 }
@@ -483,25 +480,21 @@ pub struct AdminHeaders {
     pub org_user_type: UserOrgType,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for AdminHeaders {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for AdminHeaders {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        match request.guard::<OrgHeaders>() {
-            Outcome::Forward(_) => Outcome::Forward(()),
-            Outcome::Failure(f) => Outcome::Failure(f),
-            Outcome::Success(headers) => {
-                if headers.org_user_type >= UserOrgType::Admin {
-                    Outcome::Success(Self {
-                        host: headers.host,
-                        device: headers.device,
-                        user: headers.user,
-                        org_user_type: headers.org_user_type,
-                    })
-                } else {
-                    err_handler!("You need to be Admin or Owner to call this endpoint")
-                }
-            }
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = try_outcome!(OrgHeaders::from_request(request).await);
+        if headers.org_user_type >= UserOrgType::Admin {
+            Outcome::Success(Self {
+                host: headers.host,
+                device: headers.device,
+                user: headers.user,
+                org_user_type: headers.org_user_type,
+            })
+        } else {
+            err_handler!("You need to be Admin or Owner to call this endpoint")
         }
     }
 }
@@ -520,13 +513,13 @@ impl From<AdminHeaders> for Headers {
 // but there could be cases where it is a query value.
 // First check the path, if this is not a valid uuid, try the query values.
 fn get_col_id(request: &Request) -> Option<String> {
-    if let Some(Ok(col_id)) = request.get_param::<String>(3) {
+    if let Some(Ok(col_id)) = request.param::<String>(3) {
         if uuid::Uuid::parse_str(&col_id).is_ok() {
             return Some(col_id);
         }
     }
 
-    if let Some(Ok(col_id)) = request.get_query_value::<String>("collectionId") {
+    if let Some(Ok(col_id)) = request.query_value::<String>("collectionId") {
         if uuid::Uuid::parse_str(&col_id).is_ok() {
             return Some(col_id);
         }
@@ -545,46 +538,38 @@ pub struct ManagerHeaders {
     pub org_user_type: UserOrgType,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for ManagerHeaders {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ManagerHeaders {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        match request.guard::<OrgHeaders>() {
-            Outcome::Forward(_) => Outcome::Forward(()),
-            Outcome::Failure(f) => Outcome::Failure(f),
-            Outcome::Success(headers) => {
-                if headers.org_user_type >= UserOrgType::Manager {
-                    match get_col_id(request) {
-                        Some(col_id) => {
-                            let conn = match request.guard::<DbConn>() {
-                                Outcome::Success(conn) => conn,
-                                _ => err_handler!("Error getting DB"),
-                            };
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = try_outcome!(OrgHeaders::from_request(request).await);
+        if headers.org_user_type >= UserOrgType::Manager {
+            match get_col_id(request) {
+                Some(col_id) => {
+                    let conn = match DbConn::from_request(request).await {
+                        Outcome::Success(conn) => conn,
+                        _ => err_handler!("Error getting DB"),
+                    };
 
-                            if !headers.org_user.has_full_access() {
-                                match CollectionUser::find_by_collection_and_user(
-                                    &col_id,
-                                    &headers.org_user.user_uuid,
-                                    &conn,
-                                ) {
-                                    Some(_) => (),
-                                    None => err_handler!("The current user isn't a manager for this collection"),
-                                }
-                            }
+                    if !headers.org_user.has_full_access() {
+                        match CollectionUser::find_by_collection_and_user(&col_id, &headers.org_user.user_uuid, &conn) {
+                            Some(_) => (),
+                            None => err_handler!("The current user isn't a manager for this collection"),
                         }
-                        _ => err_handler!("Error getting the collection id"),
                     }
-
-                    Outcome::Success(Self {
-                        host: headers.host,
-                        device: headers.device,
-                        user: headers.user,
-                        org_user_type: headers.org_user_type,
-                    })
-                } else {
-                    err_handler!("You need to be a Manager, Admin or Owner to call this endpoint")
                 }
+                _ => err_handler!("Error getting the collection id"),
             }
+
+            Outcome::Success(Self {
+                host: headers.host,
+                device: headers.device,
+                user: headers.user,
+                org_user_type: headers.org_user_type,
+            })
+        } else {
+            err_handler!("You need to be a Manager, Admin or Owner to call this endpoint")
         }
     }
 }
@@ -608,25 +593,21 @@ pub struct ManagerHeadersLoose {
     pub org_user_type: UserOrgType,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for ManagerHeadersLoose {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ManagerHeadersLoose {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        match request.guard::<OrgHeaders>() {
-            Outcome::Forward(_) => Outcome::Forward(()),
-            Outcome::Failure(f) => Outcome::Failure(f),
-            Outcome::Success(headers) => {
-                if headers.org_user_type >= UserOrgType::Manager {
-                    Outcome::Success(Self {
-                        host: headers.host,
-                        device: headers.device,
-                        user: headers.user,
-                        org_user_type: headers.org_user_type,
-                    })
-                } else {
-                    err_handler!("You need to be a Manager, Admin or Owner to call this endpoint")
-                }
-            }
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = try_outcome!(OrgHeaders::from_request(request).await);
+        if headers.org_user_type >= UserOrgType::Manager {
+            Outcome::Success(Self {
+                host: headers.host,
+                device: headers.device,
+                user: headers.user,
+                org_user_type: headers.org_user_type,
+            })
+        } else {
+            err_handler!("You need to be a Manager, Admin or Owner to call this endpoint")
         }
     }
 }
@@ -647,24 +628,20 @@ pub struct OwnerHeaders {
     pub user: User,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for OwnerHeaders {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for OwnerHeaders {
     type Error = &'static str;
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        match request.guard::<OrgHeaders>() {
-            Outcome::Forward(_) => Outcome::Forward(()),
-            Outcome::Failure(f) => Outcome::Failure(f),
-            Outcome::Success(headers) => {
-                if headers.org_user_type == UserOrgType::Owner {
-                    Outcome::Success(Self {
-                        host: headers.host,
-                        device: headers.device,
-                        user: headers.user,
-                    })
-                } else {
-                    err_handler!("You need to be Owner to call this endpoint")
-                }
-            }
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = try_outcome!(OrgHeaders::from_request(request).await);
+        if headers.org_user_type == UserOrgType::Owner {
+            Outcome::Success(Self {
+                host: headers.host,
+                device: headers.device,
+                user: headers.user,
+            })
+        } else {
+            err_handler!("You need to be Owner to call this endpoint")
         }
     }
 }
@@ -678,10 +655,11 @@ pub struct ClientIp {
     pub ip: IpAddr,
 }
 
-impl<'a, 'r> FromRequest<'a, 'r> for ClientIp {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ClientIp {
     type Error = ();
 
-    fn from_request(req: &'a Request<'r>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let ip = if CONFIG._ip_header_enabled() {
             req.headers().get_one(&CONFIG.ip_header()).and_then(|ip| {
                 match ip.find(',') {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,7 +38,7 @@ static PRIVATE_RSA_KEY: Lazy<EncodingKey> = Lazy::new(|| {
 static PUBLIC_RSA_KEY_VEC: Lazy<Vec<u8>> = Lazy::new(|| {
     read_file(&CONFIG.public_rsa_key()).unwrap_or_else(|e| panic!("Error loading public RSA Key.\n{}", e))
 });
-static PUBLIC_RSA_KEY: Lazy<DecodingKey> = Lazy::new(|| {
+static PUBLIC_RSA_KEY: Lazy<DecodingKey<'_>> = Lazy::new(|| {
     DecodingKey::from_rsa_pem(&PUBLIC_RSA_KEY_VEC).unwrap_or_else(|e| panic!("Error decoding public RSA Key.\n{}", e))
 });
 
@@ -411,7 +411,7 @@ pub struct OrgHeaders {
 // org_id is usually the second path param ("/organizations/<org_id>"),
 // but there are cases where it is a query value.
 // First check the path, if this is not a valid uuid, try the query values.
-fn get_org_id(request: &Request) -> Option<String> {
+fn get_org_id(request: &Request<'_>) -> Option<String> {
     if let Some(Ok(org_id)) = request.param::<String>(1) {
         if uuid::Uuid::parse_str(&org_id).is_ok() {
             return Some(org_id);
@@ -512,7 +512,7 @@ impl From<AdminHeaders> for Headers {
 // col_id is usually the fourth path param ("/organizations/<org_id>/collections/<col_id>"),
 // but there could be cases where it is a query value.
 // First check the path, if this is not a valid uuid, try the query values.
-fn get_col_id(request: &Request) -> Option<String> {
+fn get_col_id(request: &Request<'_>) -> Option<String> {
     if let Some(Ok(col_id)) = request.param::<String>(3) {
         if uuid::Uuid::parse_str(&col_id).is_ok() {
             return Some(col_id);

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,9 @@ macro_rules! make_config {
         pub struct Config { inner: RwLock<Inner> }
 
         struct Inner {
+            rocket_shutdown_handle: Option<rocket::Shutdown>,
+            ws_shutdown_handle: Option<ws::Sender>,
+
             templates: Handlebars<'static>,
             config: ConfigItems,
 
@@ -332,6 +335,8 @@ make_config! {
         attachments_folder:     String, false,  auto,   |c| format!("{}/{}", c.data_folder, "attachments");
         /// Sends folder
         sends_folder:           String, false,  auto,   |c| format!("{}/{}", c.data_folder, "sends");
+        /// Temp folder |> Used for storing temporary file uploads
+        tmp_folder:           String, false,  auto,   |c| format!("{}/{}", c.data_folder, "tmp");
         /// Templates folder
         templates_folder:       String, false,  auto,   |c| format!("{}/{}", c.data_folder, "templates");
         /// Session JWT key
@@ -508,6 +513,9 @@ make_config! {
 
         /// Max database connection retries |> Number of times to retry the database connection during startup, with 1 second between each retry, set to 0 to retry indefinitely
         db_connection_retries:  u32,    false,  def,    15;
+
+        /// Timeout when aquiring database connection
+        database_timeout:     u64,    false,  def,    30;
 
         /// Database connection pool size
         database_max_conns:     u32,    false,  def,    10;
@@ -743,6 +751,8 @@ impl Config {
 
         Ok(Config {
             inner: RwLock::new(Inner {
+                rocket_shutdown_handle: None,
+                ws_shutdown_handle: None,
                 templates: load_templates(&config.templates_folder),
                 config,
                 _env,
@@ -905,6 +915,27 @@ impl Config {
         } else {
             let hb = &CONFIG.inner.read().unwrap().templates;
             hb.render(name, data).map_err(Into::into)
+        }
+    }
+
+    pub fn set_rocket_shutdown_handle(&self, handle: rocket::Shutdown) {
+        self.inner.write().unwrap().rocket_shutdown_handle = Some(handle);
+    }
+
+    pub fn set_ws_shutdown_handle(&self, handle: ws::Sender) {
+        self.inner.write().unwrap().ws_shutdown_handle = Some(handle);
+    }
+
+    pub fn shutdown(&self) {
+        if let Ok(c) = self.inner.read() {
+            if let Some(handle) = c.ws_shutdown_handle.clone() {
+                handle.shutdown().ok();
+            }
+            // Wait a bit before stopping the web server
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if let Some(handle) = c.rocket_shutdown_handle.clone() {
+                handle.notify();
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1011,7 +1011,7 @@ where
 
 fn case_helper<'reg, 'rc>(
     h: &Helper<'reg, 'rc>,
-    r: &'reg Handlebars,
+    r: &'reg Handlebars<'_>,
     ctx: &'rc Context,
     rc: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,
@@ -1028,7 +1028,7 @@ fn case_helper<'reg, 'rc>(
 
 fn js_escape_helper<'reg, 'rc>(
     h: &Helper<'reg, 'rc>,
-    _r: &'reg Handlebars,
+    _r: &'reg Handlebars<'_>,
     _ctx: &'rc Context,
     _rc: &mut RenderContext<'reg, 'rc>,
     out: &mut dyn Output,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,8 +1,16 @@
+use std::{sync::Arc, time::Duration};
+
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use rocket::{
     http::Status,
+    outcome::IntoOutcome,
     request::{FromRequest, Outcome},
-    Request, State,
+    Request,
+};
+
+use tokio::{
+    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
+    time::timeout,
 };
 
 use crate::{
@@ -22,6 +30,23 @@ pub mod __mysql_schema;
 #[path = "schemas/postgresql/schema.rs"]
 pub mod __postgresql_schema;
 
+// There changes are based on Rocket 0.5-rc wrapper of Diesel: https://github.com/SergioBenitez/Rocket/blob/v0.5-rc/contrib/sync_db_pools
+
+// A wrapper around spawn_blocking that propagates panics to the calling code.
+pub async fn run_blocking<F, R>(job: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    match tokio::task::spawn_blocking(job).await {
+        Ok(ret) => ret,
+        Err(e) => match e.try_into_panic() {
+            Ok(panic) => std::panic::resume_unwind(panic),
+            Err(_) => unreachable!("spawn_blocking tasks are never cancelled"),
+        },
+    }
+}
+
 // This is used to generate the main DbConn and DbPool enums, which contain one variant for each database supported
 macro_rules! generate_connections {
     ( $( $name:ident: $ty:ty ),+ ) => {
@@ -29,12 +54,53 @@ macro_rules! generate_connections {
         #[derive(Eq, PartialEq)]
         pub enum DbConnType { $( $name, )+ }
 
+        pub struct DbConn {
+            conn: Arc<Mutex<Option<DbConnInner>>>,
+            permit: Option<OwnedSemaphorePermit>,
+        }
+
         #[allow(non_camel_case_types)]
-        pub enum DbConn { $( #[cfg($name)] $name(PooledConnection<ConnectionManager< $ty >>), )+ }
+        pub enum DbConnInner { $( #[cfg($name)] $name(PooledConnection<ConnectionManager< $ty >>), )+ }
+
+
+        #[derive(Clone)]
+        pub struct DbPool {
+            // This is an 'Option' so that we can drop the pool in a 'spawn_blocking'.
+            pool: Option<DbPoolInner>,
+            semaphore: Arc<Semaphore>
+        }
 
         #[allow(non_camel_case_types)]
         #[derive(Clone)]
-        pub enum DbPool { $( #[cfg($name)] $name(Pool<ConnectionManager< $ty >>), )+ }
+        pub enum DbPoolInner { $( #[cfg($name)] $name(Pool<ConnectionManager< $ty >>), )+ }
+
+        impl Drop for DbConn {
+            fn drop(&mut self) {
+                let conn = self.conn.clone();
+                let permit = self.permit.take();
+
+                // Since connection can't be on the stack in an async fn during an
+                // await, we have to spawn a new blocking-safe thread...
+                tokio::task::spawn_blocking(move || {
+                    // And then re-enter the runtime to wait on the async mutex, but in a blocking fashion.
+                    let mut conn = tokio::runtime::Handle::current().block_on(conn.lock_owned());
+
+                    if let Some(conn) = conn.take() {
+                        drop(conn);
+                    }
+
+                    // Drop permit after the connection is dropped
+                    drop(permit);
+                });
+            }
+        }
+
+        impl Drop for DbPool {
+            fn drop(&mut self) {
+                let pool = self.pool.take();
+                tokio::task::spawn_blocking(move || drop(pool));
+            }
+        }
 
         impl DbPool {
             // For the given database URL, guess it's type, run migrations create pool and return it
@@ -50,9 +116,13 @@ macro_rules! generate_connections {
                             let manager = ConnectionManager::new(&url);
                             let pool = Pool::builder()
                                 .max_size(CONFIG.database_max_conns())
+                                .connection_timeout(Duration::from_secs(CONFIG.database_timeout()))
                                 .build(manager)
                                 .map_res("Failed to create pool")?;
-                            return Ok(Self::$name(pool));
+                            return Ok(DbPool {
+                                pool: Some(DbPoolInner::$name(pool)),
+                                semaphore: Arc::new(Semaphore::new(CONFIG.database_max_conns() as usize)),
+                            });
                         }
                         #[cfg(not($name))]
                         #[allow(unreachable_code)]
@@ -61,10 +131,26 @@ macro_rules! generate_connections {
                 )+ }
             }
             // Get a connection from the pool
-            pub fn get(&self) -> Result<DbConn, Error> {
-                match self {  $(
+            pub async fn get(&self) -> Result<DbConn, Error> {
+                let duration = Duration::from_secs(CONFIG.database_timeout());
+                let permit = match timeout(duration, self.semaphore.clone().acquire_owned()).await {
+                    Ok(p) => p.expect("Semaphore should be open"),
+                    Err(_) => {
+                        err!("Timeout waiting for database connection");
+                    }
+                };
+
+                match self.pool.as_ref().expect("DbPool.pool should always be Some()") {  $(
                     #[cfg($name)]
-                    Self::$name(p) => Ok(DbConn::$name(p.get().map_res("Error retrieving connection from pool")?)),
+                    DbPoolInner::$name(p) => {
+                        let pool = p.clone();
+                        let c = run_blocking(move || pool.get_timeout(duration)).await.map_res("Error retrieving connection from pool")?;
+
+                        return Ok(DbConn {
+                            conn: Arc::new(Mutex::new(Some(DbConnInner::$name(c)))),
+                            permit: Some(permit)
+                        });
+                    },
                 )+ }
             }
         }
@@ -113,42 +199,95 @@ macro_rules! db_run {
         db_run! { $conn: sqlite, mysql, postgresql $body }
     };
 
-    // Different code for each db
-    ( $conn:ident: $( $($db:ident),+ $body:block )+ ) => {{
-        #[allow(unused)] use diesel::prelude::*;
-        match $conn {
-            $($(
-                #[cfg($db)]
-                crate::db::DbConn::$db(ref $conn) => {
-                    paste::paste! {
-                        #[allow(unused)] use crate::db::[<__ $db _schema>]::{self as schema, *};
-                        #[allow(unused)] use [<__ $db _model>]::*;
-                        #[allow(unused)] use crate::db::FromDb;
-                    }
-                    $body
-                },
-            )+)+
-        }}
-    };
-
-    // Same for all dbs
     ( @raw $conn:ident: $body:block ) => {
         db_run! { @raw $conn: sqlite, mysql, postgresql $body }
     };
 
     // Different code for each db
-    ( @raw $conn:ident: $( $($db:ident),+ $body:block )+ ) => {
+    ( $conn:ident: $( $($db:ident),+ $body:block )+ ) => {{
         #[allow(unused)] use diesel::prelude::*;
-        #[allow(unused_variables)]
-        match $conn {
-            $($(
-                #[cfg($db)]
-                crate::db::DbConn::$db(ref $conn) => {
-                    $body
-                },
-            )+)+
-        }
-    };
+
+        // It is important that this inner Arc<Mutex<>> (or the OwnedMutexGuard
+        // derived from it) never be a variable on the stack at an await point,
+        // where Drop might be called at any time. This causes (synchronous)
+        // Drop to be called from asynchronous code, which some database
+        // wrappers do not or can not handle.
+        let conn = $conn.conn.clone();
+
+        // Since connection can't be on the stack in an async fn during an
+        // await, we have to spawn a new blocking-safe thread...
+        /*
+        run_blocking(move || {
+            // And then re-enter the runtime to wait on the async mutex, but in
+            // a blocking fashion.
+            let mut conn = tokio::runtime::Handle::current().block_on(conn.lock_owned());
+            let conn = conn.as_mut().expect("internal invariant broken: self.connection is Some");
+            */
+            let mut __conn_mutex = conn.try_lock_owned().unwrap();
+            let conn = __conn_mutex.as_mut().unwrap();
+            match conn {
+                    $($(
+                    #[cfg($db)]
+                    crate::db::DbConnInner::$db($conn) => {
+                        paste::paste! {
+                            #[allow(unused)] use crate::db::[<__ $db _schema>]::{self as schema, *};
+                            #[allow(unused)] use [<__ $db _model>]::*;
+                            #[allow(unused)] use crate::db::FromDb;
+                        }
+
+                        /*
+                        // Since connection can't be on the stack in an async fn during an
+                        // await, we have to spawn a new blocking-safe thread...
+                        run_blocking(move || {
+                            // And then re-enter the runtime to wait on the async mutex, but in
+                            // a blocking fashion.
+                            let mut conn = tokio::runtime::Handle::current().block_on(async {
+                                conn.lock_owned().await
+                            });
+
+                            let conn = conn.as_mut().expect("internal invariant broken: self.connection is Some");
+                            f(conn)
+                        }).await;*/
+
+                        $body
+                    },
+                )+)+
+            }
+        // }).await
+    }};
+
+    ( @raw $conn:ident: $( $($db:ident),+ $body:block )+ ) => {{
+        #[allow(unused)] use diesel::prelude::*;
+
+        // It is important that this inner Arc<Mutex<>> (or the OwnedMutexGuard
+        // derived from it) never be a variable on the stack at an await point,
+        // where Drop might be called at any time. This causes (synchronous)
+        // Drop to be called from asynchronous code, which some database
+        // wrappers do not or can not handle.
+        let conn = $conn.conn.clone();
+
+        // Since connection can't be on the stack in an async fn during an
+        // await, we have to spawn a new blocking-safe thread...
+        run_blocking(move || {
+            // And then re-enter the runtime to wait on the async mutex, but in
+            // a blocking fashion.
+            let mut conn = tokio::runtime::Handle::current().block_on(conn.lock_owned());
+            match conn.as_mut().expect("internal invariant broken: self.connection is Some") {
+                    $($(
+                    #[cfg($db)]
+                    crate::db::DbConnInner::$db($conn) => {
+                        paste::paste! {
+                            #[allow(unused)] use crate::db::[<__ $db _schema>]::{self as schema, *};
+                            // @RAW: #[allow(unused)] use [<__ $db _model>]::*;
+                            #[allow(unused)] use crate::db::FromDb;
+                        }
+
+                        $body
+                    },
+                )+)+
+            }
+        }).await
+    }};
 }
 
 pub trait FromDb {
@@ -227,9 +366,10 @@ pub mod models;
 
 /// Creates a back-up of the sqlite database
 /// MySQL/MariaDB and PostgreSQL are not supported.
-pub fn backup_database(conn: &DbConn) -> Result<(), Error> {
+pub async fn backup_database(conn: &DbConn) -> Result<(), Error> {
     db_run! {@raw conn:
         postgresql, mysql {
+            let _ = conn;
             err!("PostgreSQL and MySQL/MariaDB do not support this backup feature");
         }
         sqlite {
@@ -244,7 +384,7 @@ pub fn backup_database(conn: &DbConn) -> Result<(), Error> {
 }
 
 /// Get the SQL Server version
-pub fn get_sql_server_version(conn: &DbConn) -> String {
+pub async fn get_sql_server_version(conn: &DbConn) -> String {
     db_run! {@raw conn:
         postgresql, mysql {
             no_arg_sql_function!(version, diesel::sql_types::Text);
@@ -260,15 +400,14 @@ pub fn get_sql_server_version(conn: &DbConn) -> String {
 /// Attempts to retrieve a single connection from the managed database pool. If
 /// no pool is currently managed, fails with an `InternalServerError` status. If
 /// no connections are available, fails with a `ServiceUnavailable` status.
-impl<'a, 'r> FromRequest<'a, 'r> for DbConn {
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for DbConn {
     type Error = ();
 
-    fn from_request(request: &'a Request<'r>) -> Outcome<DbConn, ()> {
-        // https://github.com/SergioBenitez/Rocket/commit/e3c1a4ad3ab9b840482ec6de4200d30df43e357c
-        let pool = try_outcome!(request.guard::<State<DbPool>>());
-        match pool.get() {
-            Ok(conn) => Outcome::Success(conn),
-            Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match request.rocket().state::<DbPool>() {
+            Some(p) => p.get().await.map_err(|_| ()).into_outcome(Status::ServiceUnavailable),
+            None => Outcome::Failure((Status::InternalServerError, ())),
         }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -30,7 +30,7 @@ pub mod __mysql_schema;
 #[path = "schemas/postgresql/schema.rs"]
 pub mod __postgresql_schema;
 
-// There changes are based on Rocket 0.5-rc wrapper of Diesel: https://github.com/SergioBenitez/Rocket/blob/v0.5-rc/contrib/sync_db_pools
+// These changes are based on Rocket 0.5-rc wrapper of Diesel: https://github.com/SergioBenitez/Rocket/blob/v0.5-rc/contrib/sync_db_pools
 
 // A wrapper around spawn_blocking that propagates panics to the calling code.
 pub async fn run_blocking<F, R>(job: F) -> R

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -60,7 +60,7 @@ use crate::error::MapResult;
 
 /// Database methods
 impl Attachment {
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
             sqlite, mysql {
                 match diesel::replace_into(attachments::table)
@@ -92,7 +92,7 @@ impl Attachment {
         }
     }
 
-    pub fn delete(&self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             crate::util::retry(
                 || diesel::delete(attachments::table.filter(attachments::id.eq(&self.id))).execute(conn),
@@ -116,14 +116,14 @@ impl Attachment {
         }}
     }
 
-    pub fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> EmptyResult {
-        for attachment in Attachment::find_by_cipher(cipher_uuid, conn) {
-            attachment.delete(conn)?;
+    pub async fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for attachment in Attachment::find_by_cipher(cipher_uuid, conn).await {
+            attachment.delete(conn).await?;
         }
         Ok(())
     }
 
-    pub fn find_by_id(id: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_id(id: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             attachments::table
                 .filter(attachments::id.eq(id.to_lowercase()))
@@ -133,7 +133,7 @@ impl Attachment {
         }}
     }
 
-    pub fn find_by_cipher(cipher_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_cipher(cipher_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             attachments::table
                 .filter(attachments::cipher_uuid.eq(cipher_uuid))
@@ -143,7 +143,7 @@ impl Attachment {
         }}
     }
 
-    pub fn size_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
+    pub async fn size_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             let result: Option<i64> = attachments::table
                 .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))
@@ -155,7 +155,7 @@ impl Attachment {
         }}
     }
 
-    pub fn count_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
+    pub async fn count_by_user(user_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             attachments::table
                 .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))
@@ -166,7 +166,7 @@ impl Attachment {
         }}
     }
 
-    pub fn size_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+    pub async fn size_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             let result: Option<i64> = attachments::table
                 .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))
@@ -178,7 +178,7 @@ impl Attachment {
         }}
     }
 
-    pub fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+    pub async fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             attachments::table
                 .left_join(ciphers::table.on(ciphers::uuid.eq(attachments::cipher_uuid)))

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -57,11 +57,11 @@ impl Collection {
         })
     }
 
-    pub fn to_json_details(&self, user_uuid: &str, conn: &DbConn) -> Value {
+    pub async fn to_json_details(&self, user_uuid: &str, conn: &DbConn) -> Value {
         let mut json_object = self.to_json();
         json_object["Object"] = json!("collectionDetails");
-        json_object["ReadOnly"] = json!(!self.is_writable_by_user(user_uuid, conn));
-        json_object["HidePasswords"] = json!(self.hide_passwords_for_user(user_uuid, conn));
+        json_object["ReadOnly"] = json!(!self.is_writable_by_user(user_uuid, conn).await);
+        json_object["HidePasswords"] = json!(self.hide_passwords_for_user(user_uuid, conn).await);
         json_object
     }
 }
@@ -73,8 +73,8 @@ use crate::error::MapResult;
 
 /// Database methods
 impl Collection {
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
-        self.update_users_revision(conn);
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
+        self.update_users_revision(conn).await;
 
         db_run! { conn:
             sqlite, mysql {
@@ -107,10 +107,10 @@ impl Collection {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
-        self.update_users_revision(conn);
-        CollectionCipher::delete_all_by_collection(&self.uuid, conn)?;
-        CollectionUser::delete_all_by_collection(&self.uuid, conn)?;
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
+        self.update_users_revision(conn).await;
+        CollectionCipher::delete_all_by_collection(&self.uuid, conn).await?;
+        CollectionUser::delete_all_by_collection(&self.uuid, conn).await?;
 
         db_run! { conn: {
             diesel::delete(collections::table.filter(collections::uuid.eq(self.uuid)))
@@ -119,20 +119,20 @@ impl Collection {
         }}
     }
 
-    pub fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
-        for collection in Self::find_by_organization(org_uuid, conn) {
-            collection.delete(conn)?;
+    pub async fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for collection in Self::find_by_organization(org_uuid, conn).await {
+            collection.delete(conn).await?;
         }
         Ok(())
     }
 
-    pub fn update_users_revision(&self, conn: &DbConn) {
-        UserOrganization::find_by_collection_and_org(&self.uuid, &self.org_uuid, conn).iter().for_each(|user_org| {
-            User::update_uuid_revision(&user_org.user_uuid, conn);
-        });
+    pub async fn update_users_revision(&self, conn: &DbConn) {
+        for user_org in UserOrganization::find_by_collection_and_org(&self.uuid, &self.org_uuid, conn).await.iter() {
+            User::update_uuid_revision(&user_org.user_uuid, conn).await;
+        }
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             collections::table
                 .filter(collections::uuid.eq(uuid))
@@ -142,7 +142,7 @@ impl Collection {
         }}
     }
 
-    pub fn find_by_user_uuid(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_user_uuid(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             collections::table
             .left_join(users_collections::table.on(
@@ -167,11 +167,11 @@ impl Collection {
         }}
     }
 
-    pub fn find_by_organization_and_user_uuid(org_uuid: &str, user_uuid: &str, conn: &DbConn) -> Vec<Self> {
-        Self::find_by_user_uuid(user_uuid, conn).into_iter().filter(|c| c.org_uuid == org_uuid).collect()
+    pub async fn find_by_organization_and_user_uuid(org_uuid: &str, user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+        Self::find_by_user_uuid(user_uuid, conn).await.into_iter().filter(|c| c.org_uuid == org_uuid).collect()
     }
 
-    pub fn find_by_organization(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_organization(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             collections::table
                 .filter(collections::org_uuid.eq(org_uuid))
@@ -181,7 +181,7 @@ impl Collection {
         }}
     }
 
-    pub fn find_by_uuid_and_org(uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid_and_org(uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             collections::table
                 .filter(collections::uuid.eq(uuid))
@@ -193,7 +193,7 @@ impl Collection {
         }}
     }
 
-    pub fn find_by_uuid_and_user(uuid: &str, user_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid_and_user(uuid: &str, user_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             collections::table
             .left_join(users_collections::table.on(
@@ -219,8 +219,8 @@ impl Collection {
         }}
     }
 
-    pub fn is_writable_by_user(&self, user_uuid: &str, conn: &DbConn) -> bool {
-        match UserOrganization::find_by_user_and_org(user_uuid, &self.org_uuid, conn) {
+    pub async fn is_writable_by_user(&self, user_uuid: &str, conn: &DbConn) -> bool {
+        match UserOrganization::find_by_user_and_org(user_uuid, &self.org_uuid, conn).await {
             None => false, // Not in Org
             Some(user_org) => {
                 if user_org.has_full_access() {
@@ -241,8 +241,8 @@ impl Collection {
         }
     }
 
-    pub fn hide_passwords_for_user(&self, user_uuid: &str, conn: &DbConn) -> bool {
-        match UserOrganization::find_by_user_and_org(user_uuid, &self.org_uuid, conn) {
+    pub async fn hide_passwords_for_user(&self, user_uuid: &str, conn: &DbConn) -> bool {
+        match UserOrganization::find_by_user_and_org(user_uuid, &self.org_uuid, conn).await {
             None => true, // Not in Org
             Some(user_org) => {
                 if user_org.has_full_access() {
@@ -266,7 +266,7 @@ impl Collection {
 
 /// Database methods
 impl CollectionUser {
-    pub fn find_by_organization_and_user_uuid(org_uuid: &str, user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_organization_and_user_uuid(org_uuid: &str, user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_collections::table
                 .filter(users_collections::user_uuid.eq(user_uuid))
@@ -279,14 +279,14 @@ impl CollectionUser {
         }}
     }
 
-    pub fn save(
+    pub async fn save(
         user_uuid: &str,
         collection_uuid: &str,
         read_only: bool,
         hide_passwords: bool,
         conn: &DbConn,
     ) -> EmptyResult {
-        User::update_uuid_revision(user_uuid, conn);
+        User::update_uuid_revision(user_uuid, conn).await;
 
         db_run! { conn:
             sqlite, mysql {
@@ -337,8 +337,8 @@ impl CollectionUser {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
-        User::update_uuid_revision(&self.user_uuid, conn);
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
+        User::update_uuid_revision(&self.user_uuid, conn).await;
 
         db_run! { conn: {
             diesel::delete(
@@ -351,7 +351,7 @@ impl CollectionUser {
         }}
     }
 
-    pub fn find_by_collection(collection_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_collection(collection_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_collections::table
                 .filter(users_collections::collection_uuid.eq(collection_uuid))
@@ -362,7 +362,7 @@ impl CollectionUser {
         }}
     }
 
-    pub fn find_by_collection_and_user(collection_uuid: &str, user_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_collection_and_user(collection_uuid: &str, user_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             users_collections::table
                 .filter(users_collections::collection_uuid.eq(collection_uuid))
@@ -374,10 +374,10 @@ impl CollectionUser {
         }}
     }
 
-    pub fn delete_all_by_collection(collection_uuid: &str, conn: &DbConn) -> EmptyResult {
-        CollectionUser::find_by_collection(collection_uuid, conn).iter().for_each(|collection| {
-            User::update_uuid_revision(&collection.user_uuid, conn);
-        });
+    pub async fn delete_all_by_collection(collection_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for collection in CollectionUser::find_by_collection(collection_uuid, conn).await.iter() {
+            User::update_uuid_revision(&collection.user_uuid, conn).await;
+        }
 
         db_run! { conn: {
             diesel::delete(users_collections::table.filter(users_collections::collection_uuid.eq(collection_uuid)))
@@ -386,8 +386,8 @@ impl CollectionUser {
         }}
     }
 
-    pub fn delete_all_by_user_and_org(user_uuid: &str, org_uuid: &str, conn: &DbConn) -> EmptyResult {
-        let collectionusers = Self::find_by_organization_and_user_uuid(org_uuid, user_uuid, conn);
+    pub async fn delete_all_by_user_and_org(user_uuid: &str, org_uuid: &str, conn: &DbConn) -> EmptyResult {
+        let collectionusers = Self::find_by_organization_and_user_uuid(org_uuid, user_uuid, conn).await;
 
         db_run! { conn: {
             for user in collectionusers {
@@ -405,8 +405,8 @@ impl CollectionUser {
 
 /// Database methods
 impl CollectionCipher {
-    pub fn save(cipher_uuid: &str, collection_uuid: &str, conn: &DbConn) -> EmptyResult {
-        Self::update_users_revision(collection_uuid, conn);
+    pub async fn save(cipher_uuid: &str, collection_uuid: &str, conn: &DbConn) -> EmptyResult {
+        Self::update_users_revision(collection_uuid, conn).await;
 
         db_run! { conn:
             sqlite, mysql {
@@ -435,8 +435,8 @@ impl CollectionCipher {
         }
     }
 
-    pub fn delete(cipher_uuid: &str, collection_uuid: &str, conn: &DbConn) -> EmptyResult {
-        Self::update_users_revision(collection_uuid, conn);
+    pub async fn delete(cipher_uuid: &str, collection_uuid: &str, conn: &DbConn) -> EmptyResult {
+        Self::update_users_revision(collection_uuid, conn).await;
 
         db_run! { conn: {
             diesel::delete(
@@ -449,7 +449,7 @@ impl CollectionCipher {
         }}
     }
 
-    pub fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_all_by_cipher(cipher_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(ciphers_collections::table.filter(ciphers_collections::cipher_uuid.eq(cipher_uuid)))
                 .execute(conn)
@@ -457,7 +457,7 @@ impl CollectionCipher {
         }}
     }
 
-    pub fn delete_all_by_collection(collection_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_all_by_collection(collection_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(ciphers_collections::table.filter(ciphers_collections::collection_uuid.eq(collection_uuid)))
                 .execute(conn)
@@ -465,9 +465,9 @@ impl CollectionCipher {
         }}
     }
 
-    pub fn update_users_revision(collection_uuid: &str, conn: &DbConn) {
-        if let Some(collection) = Collection::find_by_uuid(collection_uuid, conn) {
-            collection.update_users_revision(conn);
+    pub async fn update_users_revision(collection_uuid: &str, conn: &DbConn) {
+        if let Some(collection) = Collection::find_by_uuid(collection_uuid, conn).await {
+            collection.update_users_revision(conn).await;
         }
     }
 }

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -118,7 +118,7 @@ use crate::error::MapResult;
 
 /// Database methods
 impl Device {
-    pub fn save(&mut self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
         self.updated_at = Utc::now().naive_utc();
 
         db_run! { conn:
@@ -138,7 +138,7 @@ impl Device {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(devices::table.filter(devices::uuid.eq(self.uuid)))
                 .execute(conn)
@@ -146,14 +146,14 @@ impl Device {
         }}
     }
 
-    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
-        for device in Self::find_by_user(user_uuid, conn) {
-            device.delete(conn)?;
+    pub async fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for device in Self::find_by_user(user_uuid, conn).await {
+            device.delete(conn).await?;
         }
         Ok(())
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             devices::table
                 .filter(devices::uuid.eq(uuid))
@@ -163,7 +163,7 @@ impl Device {
         }}
     }
 
-    pub fn find_by_refresh_token(refresh_token: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_refresh_token(refresh_token: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             devices::table
                 .filter(devices::refresh_token.eq(refresh_token))
@@ -173,7 +173,7 @@ impl Device {
         }}
     }
 
-    pub fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             devices::table
                 .filter(devices::user_uuid.eq(user_uuid))
@@ -183,7 +183,7 @@ impl Device {
         }}
     }
 
-    pub fn find_latest_active_by_user(user_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_latest_active_by_user(user_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             devices::table
                 .filter(devices::user_uuid.eq(user_uuid))

--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -72,7 +72,7 @@ impl OrgPolicy {
 
 /// Database methods
 impl OrgPolicy {
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
             sqlite, mysql {
                 match diesel::replace_into(org_policies::table)
@@ -115,7 +115,7 @@ impl OrgPolicy {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(org_policies::table.filter(org_policies::uuid.eq(self.uuid)))
                 .execute(conn)
@@ -123,7 +123,7 @@ impl OrgPolicy {
         }}
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             org_policies::table
                 .filter(org_policies::uuid.eq(uuid))
@@ -133,7 +133,7 @@ impl OrgPolicy {
         }}
     }
 
-    pub fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             org_policies::table
                 .filter(org_policies::org_uuid.eq(org_uuid))
@@ -143,7 +143,7 @@ impl OrgPolicy {
         }}
     }
 
-    pub fn find_confirmed_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_confirmed_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             org_policies::table
                 .inner_join(
@@ -161,7 +161,7 @@ impl OrgPolicy {
         }}
     }
 
-    pub fn find_by_org_and_type(org_uuid: &str, atype: i32, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_org_and_type(org_uuid: &str, atype: i32, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             org_policies::table
                 .filter(org_policies::org_uuid.eq(org_uuid))
@@ -172,7 +172,7 @@ impl OrgPolicy {
         }}
     }
 
-    pub fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(org_policies::table.filter(org_policies::org_uuid.eq(org_uuid)))
                 .execute(conn)
@@ -183,12 +183,12 @@ impl OrgPolicy {
     /// Returns true if the user belongs to an org that has enabled the specified policy type,
     /// and the user is not an owner or admin of that org. This is only useful for checking
     /// applicability of policy types that have these particular semantics.
-    pub fn is_applicable_to_user(user_uuid: &str, policy_type: OrgPolicyType, conn: &DbConn) -> bool {
+    pub async fn is_applicable_to_user(user_uuid: &str, policy_type: OrgPolicyType, conn: &DbConn) -> bool {
         // TODO: Should check confirmed and accepted users
-        for policy in OrgPolicy::find_confirmed_by_user(user_uuid, conn) {
+        for policy in OrgPolicy::find_confirmed_by_user(user_uuid, conn).await {
             if policy.enabled && policy.has_type(policy_type) {
                 let org_uuid = &policy.org_uuid;
-                if let Some(user) = UserOrganization::find_by_user_and_org(user_uuid, org_uuid, conn) {
+                if let Some(user) = UserOrganization::find_by_user_and_org(user_uuid, org_uuid, conn).await {
                     if user.atype < UserOrgType::Admin {
                         return true;
                     }
@@ -200,11 +200,11 @@ impl OrgPolicy {
 
     /// Returns true if the user belongs to an org that has enabled the `DisableHideEmail`
     /// option of the `Send Options` policy, and the user is not an owner or admin of that org.
-    pub fn is_hide_email_disabled(user_uuid: &str, conn: &DbConn) -> bool {
-        for policy in OrgPolicy::find_confirmed_by_user(user_uuid, conn) {
+    pub async fn is_hide_email_disabled(user_uuid: &str, conn: &DbConn) -> bool {
+        for policy in OrgPolicy::find_confirmed_by_user(user_uuid, conn).await {
             if policy.enabled && policy.has_type(OrgPolicyType::SendOptions) {
                 let org_uuid = &policy.org_uuid;
-                if let Some(user) = UserOrganization::find_by_user_and_org(user_uuid, org_uuid, conn) {
+                if let Some(user) = UserOrganization::find_by_user_and_org(user_uuid, org_uuid, conn).await {
                     if user.atype < UserOrgType::Admin {
                         match serde_json::from_str::<UpCase<SendOptionsPolicyData>>(&policy.data) {
                             Ok(opts) => {
@@ -220,12 +220,4 @@ impl OrgPolicy {
         }
         false
     }
-
-    /*pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
-        db_run! { conn: {
-            diesel::delete(twofactor::table.filter(twofactor::user_uuid.eq(user_uuid)))
-                .execute(conn)
-                .map_res("Error deleting twofactors")
-        }}
-    }*/
 }

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -193,10 +193,10 @@ use crate::error::MapResult;
 
 /// Database methods
 impl Organization {
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
-        UserOrganization::find_by_org(&self.uuid, conn).iter().for_each(|user_org| {
-            User::update_uuid_revision(&user_org.user_uuid, conn);
-        });
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
+        for user_org in UserOrganization::find_by_org(&self.uuid, conn).await.iter() {
+            User::update_uuid_revision(&user_org.user_uuid, conn).await;
+        }
 
         db_run! { conn:
             sqlite, mysql {
@@ -230,13 +230,13 @@ impl Organization {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
         use super::{Cipher, Collection};
 
-        Cipher::delete_all_by_organization(&self.uuid, conn)?;
-        Collection::delete_all_by_organization(&self.uuid, conn)?;
-        UserOrganization::delete_all_by_organization(&self.uuid, conn)?;
-        OrgPolicy::delete_all_by_organization(&self.uuid, conn)?;
+        Cipher::delete_all_by_organization(&self.uuid, conn).await?;
+        Collection::delete_all_by_organization(&self.uuid, conn).await?;
+        UserOrganization::delete_all_by_organization(&self.uuid, conn).await?;
+        OrgPolicy::delete_all_by_organization(&self.uuid, conn).await?;
 
         db_run! { conn: {
             diesel::delete(organizations::table.filter(organizations::uuid.eq(self.uuid)))
@@ -245,7 +245,7 @@ impl Organization {
         }}
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             organizations::table
                 .filter(organizations::uuid.eq(uuid))
@@ -254,7 +254,7 @@ impl Organization {
         }}
     }
 
-    pub fn get_all(conn: &DbConn) -> Vec<Self> {
+    pub async fn get_all(conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             organizations::table.load::<OrganizationDb>(conn).expect("Error loading organizations").from_db()
         }}
@@ -262,8 +262,8 @@ impl Organization {
 }
 
 impl UserOrganization {
-    pub fn to_json(&self, conn: &DbConn) -> Value {
-        let org = Organization::find_by_uuid(&self.org_uuid, conn).unwrap();
+    pub async fn to_json(&self, conn: &DbConn) -> Value {
+        let org = Organization::find_by_uuid(&self.org_uuid, conn).await.unwrap();
 
         json!({
             "Id": self.org_uuid,
@@ -322,8 +322,8 @@ impl UserOrganization {
         })
     }
 
-    pub fn to_json_user_details(&self, conn: &DbConn) -> Value {
-        let user = User::find_by_uuid(&self.user_uuid, conn).unwrap();
+    pub async fn to_json_user_details(&self, conn: &DbConn) -> Value {
+        let user = User::find_by_uuid(&self.user_uuid, conn).await.unwrap();
 
         json!({
             "Id": self.uuid,
@@ -347,11 +347,12 @@ impl UserOrganization {
         })
     }
 
-    pub fn to_json_details(&self, conn: &DbConn) -> Value {
+    pub async fn to_json_details(&self, conn: &DbConn) -> Value {
         let coll_uuids = if self.access_all {
             vec![] // If we have complete access, no need to fill the array
         } else {
-            let collections = CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn);
+            let collections =
+                CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn).await;
             collections
                 .iter()
                 .map(|c| {
@@ -376,8 +377,8 @@ impl UserOrganization {
             "Object": "organizationUserDetails",
         })
     }
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
-        User::update_uuid_revision(&self.user_uuid, conn);
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
+        User::update_uuid_revision(&self.user_uuid, conn).await;
 
         db_run! { conn:
             sqlite, mysql {
@@ -410,10 +411,10 @@ impl UserOrganization {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
-        User::update_uuid_revision(&self.user_uuid, conn);
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
+        User::update_uuid_revision(&self.user_uuid, conn).await;
 
-        CollectionUser::delete_all_by_user_and_org(&self.user_uuid, &self.org_uuid, conn)?;
+        CollectionUser::delete_all_by_user_and_org(&self.user_uuid, &self.org_uuid, conn).await?;
 
         db_run! { conn: {
             diesel::delete(users_organizations::table.filter(users_organizations::uuid.eq(self.uuid)))
@@ -422,23 +423,23 @@ impl UserOrganization {
         }}
     }
 
-    pub fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
-        for user_org in Self::find_by_org(org_uuid, conn) {
-            user_org.delete(conn)?;
+    pub async fn delete_all_by_organization(org_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for user_org in Self::find_by_org(org_uuid, conn).await {
+            user_org.delete(conn).await?;
         }
         Ok(())
     }
 
-    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
-        for user_org in Self::find_any_state_by_user(user_uuid, conn) {
-            user_org.delete(conn)?;
+    pub async fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for user_org in Self::find_any_state_by_user(user_uuid, conn).await {
+            user_org.delete(conn).await?;
         }
         Ok(())
     }
 
-    pub fn find_by_email_and_org(email: &str, org_id: &str, conn: &DbConn) -> Option<UserOrganization> {
-        if let Some(user) = super::User::find_by_mail(email, conn) {
-            if let Some(user_org) = UserOrganization::find_by_user_and_org(&user.uuid, org_id, conn) {
+    pub async fn find_by_email_and_org(email: &str, org_id: &str, conn: &DbConn) -> Option<UserOrganization> {
+        if let Some(user) = super::User::find_by_mail(email, conn).await {
+            if let Some(user_org) = UserOrganization::find_by_user_and_org(&user.uuid, org_id, conn).await {
                 return Some(user_org);
             }
         }
@@ -458,7 +459,7 @@ impl UserOrganization {
         (self.access_all || self.atype >= UserOrgType::Admin) && self.has_status(UserOrgStatus::Confirmed)
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::uuid.eq(uuid))
@@ -467,7 +468,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_uuid_and_org(uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid_and_org(uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::uuid.eq(uuid))
@@ -477,7 +478,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_confirmed_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_confirmed_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::user_uuid.eq(user_uuid))
@@ -487,7 +488,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_invited_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_invited_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::user_uuid.eq(user_uuid))
@@ -497,7 +498,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_any_state_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_any_state_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::user_uuid.eq(user_uuid))
@@ -506,7 +507,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_org(org_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::org_uuid.eq(org_uuid))
@@ -515,7 +516,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
+    pub async fn count_by_org(org_uuid: &str, conn: &DbConn) -> i64 {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::org_uuid.eq(org_uuid))
@@ -526,7 +527,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_org_and_type(org_uuid: &str, atype: i32, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_org_and_type(org_uuid: &str, atype: i32, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::org_uuid.eq(org_uuid))
@@ -536,7 +537,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_user_and_org(user_uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_user_and_org(user_uuid: &str, org_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::user_uuid.eq(user_uuid))
@@ -546,7 +547,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_user_and_policy(user_uuid: &str, policy_type: OrgPolicyType, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_user_and_policy(user_uuid: &str, policy_type: OrgPolicyType, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
                 .inner_join(
@@ -565,7 +566,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_cipher_and_org(cipher_uuid: &str, org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_cipher_and_org(cipher_uuid: &str, org_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
             .filter(users_organizations::org_uuid.eq(org_uuid))
@@ -587,7 +588,7 @@ impl UserOrganization {
         }}
     }
 
-    pub fn find_by_collection_and_org(collection_uuid: &str, org_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_collection_and_org(collection_uuid: &str, org_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table
             .filter(users_organizations::org_uuid.eq(org_uuid))

--- a/src/db/models/two_factor.rs
+++ b/src/db/models/two_factor.rs
@@ -71,7 +71,7 @@ impl TwoFactor {
 
 /// Database methods
 impl TwoFactor {
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
             sqlite, mysql {
                 match diesel::replace_into(twofactor::table)
@@ -110,7 +110,7 @@ impl TwoFactor {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(twofactor::table.filter(twofactor::uuid.eq(self.uuid)))
                 .execute(conn)
@@ -118,7 +118,7 @@ impl TwoFactor {
         }}
     }
 
-    pub fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_by_user(user_uuid: &str, conn: &DbConn) -> Vec<Self> {
         db_run! { conn: {
             twofactor::table
                 .filter(twofactor::user_uuid.eq(user_uuid))
@@ -129,7 +129,7 @@ impl TwoFactor {
         }}
     }
 
-    pub fn find_by_user_and_type(user_uuid: &str, atype: i32, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_user_and_type(user_uuid: &str, atype: i32, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             twofactor::table
                 .filter(twofactor::user_uuid.eq(user_uuid))
@@ -140,7 +140,7 @@ impl TwoFactor {
         }}
     }
 
-    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(twofactor::table.filter(twofactor::user_uuid.eq(user_uuid)))
                 .execute(conn)
@@ -148,7 +148,7 @@ impl TwoFactor {
         }}
     }
 
-    pub fn migrate_u2f_to_webauthn(conn: &DbConn) -> EmptyResult {
+    pub async fn migrate_u2f_to_webauthn(conn: &DbConn) -> EmptyResult {
         let u2f_factors = db_run! { conn: {
             twofactor::table
                 .filter(twofactor::atype.eq(TwoFactorType::U2f as i32))
@@ -168,7 +168,7 @@ impl TwoFactor {
                 continue;
             }
 
-            let (_, mut webauthn_regs) = get_webauthn_registrations(&u2f.user_uuid, conn)?;
+            let (_, mut webauthn_regs) = get_webauthn_registrations(&u2f.user_uuid, conn).await?;
 
             // If the user already has webauthn registrations saved, don't overwrite them
             if !webauthn_regs.is_empty() {
@@ -207,10 +207,11 @@ impl TwoFactor {
             }
 
             u2f.data = serde_json::to_string(&regs)?;
-            u2f.save(conn)?;
+            u2f.save(conn).await?;
 
             TwoFactor::new(u2f.user_uuid.clone(), TwoFactorType::Webauthn, serde_json::to_string(&webauthn_regs)?)
-                .save(conn)?;
+                .save(conn)
+                .await?;
         }
 
         Ok(())

--- a/src/db/models/two_factor_incomplete.rs
+++ b/src/db/models/two_factor_incomplete.rs
@@ -22,7 +22,7 @@ db_object! {
 }
 
 impl TwoFactorIncomplete {
-    pub fn mark_incomplete(
+    pub async fn mark_incomplete(
         user_uuid: &str,
         device_uuid: &str,
         device_name: &str,
@@ -36,7 +36,7 @@ impl TwoFactorIncomplete {
         // Don't update the data for an existing user/device pair, since that
         // would allow an attacker to arbitrarily delay notifications by
         // sending repeated 2FA attempts to reset the timer.
-        let existing = Self::find_by_user_and_device(user_uuid, device_uuid, conn);
+        let existing = Self::find_by_user_and_device(user_uuid, device_uuid, conn).await;
         if existing.is_some() {
             return Ok(());
         }
@@ -55,15 +55,15 @@ impl TwoFactorIncomplete {
         }}
     }
 
-    pub fn mark_complete(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn mark_complete(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> EmptyResult {
         if CONFIG.incomplete_2fa_time_limit() <= 0 || !CONFIG.mail_enabled() {
             return Ok(());
         }
 
-        Self::delete_by_user_and_device(user_uuid, device_uuid, conn)
+        Self::delete_by_user_and_device(user_uuid, device_uuid, conn).await
     }
 
-    pub fn find_by_user_and_device(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_user_and_device(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! { conn: {
             twofactor_incomplete::table
                 .filter(twofactor_incomplete::user_uuid.eq(user_uuid))
@@ -74,7 +74,7 @@ impl TwoFactorIncomplete {
         }}
     }
 
-    pub fn find_logins_before(dt: &NaiveDateTime, conn: &DbConn) -> Vec<Self> {
+    pub async fn find_logins_before(dt: &NaiveDateTime, conn: &DbConn) -> Vec<Self> {
         db_run! {conn: {
             twofactor_incomplete::table
                 .filter(twofactor_incomplete::login_time.lt(dt))
@@ -84,11 +84,11 @@ impl TwoFactorIncomplete {
         }}
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
-        Self::delete_by_user_and_device(&self.user_uuid, &self.device_uuid, conn)
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
+        Self::delete_by_user_and_device(&self.user_uuid, &self.device_uuid, conn).await
     }
 
-    pub fn delete_by_user_and_device(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_by_user_and_device(user_uuid: &str, device_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(twofactor_incomplete::table
                            .filter(twofactor_incomplete::user_uuid.eq(user_uuid))
@@ -98,7 +98,7 @@ impl TwoFactorIncomplete {
         }}
     }
 
-    pub fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+    pub async fn delete_all_by_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
         db_run! { conn: {
             diesel::delete(twofactor_incomplete::table.filter(twofactor_incomplete::user_uuid.eq(user_uuid)))
                 .execute(conn)

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -192,12 +192,20 @@ use crate::db::DbConn;
 use crate::api::EmptyResult;
 use crate::error::MapResult;
 
+use futures::{stream, stream::StreamExt};
+
 /// Database methods
 impl User {
-    pub fn to_json(&self, conn: &DbConn) -> Value {
-        let orgs = UserOrganization::find_confirmed_by_user(&self.uuid, conn);
-        let orgs_json: Vec<Value> = orgs.iter().map(|c| c.to_json(conn)).collect();
-        let twofactor_enabled = !TwoFactor::find_by_user(&self.uuid, conn).is_empty();
+    pub async fn to_json(&self, conn: &DbConn) -> Value {
+        let orgs_json = stream::iter(UserOrganization::find_confirmed_by_user(&self.uuid, conn).await)
+            .then(|c| async {
+                let c = c; // Move out this single variable
+                c.to_json(conn).await
+            })
+            .collect::<Vec<Value>>()
+            .await;
+
+        let twofactor_enabled = !TwoFactor::find_by_user(&self.uuid, conn).await.is_empty();
 
         // TODO: Might want to save the status field in the DB
         let status = if self.password_hash.is_empty() {
@@ -227,7 +235,7 @@ impl User {
         })
     }
 
-    pub fn save(&mut self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
         if self.email.trim().is_empty() {
             err!("User email can't be empty")
         }
@@ -265,26 +273,26 @@ impl User {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
-        for user_org in UserOrganization::find_confirmed_by_user(&self.uuid, conn) {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
+        for user_org in UserOrganization::find_confirmed_by_user(&self.uuid, conn).await {
             if user_org.atype == UserOrgType::Owner {
                 let owner_type = UserOrgType::Owner as i32;
-                if UserOrganization::find_by_org_and_type(&user_org.org_uuid, owner_type, conn).len() <= 1 {
+                if UserOrganization::find_by_org_and_type(&user_org.org_uuid, owner_type, conn).await.len() <= 1 {
                     err!("Can't delete last owner")
                 }
             }
         }
 
-        Send::delete_all_by_user(&self.uuid, conn)?;
-        EmergencyAccess::delete_all_by_user(&self.uuid, conn)?;
-        UserOrganization::delete_all_by_user(&self.uuid, conn)?;
-        Cipher::delete_all_by_user(&self.uuid, conn)?;
-        Favorite::delete_all_by_user(&self.uuid, conn)?;
-        Folder::delete_all_by_user(&self.uuid, conn)?;
-        Device::delete_all_by_user(&self.uuid, conn)?;
-        TwoFactor::delete_all_by_user(&self.uuid, conn)?;
-        TwoFactorIncomplete::delete_all_by_user(&self.uuid, conn)?;
-        Invitation::take(&self.email, conn); // Delete invitation if any
+        Send::delete_all_by_user(&self.uuid, conn).await?;
+        EmergencyAccess::delete_all_by_user(&self.uuid, conn).await?;
+        UserOrganization::delete_all_by_user(&self.uuid, conn).await?;
+        Cipher::delete_all_by_user(&self.uuid, conn).await?;
+        Favorite::delete_all_by_user(&self.uuid, conn).await?;
+        Folder::delete_all_by_user(&self.uuid, conn).await?;
+        Device::delete_all_by_user(&self.uuid, conn).await?;
+        TwoFactor::delete_all_by_user(&self.uuid, conn).await?;
+        TwoFactorIncomplete::delete_all_by_user(&self.uuid, conn).await?;
+        Invitation::take(&self.email, conn).await; // Delete invitation if any
 
         db_run! {conn: {
             diesel::delete(users::table.filter(users::uuid.eq(self.uuid)))
@@ -293,13 +301,13 @@ impl User {
         }}
     }
 
-    pub fn update_uuid_revision(uuid: &str, conn: &DbConn) {
-        if let Err(e) = Self::_update_revision(uuid, &Utc::now().naive_utc(), conn) {
+    pub async fn update_uuid_revision(uuid: &str, conn: &DbConn) {
+        if let Err(e) = Self::_update_revision(uuid, &Utc::now().naive_utc(), conn).await {
             warn!("Failed to update revision for {}: {:#?}", uuid, e);
         }
     }
 
-    pub fn update_all_revisions(conn: &DbConn) -> EmptyResult {
+    pub async fn update_all_revisions(conn: &DbConn) -> EmptyResult {
         let updated_at = Utc::now().naive_utc();
 
         db_run! {conn: {
@@ -312,13 +320,13 @@ impl User {
         }}
     }
 
-    pub fn update_revision(&mut self, conn: &DbConn) -> EmptyResult {
+    pub async fn update_revision(&mut self, conn: &DbConn) -> EmptyResult {
         self.updated_at = Utc::now().naive_utc();
 
-        Self::_update_revision(&self.uuid, &self.updated_at, conn)
+        Self::_update_revision(&self.uuid, &self.updated_at, conn).await
     }
 
-    fn _update_revision(uuid: &str, date: &NaiveDateTime, conn: &DbConn) -> EmptyResult {
+    async fn _update_revision(uuid: &str, date: &NaiveDateTime, conn: &DbConn) -> EmptyResult {
         db_run! {conn: {
             crate::util::retry(|| {
                 diesel::update(users::table.filter(users::uuid.eq(uuid)))
@@ -329,7 +337,7 @@ impl User {
         }}
     }
 
-    pub fn find_by_mail(mail: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_mail(mail: &str, conn: &DbConn) -> Option<Self> {
         let lower_mail = mail.to_lowercase();
         db_run! {conn: {
             users::table
@@ -340,20 +348,20 @@ impl User {
         }}
     }
 
-    pub fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_uuid(uuid: &str, conn: &DbConn) -> Option<Self> {
         db_run! {conn: {
             users::table.filter(users::uuid.eq(uuid)).first::<UserDb>(conn).ok().from_db()
         }}
     }
 
-    pub fn get_all(conn: &DbConn) -> Vec<Self> {
+    pub async fn get_all(conn: &DbConn) -> Vec<Self> {
         db_run! {conn: {
             users::table.load::<UserDb>(conn).expect("Error loading users").from_db()
         }}
     }
 
-    pub fn last_active(&self, conn: &DbConn) -> Option<NaiveDateTime> {
-        match Device::find_latest_active_by_user(&self.uuid, conn) {
+    pub async fn last_active(&self, conn: &DbConn) -> Option<NaiveDateTime> {
+        match Device::find_latest_active_by_user(&self.uuid, conn).await {
             Some(device) => Some(device.updated_at),
             None => None,
         }
@@ -368,7 +376,7 @@ impl Invitation {
         }
     }
 
-    pub fn save(&self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         if self.email.trim().is_empty() {
             err!("Invitation email can't be empty")
         }
@@ -393,7 +401,7 @@ impl Invitation {
         }
     }
 
-    pub fn delete(self, conn: &DbConn) -> EmptyResult {
+    pub async fn delete(self, conn: &DbConn) -> EmptyResult {
         db_run! {conn: {
             diesel::delete(invitations::table.filter(invitations::email.eq(self.email)))
                 .execute(conn)
@@ -401,7 +409,7 @@ impl Invitation {
         }}
     }
 
-    pub fn find_by_mail(mail: &str, conn: &DbConn) -> Option<Self> {
+    pub async fn find_by_mail(mail: &str, conn: &DbConn) -> Option<Self> {
         let lower_mail = mail.to_lowercase();
         db_run! {conn: {
             invitations::table
@@ -412,9 +420,9 @@ impl Invitation {
         }}
     }
 
-    pub fn take(mail: &str, conn: &DbConn) -> bool {
-        match Self::find_by_mail(mail, conn) {
-            Some(invitation) => invitation.delete(conn).is_ok(),
+    pub async fn take(mail: &str, conn: &DbConn) -> bool {
+        match Self::find_by_mail(mail, conn).await {
+            Some(invitation) => invitation.delete(conn).await.is_ok(),
             None => false,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,7 @@ use lettre::transport::smtp::Error as SmtpErr;
 use openssl::error::ErrorStack as SSLErr;
 use regex::Error as RegexErr;
 use reqwest::Error as ReqErr;
+use rocket::error::Error as RocketErr;
 use serde_json::{Error as SerdeErr, Value};
 use std::io::Error as IoErr;
 use std::time::SystemTimeError as TimeErr;
@@ -84,6 +85,7 @@ make_error! {
     Address(AddrErr):  _has_source, _api_error,
     Smtp(SmtpErr):     _has_source, _api_error,
     OpenSSL(SSLErr):   _has_source, _api_error,
+    Rocket(RocketErr): _has_source, _api_error,
 
     DieselCon(DieselConErr): _has_source, _api_error,
     DieselMig(DieselMigErr): _has_source, _api_error,
@@ -193,8 +195,8 @@ use rocket::http::{ContentType, Status};
 use rocket::request::Request;
 use rocket::response::{self, Responder, Response};
 
-impl<'r> Responder<'r> for Error {
-    fn respond_to(self, _: &Request) -> response::Result<'r> {
+impl<'r> Responder<'r, 'static> for Error {
+    fn respond_to(self, _: &Request) -> response::Result<'static> {
         match self.error {
             ErrorKind::Empty(_) => {}  // Don't print the error in this situation
             ErrorKind::Simple(_) => {} // Don't print the error in this situation
@@ -202,8 +204,8 @@ impl<'r> Responder<'r> for Error {
         };
 
         let code = Status::from_code(self.error_code).unwrap_or(Status::BadRequest);
-
-        Response::build().status(code).header(ContentType::JSON).sized_body(Cursor::new(format!("{}", self))).ok()
+        let body = self.to_string();
+        Response::build().status(code).header(ContentType::JSON).sized_body(Some(body.len()), Cursor::new(body)).ok()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ macro_rules! make_error {
             }
         }
         impl std::fmt::Display for Error {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match &self.error {$(
                    ErrorKind::$name(e) => f.write_str(&$usr_msg_fun(e, &self.message)),
                 )+}
@@ -93,7 +93,7 @@ make_error! {
 }
 
 impl std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.source() {
             Some(e) => write!(f, "{}.\n[CAUSE] {:#?}", self.message, e),
             None => match self.error {
@@ -196,7 +196,7 @@ use rocket::request::Request;
 use rocket::response::{self, Responder, Response};
 
 impl<'r> Responder<'r, 'static> for Error {
-    fn respond_to(self, _: &Request) -> response::Result<'static> {
+    fn respond_to(self, _: &Request<'_>) -> response::Result<'static> {
         match self.error {
             ErrorKind::Empty(_) => {}  // Don't print the error in this situation
             ErrorKind::Simple(_) => {} // Don't print the error in this situation

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,15 @@ extern crate diesel;
 #[macro_use]
 extern crate diesel_migrations;
 
-use job_scheduler::{Job, JobScheduler};
-use std::{fs::create_dir_all, panic, path::Path, process::exit, str::FromStr, thread, time::Duration};
+use std::{
+    fs::{canonicalize, create_dir_all},
+    panic,
+    path::Path,
+    process::exit,
+    str::FromStr,
+    thread,
+    time::Duration,
+};
 
 #[macro_use]
 mod error;
@@ -37,9 +44,11 @@ mod util;
 
 pub use config::CONFIG;
 pub use error::{Error, MapResult};
+use rocket::data::{Limits, ToByteUnit};
 pub use util::is_running_in_docker;
 
-fn main() {
+#[rocket::main]
+async fn main() -> Result<(), Error> {
     parse_args();
     launch_info();
 
@@ -56,13 +65,16 @@ fn main() {
     });
     check_web_vault();
 
-    create_icon_cache_folder();
+    create_dir(&CONFIG.icon_cache_folder(), "icon cache");
+    create_dir(&CONFIG.tmp_folder(), "tmp folder");
+    create_dir(&CONFIG.sends_folder(), "sends folder");
+    create_dir(&CONFIG.attachments_folder(), "attachments folder");
 
     let pool = create_db_pool();
-    schedule_jobs(pool.clone());
-    crate::db::models::TwoFactor::migrate_u2f_to_webauthn(&pool.get().unwrap()).unwrap();
+    schedule_jobs(pool.clone()).await;
+    crate::db::models::TwoFactor::migrate_u2f_to_webauthn(&pool.get().await.unwrap()).unwrap();
 
-    launch_rocket(pool, extra_debug); // Blocks until program termination.
+    launch_rocket(pool, extra_debug).await // Blocks until program termination.
 }
 
 const HELP: &str = "\
@@ -127,10 +139,12 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         .level_for("hyper::server", log::LevelFilter::Warn)
         // Silence rocket logs
         .level_for("_", log::LevelFilter::Off)
-        .level_for("launch", log::LevelFilter::Off)
-        .level_for("launch_", log::LevelFilter::Off)
-        .level_for("rocket::rocket", log::LevelFilter::Off)
-        .level_for("rocket::fairing", log::LevelFilter::Off)
+        .level_for("rocket::launch", log::LevelFilter::Error)
+        .level_for("rocket::launch_", log::LevelFilter::Error)
+        .level_for("rocket::rocket", log::LevelFilter::Warn)
+        .level_for("rocket::server", log::LevelFilter::Warn)
+        .level_for("rocket::fairing::fairings", log::LevelFilter::Warn)
+        .level_for("rocket::shield::shield", log::LevelFilter::Warn)
         // Never show html5ever and hyper::proto logs, too noisy
         .level_for("html5ever", log::LevelFilter::Off)
         .level_for("hyper::proto", log::LevelFilter::Off)
@@ -243,10 +257,6 @@ fn create_dir(path: &str, description: &str) {
     create_dir_all(path).expect(&err_msg);
 }
 
-fn create_icon_cache_folder() {
-    create_dir(&CONFIG.icon_cache_folder(), "icon cache");
-}
-
 fn check_data_folder() {
     let data_folder = &CONFIG.data_folder();
     let path = Path::new(data_folder);
@@ -314,51 +324,73 @@ fn create_db_pool() -> db::DbPool {
     }
 }
 
-fn launch_rocket(pool: db::DbPool, extra_debug: bool) {
+async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error> {
     let basepath = &CONFIG.domain_path();
+
+    let mut config = rocket::Config::from(rocket::Config::figment());
+    config.address = std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED); // TODO: Allow this to be changed, keep ROCKET_ADDRESS for compat
+    config.temp_dir = canonicalize(CONFIG.tmp_folder()).unwrap().into();
+    config.limits = Limits::new() //
+        .limit("json", 10.megabytes())
+        .limit("data-form", 150.megabytes())
+        .limit("file", 150.megabytes());
 
     // If adding more paths here, consider also adding them to
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log
-    let result = rocket::ignite()
-        .mount(&[basepath, "/"].concat(), api::web_routes())
-        .mount(&[basepath, "/api"].concat(), api::core_routes())
-        .mount(&[basepath, "/admin"].concat(), api::admin_routes())
-        .mount(&[basepath, "/identity"].concat(), api::identity_routes())
-        .mount(&[basepath, "/icons"].concat(), api::icons_routes())
-        .mount(&[basepath, "/notifications"].concat(), api::notifications_routes())
+    let instance = rocket::custom(config)
+        .mount([basepath, "/"].concat(), api::web_routes())
+        .mount([basepath, "/api"].concat(), api::core_routes())
+        .mount([basepath, "/admin"].concat(), api::admin_routes())
+        .mount([basepath, "/identity"].concat(), api::identity_routes())
+        .mount([basepath, "/icons"].concat(), api::icons_routes())
+        .mount([basepath, "/notifications"].concat(), api::notifications_routes())
         .manage(pool)
         .manage(api::start_notification_server())
         .attach(util::AppHeaders())
         .attach(util::Cors())
         .attach(util::BetterLogging(extra_debug))
-        .launch();
+        .ignite()
+        .await?;
 
-    // Launch and print error if there is one
-    // The launch will restore the original logging level
-    error!("Launch error {:#?}", result);
+    CONFIG.set_rocket_shutdown_handle(instance.shutdown());
+    ctrlc::set_handler(move || {
+        info!("Exiting vaultwarden!");
+        CONFIG.shutdown();
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    instance.launch().await?;
+
+    info!("Vaultwarden process exited!");
+    Ok(())
 }
 
-fn schedule_jobs(pool: db::DbPool) {
+async fn schedule_jobs(pool: db::DbPool) {
     if CONFIG.job_poll_interval_ms() == 0 {
         info!("Job scheduler disabled.");
         return;
     }
+
+    let runtime = tokio::runtime::Handle::current();
+
     thread::Builder::new()
         .name("job-scheduler".to_string())
         .spawn(move || {
+            use job_scheduler::{Job, JobScheduler};
+
             let mut sched = JobScheduler::new();
 
             // Purge sends that are past their deletion date.
             if !CONFIG.send_purge_schedule().is_empty() {
                 sched.add(Job::new(CONFIG.send_purge_schedule().parse().unwrap(), || {
-                    api::purge_sends(pool.clone());
+                    runtime.spawn(api::purge_sends(pool.clone()));
                 }));
             }
 
             // Purge trashed items that are old enough to be auto-deleted.
             if !CONFIG.trash_purge_schedule().is_empty() {
                 sched.add(Job::new(CONFIG.trash_purge_schedule().parse().unwrap(), || {
-                    api::purge_trashed_ciphers(pool.clone());
+                    runtime.spawn(api::purge_trashed_ciphers(pool.clone()));
                 }));
             }
 
@@ -366,7 +398,7 @@ fn schedule_jobs(pool: db::DbPool) {
             // indicates that a user's master password has been compromised.
             if !CONFIG.incomplete_2fa_schedule().is_empty() {
                 sched.add(Job::new(CONFIG.incomplete_2fa_schedule().parse().unwrap(), || {
-                    api::send_incomplete_2fa_notifications(pool.clone());
+                    runtime.spawn(api::send_incomplete_2fa_notifications(pool.clone()));
                 }));
             }
 
@@ -375,7 +407,7 @@ fn schedule_jobs(pool: db::DbPool) {
             // sending reminders for requests that are about to be granted anyway.
             if !CONFIG.emergency_request_timeout_schedule().is_empty() {
                 sched.add(Job::new(CONFIG.emergency_request_timeout_schedule().parse().unwrap(), || {
-                    api::emergency_request_timeout_job(pool.clone());
+                    runtime.spawn(api::emergency_request_timeout_job(pool.clone()));
                 }));
             }
 
@@ -383,7 +415,7 @@ fn schedule_jobs(pool: db::DbPool) {
             // emergency access requests.
             if !CONFIG.emergency_notification_reminder_schedule().is_empty() {
                 sched.add(Job::new(CONFIG.emergency_notification_reminder_schedule().parse().unwrap(), || {
-                    api::emergency_notification_reminder_job(pool.clone());
+                    runtime.spawn(api::emergency_notification_reminder_job(pool.clone()));
                 }));
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+// #![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
 #![cfg_attr(feature = "unstable", feature(ip))]
 // The recursion_limit is mainly triggered by the json!() macro.
 // The more key/value pairs there are the more recursion occurs.
@@ -72,7 +74,7 @@ async fn main() -> Result<(), Error> {
 
     let pool = create_db_pool();
     schedule_jobs(pool.clone()).await;
-    crate::db::models::TwoFactor::migrate_u2f_to_webauthn(&pool.get().await.unwrap()).unwrap();
+    crate::db::models::TwoFactor::migrate_u2f_to_webauthn(&pool.get().await.unwrap()).await.unwrap();
 
     launch_rocket(pool, extra_debug).await // Blocks until program termination.
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-// #![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![warn(rust_2021_compatibility)]
 #![cfg_attr(feature = "unstable", feature(ip))]
 // The recursion_limit is mainly triggered by the json!() macro.
@@ -8,7 +8,6 @@
 // If you go above 128 it will cause rust-analyzer to fail,
 #![recursion_limit = "87"]
 
-extern crate openssl;
 #[macro_use]
 extern crate rocket;
 #[macro_use]

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,10 +5,10 @@ use std::io::Cursor;
 
 use rocket::{
     fairing::{Fairing, Info, Kind},
-    http::{ContentType, Header, HeaderMap, Method, RawStr, Status},
+    http::{ContentType, Header, HeaderMap, Method, Status},
     request::FromParam,
     response::{self, Responder},
-    Data, Request, Response, Rocket,
+    Data, Orbit, Request, Response, Rocket,
 };
 
 use std::thread::sleep;
@@ -18,6 +18,7 @@ use crate::CONFIG;
 
 pub struct AppHeaders();
 
+#[rocket::async_trait]
 impl Fairing for AppHeaders {
     fn info(&self) -> Info {
         Info {
@@ -26,7 +27,7 @@ impl Fairing for AppHeaders {
         }
     }
 
-    fn on_response(&self, _req: &Request, res: &mut Response) {
+    async fn on_response<'r>(&self, _req: &'r Request<'_>, res: &mut Response<'r>) {
         res.set_raw_header("Permissions-Policy", "accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), sync-xhr=(self \"https://haveibeenpwned.com\" \"https://2fa.directory\"), usb=(), vr=()");
         res.set_raw_header("Referrer-Policy", "same-origin");
         res.set_raw_header("X-Frame-Options", "SAMEORIGIN");
@@ -72,6 +73,7 @@ impl Cors {
     }
 }
 
+#[rocket::async_trait]
 impl Fairing for Cors {
     fn info(&self) -> Info {
         Info {
@@ -80,7 +82,7 @@ impl Fairing for Cors {
         }
     }
 
-    fn on_response(&self, request: &Request, response: &mut Response) {
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         let req_headers = request.headers();
 
         if let Some(origin) = Cors::get_allowed_origin(req_headers) {
@@ -97,7 +99,7 @@ impl Fairing for Cors {
             response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
             response.set_status(Status::Ok);
             response.set_header(ContentType::Plain);
-            response.set_sized_body(Cursor::new(""));
+            response.set_sized_body(Some(0), Cursor::new(""));
         }
     }
 }
@@ -134,25 +136,21 @@ impl<R> Cached<R> {
     }
 }
 
-impl<'r, R: Responder<'r>> Responder<'r> for Cached<R> {
-    fn respond_to(self, req: &Request) -> response::Result<'r> {
+impl<'r, R: 'r + Responder<'r, 'static> + Send> Responder<'r, 'static> for Cached<R> {
+    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'static> {
+        let mut res = self.response.respond_to(request)?;
+
         let cache_control_header = if self.is_immutable {
             format!("public, immutable, max-age={}", self.ttl)
         } else {
             format!("public, max-age={}", self.ttl)
         };
+        res.set_raw_header("Cache-Control", cache_control_header);
 
         let time_now = chrono::Local::now();
-
-        match self.response.respond_to(req) {
-            Ok(mut res) => {
-                res.set_raw_header("Cache-Control", cache_control_header);
-                let expiry_time = time_now + chrono::Duration::seconds(self.ttl.try_into().unwrap());
-                res.set_raw_header("Expires", format_datetime_http(&expiry_time));
-                Ok(res)
-            }
-            e @ Err(_) => e,
-        }
+        let expiry_time = time_now + chrono::Duration::seconds(self.ttl.try_into().unwrap());
+        res.set_raw_header("Expires", format_datetime_http(&expiry_time));
+        Ok(res)
     }
 }
 
@@ -175,11 +173,9 @@ impl<'r> FromParam<'r> for SafeString {
     type Error = ();
 
     #[inline(always)]
-    fn from_param(param: &'r RawStr) -> Result<Self, Self::Error> {
-        let s = param.percent_decode().map(|cow| cow.into_owned()).map_err(|_| ())?;
-
-        if s.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' |'0'..='9' | '-')) {
-            Ok(SafeString(s))
+    fn from_param(param: &'r str) -> Result<Self, Self::Error> {
+        if param.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' |'0'..='9' | '-')) {
+            Ok(SafeString(param.to_string()))
         } else {
             Err(())
         }
@@ -193,15 +189,16 @@ const LOGGED_ROUTES: [&str; 6] =
 
 // Boolean is extra debug, when true, we ignore the whitelist above and also print the mounts
 pub struct BetterLogging(pub bool);
+#[rocket::async_trait]
 impl Fairing for BetterLogging {
     fn info(&self) -> Info {
         Info {
             name: "Better Logging",
-            kind: Kind::Launch | Kind::Request | Kind::Response,
+            kind: Kind::Liftoff | Kind::Request | Kind::Response,
         }
     }
 
-    fn on_launch(&self, rocket: &Rocket) {
+    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
         if self.0 {
             info!(target: "routes", "Routes loaded:");
             let mut routes: Vec<_> = rocket.routes().collect();
@@ -225,34 +222,36 @@ impl Fairing for BetterLogging {
         info!(target: "start", "Rocket has launched from {}", addr);
     }
 
-    fn on_request(&self, request: &mut Request<'_>, _data: &Data) {
+    async fn on_request(&self, request: &mut Request<'_>, _data: &mut Data<'_>) {
         let method = request.method();
         if !self.0 && method == Method::Options {
             return;
         }
         let uri = request.uri();
         let uri_path = uri.path();
-        let uri_subpath = uri_path.strip_prefix(&CONFIG.domain_path()).unwrap_or(uri_path);
+        let uri_path_str = uri_path.url_decode_lossy();
+        let uri_subpath = uri_path_str.strip_prefix(&CONFIG.domain_path()).unwrap_or(&uri_path_str);
         if self.0 || LOGGED_ROUTES.iter().any(|r| uri_subpath.starts_with(r)) {
             match uri.query() {
-                Some(q) => info!(target: "request", "{} {}?{}", method, uri_path, &q[..q.len().min(30)]),
-                None => info!(target: "request", "{} {}", method, uri_path),
+                Some(q) => info!(target: "request", "{} {}?{}", method, uri_path_str, &q[..q.len().min(30)]),
+                None => info!(target: "request", "{} {}", method, uri_path_str),
             };
         }
     }
 
-    fn on_response(&self, request: &Request, response: &mut Response) {
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
         if !self.0 && request.method() == Method::Options {
             return;
         }
         let uri_path = request.uri().path();
-        let uri_subpath = uri_path.strip_prefix(&CONFIG.domain_path()).unwrap_or(uri_path);
+        let uri_path_str = uri_path.url_decode_lossy();
+        let uri_subpath = uri_path_str.strip_prefix(&CONFIG.domain_path()).unwrap_or(&uri_path_str);
         if self.0 || LOGGED_ROUTES.iter().any(|r| uri_subpath.starts_with(r)) {
             let status = response.status();
-            if let Some(route) = request.route() {
-                info!(target: "response", "{} => {} {}", route, status.code, status.reason)
+            if let Some(ref route) = request.route() {
+                info!(target: "response", "{} => {}", route, status)
             } else {
-                info!(target: "response", "{} {}", status.code, status.reason)
+                info!(target: "response", "{}", status)
             }
         }
     }
@@ -614,10 +613,7 @@ where
     }
 }
 
-use reqwest::{
-    blocking::{Client, ClientBuilder},
-    header,
-};
+use reqwest::{header, Client, ClientBuilder};
 
 pub fn get_reqwest_client() -> Client {
     get_reqwest_client_builder().build().expect("Failed to build client")

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,7 +52,7 @@ impl Fairing for AppHeaders {
 pub struct Cors();
 
 impl Cors {
-    fn get_header(headers: &HeaderMap, name: &str) -> String {
+    fn get_header(headers: &HeaderMap<'_>, name: &str) -> String {
         match headers.get_one(name) {
             Some(h) => h.to_string(),
             _ => "".to_string(),
@@ -61,7 +61,7 @@ impl Cors {
 
     // Check a request's `Origin` header against the list of allowed origins.
     // If a match exists, return it. Otherwise, return None.
-    fn get_allowed_origin(headers: &HeaderMap) -> Option<String> {
+    fn get_allowed_origin(headers: &HeaderMap<'_>) -> Option<String> {
         let origin = Cors::get_header(headers, "Origin");
         let domain_origin = CONFIG.domain_origin();
         let safari_extension_origin = "file://";
@@ -157,7 +157,7 @@ impl<'r, R: 'r + Responder<'r, 'static> + Send> Responder<'r, 'static> for Cache
 pub struct SafeString(String);
 
 impl std::fmt::Display for SafeString {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -500,7 +500,7 @@ struct UpCaseVisitor;
 impl<'de> Visitor<'de> for UpCaseVisitor {
     type Value = Value;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("an object or an array")
     }
 


### PR DESCRIPTION
Rebased on top of the latest changes in main.

Seeing as there is no release of a final Rocket 0.5 in the near future, I think it's time to consider merging this as it's a big patch and hard to keep in sync.

There shouldn't be any major breaking changes, but Rocket 0.5 brings a new configuration system so that might break things for users depending on them. That said, the ones in use by most people (ROCKET_ADDRESS, ROCKET_PORT and ROCKET_TLS) are the same as before. ROCKET_ENV has changed to ROCKET_PROFILE, so anyone using that must update their config.

The file uploads are now also handled by rocket directly, and uploaded to a configurable temp directory first, before being moved to the attachments or sends folder. We should document that the temp directory and the attachments and sends folder must be in the same partition/mount point, otherwise the file move will fail.

Also I just noticed that I'm hardcoding the listen address to 0.0.0.0, I will change that before pushing.

### Pending changes:
- [ ] Remove hardcoded listen address from main()
- [ ] Remove ROCKET_ENV from docker images if still present, make sure the listen address is set to 0.0.0.0 and the port is set correctly
- [ ] Check if the default address and port config when running the binary directly are the same, otherwise handle that in code to avoid breaking any builds depending on the default values.