### PR TITLE
Added missing `register` endpoint to `identity`

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -42,7 +42,7 @@ pub fn routes() -> Vec<rocket::Route> {
 
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
-struct RegisterData {
+pub struct RegisterData {
     Email: String,
     Kdf: Option<i32>,
     KdfIterations: Option<i32>,
@@ -82,7 +82,11 @@ fn enforce_password_hint_setting(password_hint: &Option<String>) -> EmptyResult 
 }
 
 #[post("/accounts/register", data = "<data>")]
-async fn register(data: JsonUpcase<RegisterData>, mut conn: DbConn) -> JsonResult {
+async fn register(data: JsonUpcase<RegisterData>, conn: DbConn) -> JsonResult {
+    _register(data, conn).await
+}
+
+pub async fn _register(data: JsonUpcase<RegisterData>, mut conn: DbConn) -> JsonResult {
     let data: RegisterData = data.into_inner().data;
     let email = data.Email.to_lowercase();
 

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use crate::{
     api::{
-        core::accounts::{PreloginData, _prelogin},
+        core::accounts::{PreloginData, RegisterData, _prelogin, _register},
         core::two_factor::{duo, email, email::EmailTokenData, yubikey},
         ApiResult, EmptyResult, JsonResult, JsonUpcase,
     },
@@ -20,7 +20,7 @@ use crate::{
 };
 
 pub fn routes() -> Vec<Route> {
-    routes![login, prelogin]
+    routes![login, prelogin, identity_register]
 }
 
 #[post("/connect/token", data = "<data>")]
@@ -432,6 +432,11 @@ async fn _json_err_twofactor(providers: &[i32], user_uuid: &str, conn: &mut DbCo
 #[post("/accounts/prelogin", data = "<data>")]
 async fn prelogin(data: JsonUpcase<PreloginData>, conn: DbConn) -> Json<Value> {
     _prelogin(data, conn).await
+}
+
+#[post("/accounts/register", data = "<data>")]
+async fn identity_register(data: JsonUpcase<RegisterData>, conn: DbConn) -> JsonResult {
+    _register(data, conn).await
 }
 
 // https://github.com/bitwarden/jslib/blob/master/common/src/models/request/tokenRequest.ts


### PR DESCRIPTION
In the upcomming web-vault and other clients they changed the register endpoint from `/api/accounts/register` to `/identity/register`.

This PR adds the new endpoint to already be compatible with the new clients.

Fixes #2889