### PR TITLE
Fall back to move_copy_to  if persist_to fails while saving uploaded files.

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -999,9 +999,8 @@ async fn save_attachment(
         attachment.save(&conn).await.expect("Error saving attachment");
     }
 
-    match data.data.persist_to(&file_path).await {
-        Ok(_result) => {}
-        Err(_error) => data.data.move_copy_to(&file_path).await?,
+    if let Err(_err) = data.data.persist_to(&file_path).await {
+        data.data.move_copy_to(file_path).await?
     }
 
     nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn).await).await;

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -998,7 +998,11 @@ async fn save_attachment(
         attachment.save(&conn).await.expect("Error saving attachment");
     }
 
-    data.data.persist_to(file_path).await?;
+    if CONFIG.uploads_use_copy() {
+        data.data.move_copy_to(file_path).await?;
+    } else {
+        data.data.persist_to(file_path).await?;
+    }
 
     nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn).await).await;
 

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -2,20 +2,20 @@ use std::collections::{HashMap, HashSet};
 
 use chrono::{NaiveDateTime, Utc};
 use futures::{stream, stream::StreamExt};
+use rocket::fs::TempFile;
+use rocket::serde::json::Json;
 use rocket::{
     form::{Form, FromForm},
     Route,
 };
-use rocket::fs::TempFile;
-use rocket::serde::json::Json;
 use serde_json::Value;
 
 use crate::{
     api::{self, EmptyResult, JsonResult, JsonUpcase, Notify, PasswordData, UpdateType},
     auth::Headers,
-    CONFIG,
     crypto,
-    db::{DbConn, DbPool, models::*},
+    db::{models::*, DbConn, DbPool},
+    CONFIG,
 };
 
 use super::folders::FolderData;
@@ -805,7 +805,7 @@ async fn share_cipher_by_uuid(
         nt,
         UpdateType::CipherUpdate,
     )
-        .await?;
+    .await?;
 
     Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, None, conn).await))
 }
@@ -1001,7 +1001,7 @@ async fn save_attachment(
 
     match data.data.persist_to(&file_path).await {
         Ok(_result) => {}
-        Err(_error) => data.data.move_copy_to(&file_path).await?
+        Err(_error) => data.data.move_copy_to(&file_path).await?,
     }
 
     nt.send_cipher_update(UpdateType::CipherUpdate, &cipher, &cipher.update_users_revision(&conn).await).await;

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -225,7 +225,12 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, conn: DbCo
     let folder_path = tokio::fs::canonicalize(&CONFIG.sends_folder()).await?.join(&send.uuid);
     let file_path = folder_path.join(&file_id);
     tokio::fs::create_dir_all(&folder_path).await?;
-    data.persist_to(&file_path).await?;
+
+    if CONFIG.uploads_use_copy() {
+        data.move_copy_to(&file_path).await?;
+    } else {
+        data.persist_to(&file_path).await?;
+    }
 
     let mut data_value: Value = serde_json::from_str(&send.data)?;
     if let Some(o) = data_value.as_object_mut() {

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -10,9 +10,9 @@ use serde_json::Value;
 use crate::{
     api::{ApiResult, EmptyResult, JsonResult, JsonUpcase, Notify, NumberOrString, UpdateType},
     auth::{ClientIp, Headers, Host},
-    CONFIG,
-    db::{DbConn, DbPool, models::*},
+    db::{models::*, DbConn, DbPool},
     util::SafeString,
+    CONFIG,
 };
 
 const SEND_INACCESSIBLE_MSG: &str = "Send does not exist or is no longer available";
@@ -226,10 +226,9 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, conn: DbCo
     let file_path = folder_path.join(&file_id);
     tokio::fs::create_dir_all(&folder_path).await?;
 
-
     match data.persist_to(&file_path).await {
         Ok(_result) => {}
-        Err(_error) => data.move_copy_to(&file_path).await?
+        Err(_error) => data.move_copy_to(&file_path).await?,
     }
 
     let mut data_value: Value = serde_json::from_str(&send.data)?;

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -226,9 +226,8 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, conn: DbCo
     let file_path = folder_path.join(&file_id);
     tokio::fs::create_dir_all(&folder_path).await?;
 
-    match data.persist_to(&file_path).await {
-        Ok(_result) => {}
-        Err(_error) => data.move_copy_to(&file_path).await?,
+    if let Err(_err) = data.persist_to(&file_path).await {
+        data.move_copy_to(file_path).await?
     }
 
     let mut data_value: Value = serde_json::from_str(&send.data)?;

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use chrono::{DateTime, Duration, Utc};
+use futures::TryFutureExt;
 use rocket::form::Form;
 use rocket::fs::NamedFile;
 use rocket::fs::TempFile;
@@ -226,11 +227,9 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, conn: DbCo
     let file_path = folder_path.join(&file_id);
     tokio::fs::create_dir_all(&folder_path).await?;
 
-    if CONFIG.uploads_use_copy() {
-        data.move_copy_to(&file_path).await?;
-    } else {
-        data.persist_to(&file_path).await?;
-    }
+    data.persist_to(&file_path)
+        .unwrap_or_else(data.move_copy_to(&file_path))
+        .await?;
 
     let mut data_value: Value = serde_json::from_str(&send.data)?;
     if let Some(o) = data_value.as_object_mut() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,8 +343,6 @@ make_config! {
         rsa_key_filename:       String, false,  auto,   |c| format!("{}/{}", c.data_folder, "rsa_key");
         /// Web vault folder
         web_vault_folder:       String, false,  def,    "web-vault/".to_string();
-        /// Uploading files uses move_copy_to instead of persist_to to support cross-device scenarios where having tmp_folder on the same drive is undesirable. i.e. fuse-mounted S3.
-        uploads_use_copy:       bool,   false,  def,     false;
     },
     ws {
         /// Enable websocket notifications

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,6 +343,8 @@ make_config! {
         rsa_key_filename:       String, false,  auto,   |c| format!("{}/{}", c.data_folder, "rsa_key");
         /// Web vault folder
         web_vault_folder:       String, false,  def,    "web-vault/".to_string();
+        /// Uploading files uses move_copy_to instead of persist_to to support cross-device scenarios where having tmp_folder on the same drive is undesirable. i.e. fuse-mounted S3.
+        uploads_use_copy:       bool,   false,  def,     false;
     },
     ws {
         /// Enable websocket notifications


### PR DESCRIPTION
This is to support scenarios where the attachments and sends folder are to be stored on a separate device from the tmp_folder (i.e. fuse-mounted S3 storage), due to having the tmp_dir on the same device being undesirable.

Example being fuse-mounted S3 storage with the reasoning that because S3 basically requires a copy+delete operations to rename files, it's inefficient to rename files on device, if it's even allowed.