### PR TITLE
Bump lettre to 0.10.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,12 +770,19 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "email-encoding"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690291166824e467790ac08ba42f241791567e8337bbf00c5a6e87889629f98"
+checksum = "75b91dddc343e7eaa27f9764e5bffe57370d957017fdd75244f5045e829a8441"
 dependencies = [
  "base64",
+ "memchr",
 ]
+
+[[package]]
+name = "email_address"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8684b7c9cb4857dfa1e5b9629ef584ba618c9b93bae60f58cb23f4f271d0468e"
 
 [[package]]
 name = "encoding_rs"
@@ -1435,12 +1442,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6c70001f7ee6c93b6687a06607c7a38f9a7ae460139a496c23da21e95bc289"
+checksum = "0f7e87d9d44162eea7abd87b1a7540fcb10d5e58e8bb4f173178f3dc6e453944"
 dependencies = [
  "base64",
  "email-encoding",
+ "email_address",
  "fastrand",
  "hostname",
  "httpdate",
@@ -1450,8 +1458,8 @@ dependencies = [
  "nom",
  "once_cell",
  "quoted_printable",
- "regex",
  "serde",
+ "socket2 0.4.4",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ url = "2.2.2"
 
 # Email libraries
 idna = "0.2.3" # Punycode conversion
-lettre = { version = "0.10.0-rc.6", features = ["smtp-transport", "builder", "serde", "native-tls", "hostname", "tracing"], default-features = false }
+lettre = { version = "0.10.0-rc.7", features = ["smtp-transport", "builder", "serde", "native-tls", "hostname", "tracing"], default-features = false }
 percent-encoding = "2.1.0" # URL encoding library used for URL's in the emails
 
 # Template library


### PR DESCRIPTION
Fixes the last remaining header encoding issues

Diff: https://github.com/lettre/lettre/compare/v0.10.0-rc.6...v0.10.0-rc.7