### PR TITLE
Fully remove DuckDuckGo email service.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -83,7 +83,6 @@ impl Fairing for AppHeaders {
                   https://app.simplelogin.io/api/ \
                   https://app.anonaddy.com/api/ \
                   https://api.fastmail.com/ \
-                  https://quack.duckduckgo.com/api/email/ \
                   ;\
                 ",
                 icon_service_csp = CONFIG._icon_service_csp(),


### PR DESCRIPTION
The DuckDuckGo email service is not supported for self-hosted servers. This option is already hidden via the latest web-vault.

This PR also removes some server side headers.

Fixes #2828