### PR TITLE
Add dev-only query logging support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a22b1f4804a69ed8954910b2ab30dedc759665e0284e57db95eef4a7b5edffb"
+dependencies = [
+ "diesel",
+ "log",
+]
+
+[[package]]
 name = "diesel_migrations"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3190,7 @@ dependencies = [
  "data-encoding",
  "data-url",
  "diesel",
+ "diesel_logger",
  "diesel_migrations",
  "dotenvy",
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ vendored_openssl = ["openssl/vendored"]
 # Enable MiMalloc memory allocator to replace the default malloc
 # This can improve performance for Alpine builds
 enable_mimalloc = ["mimalloc"]
+# This is a development dependency, and should only be used during development!
+# It enables the usage of the diesel_logger crate, which is able to output the generated queries.
+# You also need to set an env variable `QUERY_LOGGER=1` to fully activate this so you do not have to re-compile
+# if you want to turn off the logging for a specific run.
+query_logger = ["diesel_logger"]
 
 # Enable unstable features, requires nightly
 # Currently only used to enable rusts official ip support
@@ -70,6 +75,7 @@ serde_json = "1.0.87"
 # A safe, extensible ORM and Query builder
 diesel = { version = "2.0.2", features = ["chrono", "r2d2"] }
 diesel_migrations = "2.0.0"
+diesel_logger = { version = "0.2.0", optional = true }
 
 # Bundled SQLite
 libsqlite3-sys = { version = "0.25.2", features = ["bundled"], optional = true }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -182,10 +182,18 @@ macro_rules! generate_connections {
     };
 }
 
+#[cfg(not(query_logger))]
 generate_connections! {
     sqlite: diesel::sqlite::SqliteConnection,
     mysql: diesel::mysql::MysqlConnection,
     postgresql: diesel::pg::PgConnection
+}
+
+#[cfg(query_logger)]
+generate_connections! {
+    sqlite: diesel_logger::LoggingConnection<diesel::sqlite::SqliteConnection>,
+    mysql: diesel_logger::LoggingConnection<diesel::mysql::MysqlConnection>,
+    postgresql: diesel_logger::LoggingConnection<diesel::pg::PgConnection>
 }
 
 impl DbConnType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,13 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         log::LevelFilter::Off
     };
 
+    let diesel_logger_level: log::LevelFilter =
+        if cfg!(feature = "query_logger") && std::env::var("QUERY_LOGGER").is_ok() {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Off
+        };
+
     let mut logger = fern::Dispatch::new()
         .level(level)
         // Hide unknown certificate errors if using self-signed
@@ -191,6 +198,7 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         .level_for("cookie_store", log::LevelFilter::Off)
         // Variable level for trust-dns used by reqwest
         .level_for("trust_dns_proto", trust_dns_level)
+        .level_for("diesel_logger", diesel_logger_level)
         .chain(std::io::stdout());
 
     // Enable smtp debug logging only specifically for smtp when need.


### PR DESCRIPTION
This PR adds query logging support as an optional feature. It is only allowed during development/debug builds, and will abort when used during a `--release` build.

For this feature to be fully activated you also need to se an environment variable `QUERY_LOGGER=1` to activate the debug log-level for this crate, else there will be no output.

The reason for this PR is that sometimes it is useful to be able to see the generated queries, like when debugging an issue, or trying to optimize a query. Currently i always added this code when needed, but having this a part of the code could benifit other developers too who maybe need this.