### PR TITLE
Fix armv6 issue with bullseye images

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -93,12 +93,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME="/root/.cargo" \
     USER="root"
 
-{# {% if "alpine" not in target_file and "buildx" in target_file %}
-# Debian based Buildx builds can use some special apt caching to speedup building.
-# By default Debian based images have some rules to keep docker builds clean, we need to remove this.
-# See: https://hub.docker.com/r/docker/dockerfile
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-{% endif %} #}
 
 # Create CARGO_HOME folder and don't download rust docs
 RUN {{ mount_rust_cache -}} mkdir -pv "${CARGO_HOME}" \
@@ -226,6 +220,14 @@ RUN mkdir /data \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 {% endif %}
+
+{% if "armv6" in target_file and "alpine" not in target_file %}
+# In the Balena Bullseye images for armv6/rpi-debian there is a missing symlink.
+# This symlink was there in the buster images, and for some reason this is needed.
+# hadolint ignore=DL3059
+RUN ln -v -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
+
+{% endif -%}
 
 {% if "amd64" not in target_file %}
 # hadolint ignore=DL3059

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -129,6 +129,11 @@ RUN mkdir /data \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# In the Balena Bullseye images for armv6/rpi-debian there is a missing symlink.
+# This symlink was there in the buster images, and for some reason this is needed.
+# hadolint ignore=DL3059
+RUN ln -v -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
+
 # hadolint ignore=DL3059
 RUN [ "cross-build-end" ]
 

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -129,6 +129,11 @@ RUN mkdir /data \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# In the Balena Bullseye images for armv6/rpi-debian there is a missing symlink.
+# This symlink was there in the buster images, and for some reason this is needed.
+# hadolint ignore=DL3059
+RUN ln -v -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
+
 # hadolint ignore=DL3059
 RUN [ "cross-build-end" ]
 


### PR DESCRIPTION
It looks like the armv6 bullseye images are missing a symlink to the
dynamic linker. The previous buster images had this symlink there,
bullseye does not.

This PR fixes adds that symlink again for only the Debian armv6 build.

Resolves #2490