### PR TITLE
Mitigate attachment/send upload issues

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -947,6 +947,17 @@ async fn save_attachment(
 
     let mut data = data.into_inner();
 
+    // There seems to be a bug somewhere regarding uploading attachments using the Android Client (Maybe iOS too?)
+    // See: https://github.com/dani-garcia/vaultwarden/issues/2644
+    // Since all other clients seem to match TempFile::File and not TempFile::Buffered lets catch this and return an error for now.
+    // We need to figure out how to solve this, but for now it's better to not accept these attachments since they will be broken.
+    if let TempFile::Buffered {
+        content: _,
+    } = &data.data
+    {
+        err!("Error reading attachment data. Please try an other client.");
+    }
+
     if let Some(size_limit) = size_limit {
         if data.data.len() > size_limit {
             err!("Attachment storage limit exceeded with this file");


### PR DESCRIPTION
This PR attends to mitigate (not fix) #2644.
There seems to be an issue when uploading files either as attachment or
via send via the mobile (Android) client.

The binary data gets transfered correctly to Vaultwarden (Checked via
Wireshark), but the data is not parsed correctly for some reason.

Since the parsing is not done by Vaultwarden it self, i think we should
at least try to prevent saving the data and letting users think all
fine.

Further investigation is needed to actually fix this issue.
This is just a quick patch.