### PR TITLE
Set "Bypass admin page security" as read-only

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -533,7 +533,7 @@ make_config! {
         database_conn_init:     String, false,  def,    String::new();
 
         /// Bypass admin page security (Know the risks!) |> Disables the Admin Token for the admin page so you may use your own auth in-front
-        disable_admin_token:    bool,   true,   def,    false;
+        disable_admin_token:    bool,   false,  def,    false;
 
         /// Allowed iframe ancestors (Know the risks!) |> Allows other domains to embed the web vault into an iframe, useful for embedding into secure intranets
         allowed_iframe_ancestors: String, true, def,    String::new();


### PR DESCRIPTION
It was possible to disable the admin security via the admin interface. This is kinda insecure as mentioned in #2761.

This PR set this value as read-only and admin's need to set the correct ENV variable. Currently saved settings which do override this are still valid though. If an admin want's this removed, they either need to reset the config, or change the value in the `config.json` file.

Fixes #2761