### PR TITLE
v2022.9.2 expects a json response while registering

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -81,7 +81,7 @@ fn enforce_password_hint_setting(password_hint: &Option<String>) -> EmptyResult 
 }
 
 #[post("/accounts/register", data = "<data>")]
-async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
+async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> JsonResult {
     let data: RegisterData = data.into_inner().data;
     let email = data.Email.to_lowercase();
 
@@ -178,7 +178,10 @@ async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> EmptyResult {
         }
     }
 
-    user.save(&conn).await
+    user.save(&conn).await?;
+    Ok(Json(json!({
+      "registration": "success",
+    })))
 }
 
 #[get("/accounts/profile")]

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -180,7 +180,8 @@ async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> JsonResult {
 
     user.save(&conn).await?;
     Ok(Json(json!({
-      "registration": "success",
+      "object": "register",
+      "CaptchaBypassToken": "",
     })))
 }
 

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -180,7 +180,7 @@ async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> JsonResult {
 
     user.save(&conn).await?;
     Ok(Json(json!({
-      "object": "register",
+      "Object": "register",
       "CaptchaBypassToken": "",
     })))
 }


### PR DESCRIPTION
This is a minimal change to make vaultwarden compatible with v2022.9.2 because the web-vault expects a JSON response while registering now. It checks for the existence of a CaptchaBypassToken (see bitwarden/clients#3531) in the response which leads to a syntax error when trying to parse the Empty result.