### PR TITLE
Address inconsistency v{version} with and without a v in the version with most recent updates. 

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -70,13 +70,13 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v{{ vault_version }}
-#     $ docker image inspect --format "{{ '{{' }}.RepoDigests}}" vaultwarden/web-vault:v{{ vault_version }}
+#     $ docker pull vaultwarden/web-vault:{{ vault_version }}
+#     $ docker image inspect --format "{{ '{{' }}.RepoDigests}}" vaultwarden/web-vault:{{ vault_version }}
 #     [vaultwarden/web-vault@{{ vault_image_digest }}]
 #
 # - Conversely, to get the tag name from the digest:
 #     $ docker image inspect --format "{{ '{{' }}.RepoTags}}" vaultwarden/web-vault@{{ vault_image_digest }}
-#     [vaultwarden/web-vault:v{{ vault_version }}]
+#     [vaultwarden/web-vault:{{ vault_version }}]
 #
 FROM vaultwarden/web-vault@{{ vault_image_digest }} as vault
 

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -16,8 +16,8 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:vv2022.5.2
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:vv2022.5.2
+#     $ docker pull vaultwarden/web-vault:v2022.5.2
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.5.2
 #     [vaultwarden/web-vault@sha256:9b8b05dfcc14ebc6b2b488f54042d2a38a69b9e80e21b1ca0e4bf45470dd33ef]
 #
 # - Conversely, to get the tag name from the digest:

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -16,8 +16,8 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:vv2022.5.2
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:vv2022.5.2
+#     $ docker pull vaultwarden/web-vault:v2022.5.2
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.5.2
 #     [vaultwarden/web-vault@sha256:9b8b05dfcc14ebc6b2b488f54042d2a38a69b9e80e21b1ca0e4bf45470dd33ef]
 #
 # - Conversely, to get the tag name from the digest:

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -16,8 +16,8 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:vv2022.5.2
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:vv2022.5.2
+#     $ docker pull vaultwarden/web-vault:v2022.5.2
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.5.2
 #     [vaultwarden/web-vault@sha256:9b8b05dfcc14ebc6b2b488f54042d2a38a69b9e80e21b1ca0e4bf45470dd33ef]
 #
 # - Conversely, to get the tag name from the digest:

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -16,8 +16,8 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:vv2022.5.2
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:vv2022.5.2
+#     $ docker pull vaultwarden/web-vault:v2022.5.2
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.5.2
 #     [vaultwarden/web-vault@sha256:9b8b05dfcc14ebc6b2b488f54042d2a38a69b9e80e21b1ca0e4bf45470dd33ef]
 #
 # - Conversely, to get the tag name from the digest:


### PR DESCRIPTION
Looks like it mainly just affects documentation of process, but it did result in some of the files having 'vv2022.5.02' in them. 

Any idea when the new vault will be merged to production/latest?