### PR TITLE
Limit Cipher Note encrypted string size

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -366,6 +366,12 @@ pub async fn update_cipher_from_data(
         err!("Organization mismatch. Please resync the client before updating the cipher")
     }
 
+    if let Some(note) = &data.Notes {
+        if note.len() > 10_000 {
+            err!("The field Notes exceeds the maximum encrypted value length of 10000 characters.")
+        }
+    }
+
     // Check if this cipher is being transferred from a personal to an organization vault
     let transfer_cipher = cipher.organization_uuid.is_none() && data.OrganizationId.is_some();
 


### PR DESCRIPTION
As discussed in #2937, this will limit the amount of encrypted characters to 10.000 characters, same as Bitwarden. This will not break current ciphers which exceed this limit, but it will prevent those ciphers from being updated.

Fixes #2937