### PR TITLE
Fix hidden ciphers within organizational view.

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -5,7 +5,10 @@ use serde_json::Value;
 use std::borrow::Borrow;
 
 use crate::{
-    api::{core::CipherSyncData, EmptyResult, JsonResult, JsonUpcase, NumberOrString},
+    api::{
+        core::{CipherSyncData, CipherSyncType},
+        EmptyResult, JsonResult, JsonUpcase, NumberOrString,
+    },
     auth::{decode_emergency_access_invite, Headers},
     db::{models::*, DbConn, DbPool},
     mail, CONFIG,
@@ -596,7 +599,8 @@ async fn view_emergency_access(emer_id: String, headers: Headers, conn: DbConn) 
     }
 
     let ciphers = Cipher::find_owned_by_user(&emergency_access.grantor_uuid, &conn).await;
-    let cipher_sync_data = CipherSyncData::new(&emergency_access.grantor_uuid, &ciphers, &conn).await;
+    let cipher_sync_data =
+        CipherSyncData::new(&emergency_access.grantor_uuid, &ciphers, CipherSyncType::User, &conn).await;
 
     let ciphers_json = stream::iter(ciphers)
         .then(|c| async {

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -7,7 +7,7 @@ mod sends;
 pub mod two_factor;
 
 pub use ciphers::purge_trashed_ciphers;
-pub use ciphers::CipherSyncData;
+pub use ciphers::{CipherSyncData, CipherSyncType};
 pub use emergency_access::{emergency_notification_reminder_job, emergency_request_timeout_job};
 pub use sends::purge_sends;
 pub use two_factor::send_incomplete_2fa_notifications;

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 
 use crate::{
     api::{
-        core::CipherSyncData, EmptyResult, JsonResult, JsonUpcase, JsonUpcaseVec, Notify, NumberOrString, PasswordData,
-        UpdateType,
+        core::{CipherSyncData, CipherSyncType},
+        EmptyResult, JsonResult, JsonUpcase, JsonUpcaseVec, Notify, NumberOrString, PasswordData, UpdateType,
     },
     auth::{decode_invite, AdminHeaders, Headers, ManagerHeaders, ManagerHeadersLoose, OwnerHeaders},
     db::{models::*, DbConn},
@@ -487,7 +487,7 @@ struct OrgIdData {
 #[get("/ciphers/organization-details?<data..>")]
 async fn get_org_details(data: OrgIdData, headers: Headers, conn: DbConn) -> Json<Value> {
     let ciphers = Cipher::find_by_org(&data.organization_id, &conn).await;
-    let cipher_sync_data = CipherSyncData::new(&headers.user.uuid, &ciphers, &conn).await;
+    let cipher_sync_data = CipherSyncData::new(&headers.user.uuid, &ciphers, CipherSyncType::Organization, &conn).await;
 
     let ciphers_json = stream::iter(ciphers)
         .then(|c| async {


### PR DESCRIPTION
This PR fixes #2566
If Organizational syncs returned a FolderId it would cause the web-vault
to hide the cipher because there is a FolderId set. Upstream seems to
not return FolderId and Favorite. When set to null/false it will behave
the same.

In this PR I have added a new CipherSyncType enum to select which type
of sync to execute, and return an empty list for both Folders and Favorites if this is for Orgs.
This also reduces the database load a bit since it will not execute those queries.