### PR TITLE
validate billing_email on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,9 @@ name = "email_address"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b32a7a2580c4473f10f66b512c34bdd7d33c5e3473227ca833abdb5afe4809"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -3162,6 +3165,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dotenvy",
+ "email_address",
  "fern",
  "futures",
  "governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ url = "2.3.1"
 # Email librariese-Base, Update crates and small change.
 lettre = { version = "0.10.1", features = ["smtp-transport", "builder", "serde", "tokio1-native-tls", "hostname", "tracing", "tokio1"], default-features = false }
 percent-encoding = "2.2.0" # URL encoding library used for URL's in the emails
+email_address = "0.2.3"
 
 # Template library
 handlebars = { version = "4.3.5", features = ["dir_source"] }

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -217,6 +217,10 @@ use crate::error::MapResult;
 /// Database methods
 impl Organization {
     pub async fn save(&self, conn: &mut DbConn) -> EmptyResult {
+        if !email_address::EmailAddress::is_valid(self.billing_email.trim()) {
+            err!(format!("BillingEmail {} is not a valid email address", self.billing_email.trim()))
+        }
+
         for user_org in UserOrganization::find_by_org(&self.uuid, conn).await.iter() {
             User::update_uuid_revision(&user_org.user_uuid, conn).await;
         }


### PR DESCRIPTION
As discussed in #2849 the billing email address should be validated server-side since the client does not currently check the field when updating it.

The same validation could be used for user.email but not sure if this is needed.

As far as I've tested it, this change should only affect creating and updating organizations as the organization itself is not saved in other functions but I might have missed something.