### PR TITLE
redirect to admin login page when forward fails

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@ use rocket::serde::json::Json;
 use serde_json::Value;
 
 pub use crate::api::{
+    admin::catchers as admin_catchers,
     admin::routes as admin_routes,
     core::catchers as core_catchers,
     core::purge_sends,

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,6 +435,7 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         .mount([basepath, "/notifications"].concat(), api::notifications_routes())
         .register([basepath, "/"].concat(), api::web_catchers())
         .register([basepath, "/api"].concat(), api::core_catchers())
+        .register([basepath, "/admin"].concat(), api::admin_catchers())
         .manage(pool)
         .manage(api::start_notification_server())
         .attach(util::AppHeaders())

--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -352,7 +352,13 @@
         supportString += "* Reverse proxy and version: \n";
         supportString += "* Other relevant information: \n";
 
-        let jsonResponse = await fetch('{{urlpath}}/admin/diagnostics/config');
+        let jsonResponse = await fetch('{{urlpath}}/admin/diagnostics/config', {
+                'headers': { 'Accept': 'application/json' }
+        });
+        if (!jsonResponse.ok) {
+                alert("Generation failed: " + jsonResponse.statusText);
+                throw new Error(jsonResponse);
+        }
         const configJson = await jsonResponse.json();
         supportString += "\n### Config (Generated via diagnostics page)\n<details><summary>Show Running Config</summary>\n"
         supportString += "\n**Environment settings which are overridden:** {{page_data.overrides}}\n"

--- a/src/static/templates/admin/login.hbs
+++ b/src/static/templates/admin/login.hbs
@@ -12,8 +12,11 @@
             <h6 class="mb-0 text-white">Authentication key needed to continue</h6>
             <small>Please provide it below:</small>
 
-            <form class="form-inline" method="post">
+            <form class="form-inline" method="post" action="{{urlpath}}/admin">
                 <input type="password" class="form-control w-50 mr-2" name="token" placeholder="Enter admin token" autofocus="autofocus">
+                {{#if redirect}}
+                <input type="hidden" id="redirect" name="redirect" value="/{{redirect}}">
+                {{/if}}
                 <button type="submit" class="btn btn-primary">Enter</button>
             </form>
         </div>


### PR DESCRIPTION
Currently, if the admin guard fails the user will get a 404 page instead of being forwarded to the login page.

This change addresses issues like #2880 and #2883 by implementing a default forward catcher for all admin pages so this comment is correct:
https://github.com/dani-garcia/vaultwarden/blob/f60a6929a9a289bd39c38eeb793ebf54c4d88199/src/api/admin.rs#L656