### PR TITLE
Database connection init

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,6 +29,17 @@
 ## Define the size of the connection pool used for connecting to the database.
 # DATABASE_MAX_CONNS=10
 
+## Database connection initialization
+## Allows SQL statements to be run whenever a new database connection is created.
+## For example, this can be used to run connection-scoped pragma statements.
+##
+## Statements to run when creating a new SQLite connection
+# SQLITE_CONN_INIT=""
+## Statements to run when creating a new MySQL connection
+# MYSQL_CONN_INIT=""
+## Statements to run when creating a new PostgreSQL connection
+# POSTGRESQL_CONN_INIT=""
+
 ## Individual folders, these override %DATA_FOLDER%
 # RSA_KEY_FILENAME=data/rsa_key
 # ICON_CACHE_FOLDER=data/icon_cache

--- a/.env.template
+++ b/.env.template
@@ -34,7 +34,7 @@
 ## For example, this can be used to run connection-scoped pragma statements.
 ##
 ## Statements to run when creating a new SQLite connection
-# SQLITE_CONN_INIT=""
+# SQLITE_CONN_INIT="PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;"
 ## Statements to run when creating a new MySQL connection
 # MYSQL_CONN_INIT=""
 ## Statements to run when creating a new PostgreSQL connection

--- a/.env.template
+++ b/.env.template
@@ -31,14 +31,12 @@
 
 ## Database connection initialization
 ## Allows SQL statements to be run whenever a new database connection is created.
-## For example, this can be used to run connection-scoped pragma statements.
-##
-## Statements to run when creating a new SQLite connection
-# SQLITE_CONN_INIT="PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;"
-## Statements to run when creating a new MySQL connection
-# MYSQL_CONN_INIT=""
-## Statements to run when creating a new PostgreSQL connection
-# POSTGRESQL_CONN_INIT=""
+## This is mainly useful for connection-scoped pragmas.
+## If empty, a database-specific default is used:
+## - SQLite: "PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;"
+## - MySQL: ""
+## - PostgreSQL: ""
+# DATABASE_CONN_INIT=""
 
 ## Individual folders, these override %DATA_FOLDER%
 # RSA_KEY_FILENAME=data/rsa_key

