### PR TITLE
Improve comments

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -83,11 +83,11 @@
 
 ## Controls whether event logging is enabled for organizations
 ## This setting applies to organizations.
-## Default this is disabled. Also check the EVENT_CLEANUP_SCHEDULE and EVENTS_DAYS_RETAIN settings.
+## Disabled by default. Also check the EVENT_CLEANUP_SCHEDULE and EVENTS_DAYS_RETAIN settings.
 # ORG_EVENTS_ENABLED=false
 
 ## Number of days to retain events stored in the database.
-## If unset (the default), events are kept indefently and also disables the scheduled job!
+## If unset (the default), events are kept indefinitely and the scheduled job is disabled!
 # EVENTS_DAYS_RETAIN=
 
 ## Job scheduler settings


### PR DESCRIPTION
- The first one was not a proper sentence.
- The second one mixed passive and active form in the second part of the sentence.
- fixed spelling error