### PR TITLE
Fix admin repost warning.

### DIFF
--- a/src/static/templates/admin/base.hbs
+++ b/src/static/templates/admin/base.hbs
@@ -32,7 +32,11 @@
     <script>
         'use strict';
 
-        function reload() { window.location.reload(); }
+        function reload() {
+            // Reload the page by setting the exact same href
+            // Using window.location.reload() could cause a repost.
+            window.location = window.location.href;
+        }
         function msg(text, reload_page = true) {
             text && alert(text);
             reload_page && reload();


### PR DESCRIPTION
Currently when you login into the admin, and then directly hit the save button, it will come with a re-post/re-submit warning. This has to do with the `window.location.reload()` function, which triggers the admin login POST again.

By changing the way to reload the page, we prevent this repost.