### PR TITLE
Fix issue 2737, unable to create org

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1351,7 +1351,7 @@ fn get_organization_tax(org_id: String, _headers: Headers) -> Json<Value> {
 }
 
 #[get("/plans")]
-fn get_plans(_headers: Headers) -> Json<Value> {
+fn get_plans() -> Json<Value> {
     // Respond with a minimal json just enough to allow the creation of an new organization.
     Json(json!({
         "Object": "list",


### PR DESCRIPTION
There was a small oversight on upgrading to v2022.9.0 web-vault version. It seems the call to the /plans/ endpoint doesn't provide authentication anymore.

Removed this check and it seems to work again.

Fixes #2737