### PR TITLE
allow managers to set groups of a collection

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1748,7 +1748,7 @@ async fn _restore_organization_user(
 }
 
 #[get("/organizations/<org_id>/groups")]
-async fn get_groups(org_id: String, _headers: AdminHeaders, mut conn: DbConn) -> JsonResult {
+async fn get_groups(org_id: String, _headers: ManagerHeadersLoose, mut conn: DbConn) -> JsonResult {
     let groups = Group::find_by_organization(&org_id, &mut conn).await.iter().map(Group::to_json).collect::<Value>();
 
     Ok(Json(json!({


### PR DESCRIPTION
Managers should be allowed to set the groups of a collection. In order to do that, they'll need the permission to get the groups of an organization. 

fixes #2932
fixes #2930 