### PR TITLE
Support Org Export for v2022.11 clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
 name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,6 +3207,7 @@ dependencies = [
  "ring",
  "rmpv",
  "rocket",
+ "semver",
  "serde",
  "serde_json",
  "syslog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,9 @@ governor = "0.5.0"
 # Capture CTRL+C
 ctrlc = { version = "3.2.3", features = ["termination"] }
 
+# Check client versions for specific features.
+semver = "1.0.14"
+
 # Allow overriding the default memory allocator
 # Mainly used for the musl builds, since the default musl malloc is very slow
 mimalloc = { version = "0.1.30", features = ["secure"], default-features = false, optional = true }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -481,6 +481,7 @@ pub struct AdminHeaders {
     pub device: Device,
     pub user: User,
     pub org_user_type: UserOrgType,
+    pub client_version: Option<String>,
 }
 
 #[rocket::async_trait]
@@ -489,12 +490,14 @@ impl<'r> FromRequest<'r> for AdminHeaders {
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let headers = try_outcome!(OrgHeaders::from_request(request).await);
+        let client_version = request.headers().get_one("Bitwarden-Client-Version").map(String::from);
         if headers.org_user_type >= UserOrgType::Admin {
             Outcome::Success(Self {
                 host: headers.host,
                 device: headers.device,
                 user: headers.user,
                 org_user_type: headers.org_user_type,
+                client_version,
             })
         } else {
             err_handler!("You need to be Admin or Owner to call this endpoint")


### PR DESCRIPTION
Since v2022.9.x the org export uses a different endpoint. But, since v2022.11.x this endpoint will return a different format. See: https://github.com/bitwarden/clients/pull/3641 and https://github.com/bitwarden/server/pull/2316

To support both version in the case of users having an older client either web-vault or cli this PR checks the version and responds using the correct format. If no version can be determined it will use the new format as a default.