### PR TITLE
Add Spanish version of USA healthcare.gov

### DIFF
--- a/src/static/global_domains.json
+++ b/src/static/global_domains.json
@@ -328,6 +328,7 @@
     "Type": 33,
     "Domains": [
       "healthcare.gov",
+      "cuidadodesalud.gov",
       "cms.gov"
     ],
     "Excluded": false


### PR DESCRIPTION
The site for USA health insurance has a totally separate base domain in Spanish