### PR TITLE
Update Rust version in Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
 
       # Upload artifact to Github Actions
       - name: Upload artifact
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: vaultwarden-${{ matrix.target-triple }}${{ matrix.ext }}
           path: target/${{ matrix.target-triple }}/release/vaultwarden${{ matrix.ext }}

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -3,22 +3,22 @@
 # This file was generated using a Jinja2 template.
 # Please make your changes in `Dockerfile.j2` and then `make` the individual Dockerfiles.
 
-{% set build_stage_base_image = "rust:1.60-bullseye" %}
+{% set build_stage_base_image = "rust:1.61-bullseye" %}
 {% if "alpine" in target_file %}
 {%   if "amd64" in target_file %}
-{%     set build_stage_base_image = "blackdex/rust-musl:x86_64-musl-stable" %}
+{%     set build_stage_base_image = "blackdex/rust-musl:x86_64-musl-stable-1.61.0" %}
 {%     set runtime_stage_base_image = "alpine:3.15" %}
 {%     set package_arch_target = "x86_64-unknown-linux-musl" %}
 {%   elif "armv7" in target_file %}
-{%     set build_stage_base_image = "blackdex/rust-musl:armv7-musleabihf-stable" %}
+{%     set build_stage_base_image = "blackdex/rust-musl:armv7-musleabihf-stable-1.61.0" %}
 {%     set runtime_stage_base_image = "balenalib/armv7hf-alpine:3.15" %}
 {%     set package_arch_target = "armv7-unknown-linux-musleabihf" %}
 {%   elif "armv6" in target_file %}
-{%     set build_stage_base_image = "blackdex/rust-musl:arm-musleabi-stable" %}
+{%     set build_stage_base_image = "blackdex/rust-musl:arm-musleabi-stable-1.61.0" %}
 {%     set runtime_stage_base_image = "balenalib/rpi-alpine:3.15" %}
 {%     set package_arch_target = "arm-unknown-linux-musleabi" %}
 {%   elif "arm64" in target_file %}
-{%     set build_stage_base_image = "blackdex/rust-musl:aarch64-musl-stable" %}
+{%     set build_stage_base_image = "blackdex/rust-musl:aarch64-musl-stable-1.61.0" %}
 {%     set runtime_stage_base_image = "balenalib/aarch64-alpine:3.15" %}
 {%     set package_arch_target = "aarch64-unknown-linux-musl" %}
 {%   endif %}

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:x86_64-musl-stable as build
+FROM blackdex/rust-musl:x86_64-musl-stable-1.61.0 as build
 
 
 

--- a/docker/amd64/Dockerfile.buildx
+++ b/docker/amd64/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:x86_64-musl-stable as build
+FROM blackdex/rust-musl:x86_64-musl-stable-1.61.0 as build
 
 
 

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:aarch64-musl-stable as build
+FROM blackdex/rust-musl:aarch64-musl-stable-1.61.0 as build
 
 
 

--- a/docker/arm64/Dockerfile.buildx
+++ b/docker/arm64/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/arm64/Dockerfile.buildx.alpine
+++ b/docker/arm64/Dockerfile.buildx.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:aarch64-musl-stable as build
+FROM blackdex/rust-musl:aarch64-musl-stable-1.61.0 as build
 
 
 

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:arm-musleabi-stable as build
+FROM blackdex/rust-musl:arm-musleabi-stable-1.61.0 as build
 
 
 

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/armv6/Dockerfile.buildx.alpine
+++ b/docker/armv6/Dockerfile.buildx.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:arm-musleabi-stable as build
+FROM blackdex/rust-musl:arm-musleabi-stable-1.61.0 as build
 
 
 

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:armv7-musleabihf-stable as build
+FROM blackdex/rust-musl:armv7-musleabihf-stable-1.61.0 as build
 
 
 

--- a/docker/armv7/Dockerfile.buildx
+++ b/docker/armv7/Dockerfile.buildx
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM rust:1.60-bullseye as build
+FROM rust:1.61-bullseye as build
 
 
 

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -27,7 +27,7 @@
 FROM vaultwarden/web-vault@sha256:df7f12b1e22bf0dfc1b6b6f46921b4e9e649561931ba65357c1eb1963514b3b5 as vault
 
 ########################## BUILD IMAGE  ##########################
-FROM blackdex/rust-musl:armv7-musleabihf-stable as build
+FROM blackdex/rust-musl:armv7-musleabihf-stable-1.61.0 as build
 
 
 


### PR DESCRIPTION
Updated Rust from v1.60 to v1.61 for building the images.
Also made the rust version fixed for the Alpine build images to prevent
those images being build with a newer version when released.