### PR TITLE
disable legacy X-XSS-Protection feature

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -32,7 +32,8 @@ impl Fairing for AppHeaders {
         res.set_raw_header("Referrer-Policy", "same-origin");
         res.set_raw_header("X-Frame-Options", "SAMEORIGIN");
         res.set_raw_header("X-Content-Type-Options", "nosniff");
-        res.set_raw_header("X-XSS-Protection", "1; mode=block");
+        // Obsolete in modern browsers, unsafe (XS-Leak), and largely replaced by CSP
+        res.set_raw_header("X-XSS-Protection", "0");
         let csp = format!(
             // Chrome Web Store: https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb
             // Edge Add-ons: https://microsoftedge.microsoft.com/addons/detail/bitwarden-free-password/jbkfoedolllekgbhcbcoahefnbanhhlh?hl=en-US


### PR DESCRIPTION
Obsolete in modern browsers, unsafe, and largely replaced by CSP.

- [XS-Leak attacks](https://github.com/xsleaks/xsleaks/wiki/Links#annex-xss-filters-information-leaks)
- Removal of XSS auditor in [Chrome](https://chromestatus.com/feature/5021976655560704), [Edge ](https://blogs.windows.com/windows-insider/2018/07/25/announcing-windows-10-insider-preview-build-17723-and-build-18204/) and [Safari](https://bugs.webkit.org/show_bug.cgi?id=230499)

Since there are still [a few browsers using it](https://caniuse.com/mdn-http_headers_x-xss-protection), we should explicitly disable it for now to be on the safe side.