### PR TITLE
Remove patched multer-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,8 @@ dependencies = [
 [[package]]
 name = "multer"
 version = "2.0.4"
-source = "git+https://github.com/BlackDex/multer-rs?rev=477d16b7fa0f361b5c2a5ba18a5b28bec6d26a8a#477d16b7fa0f361b5c2a5ba18a5b28bec6d26a8a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed4198ce7a4cbd2a57af78d28c6fbb57d81ac5f1d6ad79ac6c5587419cbdf22"
 dependencies = [
  "bytes",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,12 +152,6 @@ semver = "1.0.14"
 # Mainly used for the musl builds, since the default musl malloc is very slow
 mimalloc = { version = "0.1.32", features = ["secure"], default-features = false, optional = true }
 
-[patch.crates-io]
-# Using a patched version of multer-rs (Used by Rocket) to fix attachment/send file uploads
-# Issue: https://github.com/dani-garcia/vaultwarden/issues/2644
-# Patch: https://github.com/BlackDex/multer-rs/commit/477d16b7fa0f361b5c2a5ba18a5b28bec6d26a8a
-multer = { git = "https://github.com/BlackDex/multer-rs", rev = "477d16b7fa0f361b5c2a5ba18a5b28bec6d26a8a" }
-
 # Strip debuginfo from the release builds
 # Also enable thin LTO for some optimizations
 [profile.release]

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -999,19 +999,6 @@ async fn save_attachment(
 
     let mut data = data.into_inner();
 
-    // There is a bug regarding uploading attachments/sends using the Mobile clients
-    // See: https://github.com/dani-garcia/vaultwarden/issues/2644 && https://github.com/bitwarden/mobile/issues/2018
-    // This has been fixed via a PR: https://github.com/bitwarden/mobile/pull/2031, but hasn't landed in a new release yet.
-    // On the vaultwarden side this is temporarily fixed by using a custom multer library
-    // See: https://github.com/dani-garcia/vaultwarden/pull/2675
-    // In any case we will match TempFile::File and not TempFile::Buffered, since Buffered will alter the contents.
-    if let TempFile::Buffered {
-        content: _,
-    } = &data.data
-    {
-        err!("Error reading attachment data. Please try an other client.");
-    }
-
     if let Some(size_limit) = size_limit {
         if data.data.len() > size_limit {
             err!("Attachment storage limit exceeded with this file");


### PR DESCRIPTION
Seems like the fix was merged into 2022.10.0: https://github.com/bitwarden/mobile/releases/tag/v2022.10.0. Which is few months old now, so I think it is safe to remvove the workarounds

cc @BlackDex