### PR TITLE
 Rename/Fix revoke/restore endpoints

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -196,7 +196,7 @@ impl UserOrganization {
         }
     }
 
-    pub fn activate(&mut self) {
+    pub fn restore(&mut self) {
         if self.status < UserOrgStatus::Accepted as i32 {
             self.status += ACTIVATE_REVOKE_DIFF;
         }


### PR DESCRIPTION
In web-vault v2022.9.x it seems the endpoints changed.
 - activate > restore
 - deactivate > revoke

This PR adds those endpoints and renames the functions. It also keeps the previous endpoints for now to be compatible with previous vault verions for now, just in case.