### PR TITLE
Add TMP_FOLDER to .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,6 +43,7 @@
 # ICON_CACHE_FOLDER=data/icon_cache
 # ATTACHMENTS_FOLDER=data/attachments
 # SENDS_FOLDER=data/sends
+# TMP_FOLDER=data/tmp
 
 ## Templates data folder, by default uses embedded templates
 ## Check source code to see the format


### PR DESCRIPTION
The TMP_FOLDER env variable is missing in .env.template.