### PR TITLE
Prevent some ROCKET env variables to cause issues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,13 @@ macro_rules! make_config {
                     }
                 };
 
+                // Delete some old Rocket env variables which could cause issues and have no use for Vaultwarden.
+                std::env::remove_var("ROCKET_CLI_COLORS"); // This is disabled by default and could cause issues when set
+                std::env::remove_var("ROCKET_ENV"); // Vaultwarden configures sane defaults for this already
+                std::env::remove_var("ROCKET_PROFILE"); // Vaultwarden configures sane defaults for this already
+                std::env::remove_var("ROCKET_LOG"); // The log level is determined by Vaultwarden via LOG_LEVEL
+                std::env::remove_var("ROCKET_LOG_LEVEL"); // The log level is determined by Vaultwarden via LOG_LEVEL
+
                 let mut builder = ConfigBuilder::default();
                 $($(
                     builder.$name = make_config! { @getenv &stringify!($name).to_uppercase(), $ty };


### PR DESCRIPTION
Some ROCKET_ env variables can cause issues if they are set.
With the older Rocket v0.4.x this was not an issue.
But with Rocket v0.5.x some have changed and we control them in a
different way.

This PR removes/unset these variables to prevent errors during startup.
resolves #2482