### PR TITLE
check if data folder is a writable directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,10 @@ async fn check_data_folder() {
         }
         exit(1);
     }
+    if !path.is_dir() {
+        error!("Data folder '{}' is not a directory.", data_folder);
+        exit(1);
+    }
 
     if is_running_in_docker()
         && std::env::var("I_REALLY_WANT_VOLATILE_STORAGE").is_err()


### PR DESCRIPTION
Adds a check if the data folder is a directory and also returns a more verbose error message if the permission was denied when creating a file.

I tried adding something like the following to `check_data_folder()` as well
```rust
let metadata = path.metadata().unwrap();
if metadata.permissions().readonly() {
    warn!("Data folder '{}' is read-only.", data_folder);
}
```
However,  this does not really work because [`readonly()`](https://github.com/rust-lang/rust/blob/master/library/std/src/sys/unix/fs.rs#L498-L501) only checks if _anyone_ has write permissions. :confounded: 