### PR TITLE
Update config comment to reflect rfc8314.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -352,7 +352,7 @@
 # SMTP_FROM=vaultwarden@domain.tld
 # SMTP_FROM_NAME=Vaultwarden
 # SMTP_SECURITY=starttls # ("starttls", "force_tls", "off") Enable a secure connection. Default is "starttls" (Explicit - ports 587 or 25), "force_tls" (Implicit - port 465) or "off", no encryption (port 25)
-# SMTP_PORT=587          # Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 is outdated and used with Implicit TLS.
+# SMTP_PORT=587          # Ports 587 (submission), 465 (submissions) and 25 (smtp) are standard without encryption and with encryption ports, 587 use STARTTLS (Explicit encryption) and 465 use native TLS (Implicit encryption)
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
 # SMTP_TIMEOUT=15

--- a/.env.template
+++ b/.env.template
@@ -352,7 +352,7 @@
 # SMTP_FROM=vaultwarden@domain.tld
 # SMTP_FROM_NAME=Vaultwarden
 # SMTP_SECURITY=starttls # ("starttls", "force_tls", "off") Enable a secure connection. Default is "starttls" (Explicit - ports 587 or 25), "force_tls" (Implicit - port 465) or "off", no encryption (port 25)
-# SMTP_PORT=587          # Ports 587 (submission), 465 (submissions) and 25 (smtp) are standard without encryption and with encryption ports, 587 use STARTTLS (Explicit encryption) and 465 use native TLS (Implicit encryption)
+# SMTP_PORT=587          # Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 (submissions) is used for encrypted submission (Implicit TLS).
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
 # SMTP_TIMEOUT=15


### PR DESCRIPTION
TL;DR : Port 465 with implicit TLS for SMTP isn't outdated since RFC 8314

As stated in [RFC 8314](https://tools.ietf.org/html/rfc8314) : 
![image](https://user-images.githubusercontent.com/26208369/201494637-a9d70f67-89f9-4d89-b84d-c65b0ae2755a.png)

Also as stated [here](https://github.com/iredmail/iRedMail/issues/22#issuecomment-731779992) 

The IANA registry has been modified to register port 465 for native tls smtp connections : 

![image](https://user-images.githubusercontent.com/26208369/201494695-21b8f7a2-3243-44a6-80d2-93a46f67f399.png)