### PR TITLE
Update WebSocket Notifications

### DIFF
--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -50,7 +50,7 @@ async fn post_folders(data: JsonUpcase<FolderData>, headers: Headers, mut conn: 
     let mut folder = Folder::new(headers.user.uuid, data.Name);
 
     folder.save(&mut conn).await?;
-    nt.send_folder_update(UpdateType::FolderCreate, &folder).await;
+    nt.send_folder_update(UpdateType::SyncFolderCreate, &folder, &headers.device.uuid).await;
 
     Ok(Json(folder.to_json()))
 }
@@ -88,7 +88,7 @@ async fn put_folder(
     folder.name = data.Name;
 
     folder.save(&mut conn).await?;
-    nt.send_folder_update(UpdateType::FolderUpdate, &folder).await;
+    nt.send_folder_update(UpdateType::SyncFolderUpdate, &folder, &headers.device.uuid).await;
 
     Ok(Json(folder.to_json()))
 }
@@ -112,6 +112,6 @@ async fn delete_folder(uuid: String, headers: Headers, mut conn: DbConn, nt: Not
     // Delete the actual folder entry
     folder.delete(&mut conn).await?;
 
-    nt.send_folder_update(UpdateType::FolderDelete, &folder).await;
+    nt.send_folder_update(UpdateType::SyncFolderDelete, &folder, &headers.device.uuid).await;
     Ok(())
 }


### PR DESCRIPTION
Previously the websocket notifications were using the string `app_id` as the
`ContextId`. This was incorrect and should have been the device_uuid
from the client device executing the request. The clients will ignore
the websocket request if the uuid matches. This also fixes some issues
with the Desktop client which is able to modify attachments within the
same screen and causes an issue when saving the attachment afterwards.

Also changed the way to handle removed attachments, since that causes an
error saving the vault cipher afterwards, complaining about a missing
attachment. Bitwarden ignores this, and continues with the remaining
attachments (if any). This also fixes #2591 .

Further some more websocket notifications have been added to some other
functions which enhance the user experience.

- Logout users when deauthed, changed password, rotated keys
- Trigger OrgSyncKeys on user confirm and removal
- Added some extra to the send feature

Also renamed UpdateTypes to match Bitwarden naming.
