### PR TITLE
automatically purge stale invitations

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -97,6 +97,10 @@
 ## Defaults to daily (5 minutes after midnight). Set blank to disable this job.
 # TRASH_PURGE_SCHEDULE="0 5 0 * * *"
 ##
+## Cron schedule of the job that checks for stale invitations past their expiration date.
+## Defaults to hourly (3rd minute of every hour). Set blank to disable this job.
+# INVITATION_PURGE_SCHEDULE="0 3 * * * *"
+##
 ## Cron schedule of the job that checks for incomplete 2FA logins.
 ## Defaults to once every minute. Set blank to disable this job.
 # INCOMPLETE_2FA_SCHEDULE="30 * * * * *"
@@ -244,6 +248,9 @@
 # INVITATIONS_ALLOWED=true
 ## Name shown in the invitation emails that don't come from a specific organization
 # INVITATION_ORG_NAME=Vaultwarden
+
+## Specify the number of hours after which an Organization Invite will automatically expire (0 means never)
+# INVITATION_EXPIRATION_HOURS=0
 
 ## Per-organization attachment storage limit (KB)
 ## Max kilobytes of attachment storage allowed per organization.

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -6,6 +6,7 @@ mod organizations;
 mod sends;
 pub mod two_factor;
 
+pub use accounts::purge_stale_invitations;
 pub use ciphers::purge_trashed_ciphers;
 pub use ciphers::{CipherSyncData, CipherSyncType};
 pub use emergency_access::{emergency_notification_reminder_job, emergency_request_timeout_job};

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,6 +12,7 @@ pub use crate::api::{
     admin::routes as admin_routes,
     core::catchers as core_catchers,
     core::purge_sends,
+    core::purge_stale_invitations,
     core::purge_trashed_ciphers,
     core::routes as core_routes,
     core::two_factor::send_incomplete_2fa_notifications,

--- a/src/config.rs
+++ b/src/config.rs
@@ -361,6 +361,9 @@ make_config! {
         /// Trash purge schedule |> Cron schedule of the job that checks for trashed items to delete permanently.
         /// Defaults to daily. Set blank to disable this job.
         trash_purge_schedule:   String, false,  def,    "0 5 0 * * *".to_string();
+        /// Purge stale invidations |> Cron schedule of the job that checks for stale invitations
+        /// Defaults to hourly. Set blank to disable this job.
+        invitation_purge_schedule: String, false, def, "0 3 * * * *".to_string();
         /// Incomplete 2FA login schedule |> Cron schedule of the job that checks for incomplete 2FA logins.
         /// Defaults to once every minute. Set blank to disable this job.
         incomplete_2fa_schedule: String, false,  def,   "30 * * * * *".to_string();
@@ -430,6 +433,8 @@ make_config! {
         org_creation_users:     String, true,   def,    "".to_string();
         /// Allow invitations |> Controls whether users can be invited by organization admins, even when signups are otherwise disabled
         invitations_allowed:    bool,   true,   def,    true;
+        /// Invitation auto-expiration time (hours) |> Specify the number of hours after which an Organization Invite will expire (0 means never)
+        invitation_expiration_hours: u32, false, def, 120;
         /// Allow emergency access |> Controls whether users can enable emergency access to their accounts. This setting applies globally to all users.
         emergency_access_allowed:    bool,   true,   def,    true;
         /// Password iterations |> Number of server-side passwords hashing iterations.

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -481,6 +481,15 @@ impl UserOrganization {
         Ok(())
     }
 
+    pub async fn delete_invites_for_user(user_uuid: &str, conn: &DbConn) -> EmptyResult {
+        for membership in Self::find_by_user(user_uuid, conn).await {
+            if membership.status == super::UserOrgStatus::Invited as i32 {
+                membership.delete(conn).await?;
+            }
+        }
+        Ok(())
+    }
+
     pub async fn find_by_email_and_org(email: &str, org_id: &str, conn: &DbConn) -> Option<UserOrganization> {
         if let Some(user) = super::User::find_by_mail(email, conn).await {
             if let Some(user_org) = UserOrganization::find_by_user_and_org(&user.uuid, org_id, conn).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,6 +478,13 @@ async fn schedule_jobs(pool: db::DbPool) {
                 }));
             }
 
+            // Purge stale invitations
+            if !CONFIG.invitation_purge_schedule().is_empty() {
+                sched.add(Job::new(CONFIG.invitation_purge_schedule().parse().unwrap(), || {
+                    runtime.spawn(api::purge_stale_invitations(pool.clone()));
+                }));
+            }
+
             // Send email notifications about incomplete 2FA logins, which potentially
             // indicates that a user's master password has been compromised.
             if !CONFIG.incomplete_2fa_schedule().is_empty() {


### PR DESCRIPTION
Fixes part of #2792 by automatically deleting invited users that have not registered before the expiration date.

`INVITATION_EXPIRATION_HOURS` defaults to 120 (5 days) because that was the default expiration date of the Invite JWT. When set to 0 the expiration date is not checked.

Also no invitation is deleted when mail is disabled.