### PR TITLE
Update build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,10 @@ jobs:
       matrix:
         channel:
           - "rust-toolchain" # The version defined in rust-toolchain
-          - "1.60.0" # The supported MSRV
+          - "msrv" # The supported MSRV
+        include:
+          - channel: "msrv"
+            version: "1.60.0"
 
     name: Build and Test ${{ matrix.channel }}
 
@@ -63,7 +66,7 @@ jobs:
         with:
           profile: minimal
           override: true
-          toolchain: ${{ matrix.channel }}
+          toolchain: ${{ matrix.version }}
       # End Install the MSRV channel to be used
 
 
@@ -193,5 +196,5 @@ jobs:
         if: ${{ matrix.channel == 'rust-toolchain' }}
         with:
           name: vaultwarden
-          path: target/${{ matrix.target-triple }}/release/vaultwarden
+          path: target/release/vaultwarden
       # End Upload artifact to Github Actions

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,13 +1,9 @@
 name: Hadolint
 
-on:
-  push:
-    paths:
-      - "docker/**"
-
-  pull_request:
-    paths:
-      - "docker/**"
+on: [
+      push,
+      pull_request
+    ]
 
 jobs:
   hadolint:


### PR DESCRIPTION
Currently the branch protection is set on specific workflows which needs to be run every time a PR is created (or a push).

Because it isn't possible to tell the branch protection only to do it's job if specific files are touched or not, we just need to make sure these jobs are always started.

Also, because we now check the builds for an MSRV, and the title would change all the time, that would cause the branch protection to be updated everytime the MSRV would change. This is now also addressed by naming that job 'msrv' instead of the version number.