### PR TITLE
Make container get to a healthy state faster (60s -> 10s)

### DIFF
--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -249,6 +249,6 @@ COPY --from=build /app/target/release/vaultwarden .
 COPY docker/healthcheck.sh /healthcheck.sh
 COPY docker/start.sh /start.sh
 
-HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=10s --timeout=10s CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]


### PR DESCRIPTION
The way Docker health checks work is:

1. The container is started
2. Docker waits a full healthcheck `interval`
3. A healthcheck is made. If OK, mark as healthy

The problem is that (as described in 2.), Docker always waits a full interval before doing the first check. The `interval` configuration serves 2 purposes:
- wait time before the first health check
- wait time between subsequent health checks

This annoyance is also described in: https://github.com/moby/moby/issues/33410

The way this manifests as a problem is when reverse-proxying with Traefik, like we do by default in https://github.com/spantaleev/vaultwarden-docker-ansible-deploy

Traefik refuses to reverse-proxy to containers which are unhealthy (Health Status=starting is also considered unhealthy).

This means that Vaultwarden, with its current 60 second healthcheck interval will take a full minute to become healthy and to be reachable by Traefik.

In vaultwarden-docker-ansible-deploy, we currently work around this by overriding the default health check interval:
https://github.com/spantaleev/vaultwarden-docker-ansible-deploy/blob/015c459970d41743bd75980c2df02e389e1b461b/roles/custom/devture_vaultwarden/templates/vaultwarden.service.j2#L15-L36

With our workaround (which this patch also applies), it *only* takes 10 seconds after Vaultwarden startup and until Traefik would reverse-proxy to it.

----

This PR only updates `docker/Dockerfile.j2`. I haven't executed `make` in `docker/`, but I could do it and push that too if you'd like. Feel free to also do it yourself though!