### PR TITLE
Add support for custom .env file path

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,11 @@
 ##
 ## Be aware that most of these settings will be overridden if they were changed
 ## in the admin interface. Those overrides are stored within DATA_FOLDER/config.json .
+##
+## By default, vaultwarden expects for this file to be named ".env" and located
+## in the current working directory. If this is not the case, the environment
+## variable ENV_FILE can be set to the location of this file prior to starting
+## vaultwarden.
 
 ## Main data folder
 # DATA_FOLDER=data

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ macro_rules! make_config {
         impl ConfigBuilder {
             #[allow(clippy::field_reassign_with_default)]
             fn from_env() -> Self {
-                match dotenv::from_path(".env") {
+                match dotenv::from_path(get_env("ENV_FILE").unwrap_or_else(|| String::from(".env"))) {
                     Ok(_) => (),
                     Err(e) => match e {
                         dotenv::Error::LineParse(msg, pos) => {


### PR DESCRIPTION
Hi! I'm working on packaging this for Void, and in writing the runit service, I came across an annoyance: since the `.env` file can't be in the current working directory, it won't find it and thus has to read from the environment variables directly. This *can* be done with something like:
```
#!/bin/sh
exec chpst -u _vaultwarden:_vaultwarden \
        env $(grep -v '^#' ${ENV_FILE:-/etc/vaultwarden.env} | xargs -d '\n') vaultwarden
```
But that is less than ideal IMO. This patch is a simple way to pass a single custom location where the env/config can be found.