### PR TITLE
Log message to stderr if LOG_FILE is not writable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -665,6 +665,12 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         err!(format!("`DATABASE_MAX_CONNS` contains an invalid value. Ensure it is between 1 and {}.", limit,));
     }
 
+    if let Some(log_file) = &cfg.log_file {
+        if std::fs::OpenOptions::new().append(true).create(true).open(log_file).is_err() {
+            err!("Unable to write to log file", log_file);
+        }
+    }
+
     let dom = cfg.domain.to_lowercase();
     if !dom.starts_with("http://") && !dom.starts_with("https://") {
         err!(


### PR DESCRIPTION
Closes #3055. Logs a message to stderr if the configured log file isn't writable. Because the `error!` macro is configured to use any log files already set up I'm using `eprintln!` here. Let me know if there's another way you would prefer.