### PR TITLE
make support string more secure

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -229,17 +229,18 @@ macro_rules! make_config {
                     inner.config.clone()
                 };
 
-                /// We map over the string and remove all alphanumeric, _ and - characters.
-                /// This is the fastest way (within micro-seconds) instead of using a regex (which takes mili-seconds)
                 fn _privacy_mask(value: &str) -> String {
-                    value.chars().map(|c|
-                        match c {
-                            c if c.is_alphanumeric() => '*',
-                            '_' => '*',
-                            '-' => '*',
-                            _ => c
+                    let mut masked: String = String::new();
+                    let mut n = 0;
+                    for c in value.chars() {
+                        if n <= 12 && [':', '/'].contains(&c) {
+                            masked += &c.to_string();
+                        } else {
+                            masked += &'*'.to_string();
                         }
-                    ).collect::<String>()
+                        n += 1;
+                    }
+                    masked
                 }
 
                 serde_json::Value::Object({

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,6 +233,9 @@ macro_rules! make_config {
                     let mut masked: String = String::new();
                     let mut n = 0;
                     for c in value.chars() {
+                        if c == ',' {
+                            masked += &c.to_string();
+                        }
                         if n <= 12 && [':', '/'].contains(&c) {
                             masked += &c.to_string();
                         } else {


### PR DESCRIPTION
When a support string is generated the masked entries still show certain info:

- length of a password, user, database name in the DB URL
- length of smtp username
- domain length and TLD length, if subdomain is used or a sub directory
- length and format of smtp_from

This change masks the fields with `***` as it is done for passwords.