### PR TITLE
Optimize CipherSyncData for very large vaults

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -584,10 +584,9 @@ async fn view_emergency_access(emer_id: String, headers: Headers, mut conn: DbCo
     }
 
     let ciphers = Cipher::find_owned_by_user(&emergency_access.grantor_uuid, &mut conn).await;
-    let cipher_sync_data =
-        CipherSyncData::new(&emergency_access.grantor_uuid, &ciphers, CipherSyncType::User, &mut conn).await;
+    let cipher_sync_data = CipherSyncData::new(&emergency_access.grantor_uuid, CipherSyncType::User, &mut conn).await;
 
-    let mut ciphers_json = Vec::new();
+    let mut ciphers_json = Vec::with_capacity(ciphers.len());
     for c in ciphers {
         ciphers_json
             .push(c.to_json(&headers.host, &emergency_access.grantor_uuid, Some(&cipher_sync_data), &mut conn).await);

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -617,9 +617,9 @@ async fn get_org_details(data: OrgIdData, headers: Headers, mut conn: DbConn) ->
 
 async fn _get_org_details(org_id: &str, host: &str, user_uuid: &str, conn: &mut DbConn) -> Value {
     let ciphers = Cipher::find_by_org(org_id, conn).await;
-    let cipher_sync_data = CipherSyncData::new(user_uuid, &ciphers, CipherSyncType::Organization, conn).await;
+    let cipher_sync_data = CipherSyncData::new(user_uuid, CipherSyncType::Organization, conn).await;
 
-    let mut ciphers_json = Vec::new();
+    let mut ciphers_json = Vec::with_capacity(ciphers.len());
     for c in ciphers {
         ciphers_json.push(c.to_json(host, user_uuid, Some(&cipher_sync_data), conn).await);
     }


### PR DESCRIPTION
As mentioned in #3111, using a very very large vault causes some issues. Mainly because of a SQLite limit, but, it could also cause issue on MariaDB/MySQL or PostgreSQL. It also uses a lot of memory, and memory allocations.

This PR solves this by removing the need of all the cipher_uuid's just to gather the correct attachments.

It will use the user_uuid and org_uuid's to get all attachments linked to both, weither the user has access to them or not. This isn't an issue, since the matching is done per cipher and the attachment data is only returned if there is a matching cipher to where the user has access to.

I also modified some code to be able to use `::with_capacity(n)` where possible. This prevents re-allocations if the `Vec` increases size, which will happen a lot if there are a lot of ciphers.

According to my tests measuring the time it takes to sync, it seems to have lowered the duration a bit more.

Fixes #3111