### PR TITLE
Fix upload limits and disable color logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -336,10 +336,11 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
 
     let mut config = rocket::Config::from(rocket::Config::figment());
     config.temp_dir = canonicalize(CONFIG.tmp_folder()).unwrap().into();
-    config.limits = Limits::new() //
-        .limit("json", 10.megabytes())
-        .limit("data-form", 150.megabytes())
-        .limit("file", 150.megabytes());
+    config.cli_colors = false; // Make sure Rocket does not color any values for logging.
+    config.limits = Limits::new()
+        .limit("json", 20.megabytes()) // 20MB should be enough for very large imports, something like 5000+ vault entries
+        .limit("data-form", 525.megabytes()) // This needs to match the maximum allowed file size for Send
+        .limit("file", 525.megabytes()); // This needs to match the maximum allowed file size for attachments
 
     // If adding more paths here, consider also adding them to
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log


### PR DESCRIPTION
The limits for uploading files were to small in regards to the allowed
maximum filesize of the Bitwarden clients including the web-vault.
Changed both `data-form` (used for Send) and `file` (used for
attachments) to be 525MB, this is the same size we already check our selfs.

Also changed the `json` limit to be 20MB, this should allow very large
imports with 4000/5000+ items depending on if there are large notes or not.

And, also disabled Rocket from outputting colors, these colors were also
send to the log files and syslog. I think this changed in Rocket 0.5rc
somewhere, need to look a bit further into that maybe.