### PR TITLE
Fix persistent folder check within containers

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -181,14 +181,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN {{ mount_rust_cache -}} cargo build --features ${DB} --release{{ package_arch_target_param }}
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -250,7 +242,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 {% if package_arch_target is defined %}
 COPY --from=build /app/target/{{ package_arch_target }}/release/vaultwarden .
 {% else %}

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -84,14 +84,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -124,7 +116,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=x86_64-unknown-linux-musl
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -116,7 +108,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/amd64/Dockerfile.buildx
+++ b/docker/amd64/Dockerfile.buildx
@@ -84,14 +84,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -124,7 +116,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=x86_64-unknown-linux-musl
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -116,7 +108,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/x86_64-unknown-linux-musl/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -148,7 +140,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=aarch64-unknown-linux-musl
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -120,7 +112,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/aarch64-unknown-linux-musl/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/arm64/Dockerfile.buildx
+++ b/docker/arm64/Dockerfile.buildx
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=aarch64-unknown-linux-gnu
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -148,7 +140,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/aarch64-unknown-linux-gnu/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/arm64/Dockerfile.buildx.alpine
+++ b/docker/arm64/Dockerfile.buildx.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=aarch64-unknown-linux-musl
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -120,7 +112,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/aarch64-unknown-linux-musl/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -153,7 +145,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -80,14 +80,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=arm-unknown-linux-musleabi
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -122,7 +114,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/arm-unknown-linux-musleabi/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=arm-unknown-linux-gnueabi
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -153,7 +145,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/arm-unknown-linux-gnueabi/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv6/Dockerfile.buildx.alpine
+++ b/docker/armv6/Dockerfile.buildx.alpine
@@ -80,14 +80,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=arm-unknown-linux-musleabi
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -122,7 +114,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/arm-unknown-linux-musleabi/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -148,7 +140,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-musleabihf
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -120,7 +112,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/armv7-unknown-linux-musleabihf/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv7/Dockerfile.buildx
+++ b/docker/armv7/Dockerfile.buildx
@@ -104,14 +104,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -148,7 +140,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -78,14 +78,6 @@ RUN touch src/main.rs
 # hadolint ignore=DL3059
 RUN --mount=type=cache,target=/root/.cargo/git --mount=type=cache,target=/root/.cargo/registry cargo build --features ${DB} --release --target=armv7-unknown-linux-musleabihf
 
-# Create a special empty file which we check within the application.
-# If this file exists, then we exit Vaultwarden to prevent data loss when someone forgets to use volumes.
-# If you really really want to use volatile storage you can set the env `I_REALLY_WANT_VOLATILE_STORAGE=true`
-# This file should disappear if a volume is mounted on-top of this using a docker volume.
-# We run this in the build image and copy it over, because the runtime image could be missing some executables.
-# hadolint ignore=DL3059
-RUN touch /vaultwarden_docker_persistent_volume_check
-
 ######################## RUNTIME IMAGE  ########################
 # Create a new stage with a minimal image
 # because we already have a binary built
@@ -120,7 +112,6 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 COPY --from=vault /web-vault ./web-vault
-COPY --from=build /vaultwarden_docker_persistent_volume_check /data/vaultwarden_docker_persistent_volume_check
 COPY --from=build /app/target/armv7-unknown-linux-musleabihf/release/vaultwarden .
 
 COPY docker/healthcheck.sh /healthcheck.sh


### PR DESCRIPTION
The previous persistent folder check worked by checking if a file
exists. If you used a bind-mount, then this file is not there. But when
using a docker/podman volume those files are copied, and caused the
container to not start.

This change checks the `/proc/self/mountinfo` for a specific patern to
see if the data folder is persistent or not.

Fixes #2622