--- a/src/config.rs
+++ b/src/config.rs
@@ -515,10 +515,19 @@ make_config! {
         db_connection_retries:  u32,    false,  def,    15;
 
         /// Timeout when aquiring database connection
-        database_timeout:     u64,    false,  def,    30;
+        database_timeout:       u64,    false,  def,    30;
 
         /// Database connection pool size
         database_max_conns:     u32,    false,  def,    10;
+
+        /// SQLite connection init |> Statements to run when creating a new SQLite connection
+        sqlite_conn_init:       String, false,  def,    "".to_string();
+
+        /// MySQL connection init |> Statements to run when creating a new MySQL connection
+        mysql_conn_init:        String, false,  def,    "".to_string();
+
+        /// PostgreSQL connection init |> Statements to run when creating a new PostgreSQL connection
+        postgresql_conn_init:   String, false,  def,    "".to_string();
 
         /// Bypass admin page security (Know the risks!) |> Disables the Admin Token for the admin page so you may use your own auth in-front
         disable_admin_token:    bool,   true,   def,    false;

--- a/src/config.rs
+++ b/src/config.rs
@@ -521,7 +521,7 @@ make_config! {
         database_max_conns:     u32,    false,  def,    10;
 
         /// SQLite connection init |> Statements to run when creating a new SQLite connection
-        sqlite_conn_init:       String, false,  def,    "".to_string();
+        sqlite_conn_init:       String, false,  def,    "PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;".to_string();
 
         /// MySQL connection init |> Statements to run when creating a new MySQL connection
         mysql_conn_init:        String, false,  def,    "".to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -520,14 +520,8 @@ make_config! {
         /// Database connection pool size
         database_max_conns:     u32,    false,  def,    10;
 
-        /// SQLite connection init |> Statements to run when creating a new SQLite connection
-        sqlite_conn_init:       String, false,  def,    "PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;".to_string();
-
-        /// MySQL connection init |> Statements to run when creating a new MySQL connection
-        mysql_conn_init:        String, false,  def,    "".to_string();
-
-        /// PostgreSQL connection init |> Statements to run when creating a new PostgreSQL connection
-        postgresql_conn_init:   String, false,  def,    "".to_string();
+        /// Database connection init |> SQL statements to run when creating a new database connection, mainly useful for connection-scoped pragmas. If empty, a database-specific default is used.
+        database_conn_init:     String, false,  def,    "".to_string();
 
         /// Bypass admin page security (Know the risks!) |> Disables the Admin Token for the admin page so you may use your own auth in-front
         disable_admin_token:    bool,   true,   def,    false;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
-use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+use diesel::{
+    connection::SimpleConnection,
+    r2d2::{ConnectionManager, CustomizeConnection, Pool, PooledConnection},
+};
+
 use rocket::{
     http::Status,
     outcome::IntoOutcome,
@@ -62,6 +66,23 @@ macro_rules! generate_connections {
         #[allow(non_camel_case_types)]
         pub enum DbConnInner { $( #[cfg($name)] $name(PooledConnection<ConnectionManager< $ty >>), )+ }
 
+        #[derive(Debug)]
+        pub struct DbConnOptions {
+            pub init_stmts: String,
+        }
+
+        $( // Based on <https://stackoverflow.com/a/57717533>.
+        #[cfg($name)]
+        impl CustomizeConnection<$ty, diesel::r2d2::Error> for DbConnOptions {
+            fn on_acquire(&self, conn: &mut $ty) -> Result<(), diesel::r2d2::Error> {
+                (|| {
+                    if !self.init_stmts.is_empty() {
+                        conn.batch_execute(&self.init_stmts)?;
+                    }
+                    Ok(())
+                })().map_err(diesel::r2d2::Error::QueryError)
+            }
+        })+
 
         #[derive(Clone)]
         pub struct DbPool {
@@ -103,7 +124,8 @@ macro_rules! generate_connections {
         }
 
         impl DbPool {
-            // For the given database URL, guess it's type, run migrations create pool and return it
+            // For the given database URL, guess its type, run migrations, create pool, and return it
+            #[allow(clippy::diverging_sub_expression)]
             pub fn from_config() -> Result<Self, Error> {
                 let url = CONFIG.database_url();
                 let conn_type = DbConnType::from_url(&url)?;
@@ -117,6 +139,9 @@ macro_rules! generate_connections {
                             let pool = Pool::builder()
                                 .max_size(CONFIG.database_max_conns())
                                 .connection_timeout(Duration::from_secs(CONFIG.database_timeout()))
+                                .connection_customizer(Box::new(DbConnOptions{
+                                    init_stmts: paste::paste!{ CONFIG. [< $name _conn_init >] () }
+                                }))
                                 .build(manager)
                                 .map_res("Failed to create pool")?;
                             return Ok(DbPool {


### PR DESCRIPTION
Adds support for database connection init statements. This is probably mainly useful for running connection-scoped pragma statements.

Also adds default connection-scoped pragmas for SQLite:

* [`PRAGMA busy_timeout = 5000`](https://www.sqlite.org/pragma.html#pragma_busy_timeout) tells SQLite to keep trying for up to 5000 ms when there is lock contention, rather than aborting immediately. This should hopefully prevent the vast majority of "database is locked" panics observed since the async transition, e.g.: #2436

* [`PRAGMA synchronous = NORMAL`](https://www.sqlite.org/pragma.html#pragma_synchronous) trades better performance for a small potential loss in durability (the default is `FULL`). The SQLite docs recommend `NORMAL` as "a good choice for most applications running in WAL mode".