### PR TITLE
Add MFA icon to org member overview

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -2,7 +2,7 @@ use num_traits::FromPrimitive;
 use serde_json::Value;
 use std::cmp::Ordering;
 
-use super::{CollectionUser, GroupUser, OrgPolicy, OrgPolicyType, User};
+use super::{CollectionUser, GroupUser, OrgPolicy, OrgPolicyType, TwoFactor, User};
 use crate::CONFIG;
 
 db_object! {
@@ -365,6 +365,8 @@ impl UserOrganization {
             self.status
         };
 
+        let twofactor_enabled = !TwoFactor::find_by_user(&user.uuid, conn).await.is_empty();
+
         json!({
             "Id": self.uuid,
             "UserId": self.user_uuid,
@@ -374,6 +376,7 @@ impl UserOrganization {
             "Status": status,
             "Type": self.atype,
             "AccessAll": self.access_all,
+            "TwoFactorEnabled": twofactor_enabled,
 
             "Object": "organizationUserUserDetails",
         })


### PR DESCRIPTION
The Organization member overview supports showing an icon if the user has MFA enabled or not. This PR adds this feature.

This is very useful if you want to enable force mfa for example.

Example:
![image](https://user-images.githubusercontent.com/610450/211919433-70049ead-8166-47c7-bc4b-acde03b27851.png)
