### PR TITLE
Fix building mimalloc on armv6

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -105,10 +105,9 @@ RUN {{ mount_rust_cache -}} mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
 {% if "alpine" in target_file %}
-ENV RUSTFLAGS='-C link-arg=-s'
-{%   if "armv7" in target_file %}
-{#- https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html -#}
-ENV CFLAGS_armv7_unknown_linux_musleabihf="-mfpu=vfpv3-d16"
+{%   if "armv6" in target_file %}
+# To be able to build the armv6 image with mimalloc we need to specifically specify the libatomic.a file location
+ENV RUSTFLAGS='-Clink-arg=/usr/local/musl/{{ package_arch_target }}/lib/libatomic.a'
 {%   endif %}
 {% elif "arm" in target_file %}
 #
@@ -163,7 +162,7 @@ RUN {{ mount_rust_cache -}} rustup target add {{ package_arch_target }}
 {% endif %}
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-{% if "alpine" in target_file and "amd64" in target_file %}
+{% if "alpine" in target_file %}
 # Enable MiMalloc to improve performance on Alpine builds
 ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 {% else %}

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -58,7 +57,8 @@ COPY ./build.rs ./build.rs
 RUN rustup target add aarch64-unknown-linux-musl
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/arm64/Dockerfile.buildx.alpine
+++ b/docker/arm64/Dockerfile.buildx.alpine
@@ -44,7 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -58,7 +57,8 @@ COPY ./build.rs ./build.rs
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry rustup target add aarch64-unknown-linux-musl
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -44,7 +44,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
+# To be able to build the armv6 image with mimalloc we need to specifically specify the libatomic.a file location
+ENV RUSTFLAGS='-Clink-arg=/usr/local/musl/arm-unknown-linux-musleabi/lib/libatomic.a'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -58,7 +59,8 @@ COPY ./build.rs ./build.rs
 RUN rustup target add arm-unknown-linux-musleabi
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/armv6/Dockerfile.buildx.alpine
+++ b/docker/armv6/Dockerfile.buildx.alpine
@@ -44,7 +44,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
+# To be able to build the armv6 image with mimalloc we need to specifically specify the libatomic.a file location
+ENV RUSTFLAGS='-Clink-arg=/usr/local/musl/arm-unknown-linux-musleabi/lib/libatomic.a'
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -58,7 +59,8 @@ COPY ./build.rs ./build.rs
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry rustup target add arm-unknown-linux-musleabi
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -44,8 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
-ENV CFLAGS_armv7_unknown_linux_musleabihf="-mfpu=vfpv3-d16"
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -59,7 +57,8 @@ COPY ./build.rs ./build.rs
 RUN rustup target add armv7-unknown-linux-musleabihf
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -44,8 +44,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry mkdir -pv "${CARGO_HOME}" \
     && rustup set profile minimal
 
-ENV RUSTFLAGS='-C link-arg=-s'
-ENV CFLAGS_armv7_unknown_linux_musleabihf="-mfpu=vfpv3-d16"
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -59,7 +57,8 @@ COPY ./build.rs ./build.rs
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry rustup target add armv7-unknown-linux-musleabihf
 
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder


### PR DESCRIPTION
The armv6 builds need a specific location for the libatomic.a file.
This commit fixes that by adding a RUSTFLAGS argument for this.

Also removed the `link-arg=-s` since this is now already done during via the release profile
And removed the CFLAGS for armv7, this is already fixed by default in the blackdex/rust-musl images.