### PR TITLE
Added support for web-vault v2022.9

### DIFF
--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -19,7 +19,14 @@ pub mod webauthn;
 pub mod yubikey;
 
 pub fn routes() -> Vec<Route> {
-    let mut routes = routes![get_twofactor, get_recover, recover, disable_twofactor, disable_twofactor_put,];
+    let mut routes = routes![
+        get_twofactor,
+        get_recover,
+        recover,
+        disable_twofactor,
+        disable_twofactor_put,
+        get_device_verification_settings,
+    ];
 
     routes.append(&mut authenticator::routes());
     routes.append(&mut duo::routes());
@@ -187,4 +194,22 @@ pub async fn send_incomplete_2fa_notifications(pool: DbPool) {
             .expect("Error sending incomplete 2FA email");
         login.delete(&conn).await.expect("Error deleting incomplete 2FA record");
     }
+}
+
+// This function currently is just a dummy and the actual part is not implemented yet.
+// This also prevents 404 errors.
+//
+// See the following Bitwarden PR's regarding this feature.
+// https://github.com/bitwarden/clients/pull/2843
+// https://github.com/bitwarden/clients/pull/2839
+// https://github.com/bitwarden/server/pull/2016
+//
+// The HTML part is hidden via the CSS patches done via the bw_web_build repo
+#[get("/two-factor/get-device-verification-settings")]
+fn get_device_verification_settings(_headers: Headers, _conn: DbConn) -> Json<Value> {
+    Json(json!({
+        "isDeviceVerificationSectionEnabled":false,
+        "unknownDeviceVerificationEnabled":false,
+        "object":"deviceVerificationSettings"
+    }))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -60,7 +60,7 @@ impl Fairing for AppHeaders {
             // Leaked Passwords check: api.pwnedpasswords.com
             // 2FA/MFA Site check: 2fa.directory
             // # Mail Relay: https://bitwarden.com/blog/add-privacy-and-security-using-email-aliases-with-bitwarden/
-            // app.simplelogin.io, app.anonaddy.com, relay.firefox.com
+            // app.simplelogin.io, app.anonaddy.com, api.fastmail.com
             let csp = format!(
                 "default-src 'self'; \
                 script-src 'self'{script_src}; \
@@ -68,7 +68,7 @@ impl Fairing for AppHeaders {
                 img-src 'self' data: https://haveibeenpwned.com/ https://www.gravatar.com {icon_service_csp}; \
                 child-src 'self' https://*.duosecurity.com https://*.duofederal.com; \
                 frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; \
-                connect-src 'self' https://api.pwnedpasswords.com/range/ https://2fa.directory/api/ https://app.simplelogin.io/api/ https://app.anonaddy.com/api/ https://relay.firefox.com/api/; \
+                connect-src 'self' https://api.pwnedpasswords.com/range/ https://2fa.directory/api/ https://app.simplelogin.io/api/ https://app.anonaddy.com/api/ https://api.fastmail.com/; \
                 object-src 'self' blob:; \
                 frame-ancestors 'self' chrome-extension://nngceckbapebfimnlniiiahkandclblb chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh moz-extension://* {allowed_iframe_ancestors};",
                 icon_service_csp=CONFIG._icon_service_csp(),


### PR DESCRIPTION
- The new web-vault version supports fastmail.com anon email, add the correct api host to support it.
- Removed Firefox Relay, this seems only to be supported on SaaS.
- Added a function to the two-factor api to prevent 404 errors.