### PR TITLE
feat: Bump web-vault to v2022.10.1

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -59,8 +59,8 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-{% set vault_version = "v2022.10.0" %}
-{% set vault_image_digest = "sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80" %}
+{% set vault_version = "v2022.10.1" %}
+{% set vault_image_digest = "sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215" %}
 # The web-vault digest specifies a particular web-vault build on Docker Hub.
 # Using the digest instead of the tag name provides better security,
 # as the digest of an image is immutable, whereas a tag name can later

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:x86_64-musl-stable-1.64.0 as build

--- a/docker/amd64/Dockerfile.buildx
+++ b/docker/amd64/Dockerfile.buildx
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/amd64/Dockerfile.buildx.alpine
+++ b/docker/amd64/Dockerfile.buildx.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:x86_64-musl-stable-1.64.0 as build

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:aarch64-musl-stable-1.64.0 as build

--- a/docker/arm64/Dockerfile.buildx
+++ b/docker/arm64/Dockerfile.buildx
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/arm64/Dockerfile.buildx.alpine
+++ b/docker/arm64/Dockerfile.buildx.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:aarch64-musl-stable-1.64.0 as build

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:arm-musleabi-stable-1.64.0 as build

--- a/docker/armv6/Dockerfile.buildx
+++ b/docker/armv6/Dockerfile.buildx
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/armv6/Dockerfile.buildx.alpine
+++ b/docker/armv6/Dockerfile.buildx.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:arm-musleabi-stable-1.64.0 as build

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:armv7-musleabihf-stable-1.64.0 as build

--- a/docker/armv7/Dockerfile.buildx
+++ b/docker/armv7/Dockerfile.buildx
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM rust:1.64-bullseye as build

--- a/docker/armv7/Dockerfile.buildx.alpine
+++ b/docker/armv7/Dockerfile.buildx.alpine
@@ -16,15 +16,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull vaultwarden/web-vault:v2022.10.0
-#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.0
-#     [vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80]
+#     $ docker pull vaultwarden/web-vault:v2022.10.1
+#     $ docker image inspect --format "{{.RepoDigests}}" vaultwarden/web-vault:v2022.10.1
+#     [vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80
-#     [vaultwarden/web-vault:v2022.10.0]
+#     $ docker image inspect --format "{{.RepoTags}}" vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215
+#     [vaultwarden/web-vault:v2022.10.1]
 #
-FROM vaultwarden/web-vault@sha256:8e8405d252bb6ecc7d59d90e9ba9dde09f35c1b6858371274c67c3e0a6f14a80 as vault
+FROM vaultwarden/web-vault@sha256:02aebd82a8dda3c8c9606cb48f5fd9acdf5c9a422e09b72a9946bab522352215 as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM blackdex/rust-musl:armv7-musleabihf-stable-1.64.0 as build


### PR DESCRIPTION
This pull request bumps webvault to 2022.10.1, what else?