### PR TITLE
Small change in log-level for better debugging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         // Hide failed to close stream messages
         .level_for("hyper::server", log::LevelFilter::Warn)
         // Silence rocket logs
-        .level_for("_", log::LevelFilter::Off)
+        .level_for("_", log::LevelFilter::Warn)
         .level_for("rocket::launch", log::LevelFilter::Error)
         .level_for("rocket::launch_", log::LevelFilter::Error)
         .level_for("rocket::rocket", log::LevelFilter::Warn)


### PR DESCRIPTION
Regarding some recent issues with sending attachments, but previously
also some changes to the API for example which could cause a `400` error
it just returned that there is something wrong, but not to much details
on what exactly.

To help with getting a bit more detailed information, we should set the
log-level for `_` to at least `Warn`.