### PR TITLE
add support for system mta though sendmail

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -373,7 +373,7 @@
 # ROCKET_WORKERS=10
 # ROCKET_TLS={certs="/path/to/certs.pem",key="/path/to/key.pem"}
 
-## Mail specific settings, set SMTP_HOST and SMTP_FROM to enable the mail service.
+## Mail specific settings, set SMTP_FROM and either SMTP_HOST or USE_SENDMAIL to enable the mail service.
 ## To make sure the email links are pointing to the correct host, set the DOMAIN variable.
 ## Note: if SMTP_USERNAME is specified, SMTP_PASSWORD is mandatory
 # SMTP_HOST=smtp.domain.tld
@@ -384,6 +384,11 @@
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
 # SMTP_TIMEOUT=15
+
+# Whether to send mail via the `sendmail` command
+# USE_SENDMAIL=false
+# Which sendmail command to use. The one found in the $PATH is used if not specified.
+# SENDMAIL_COMMAND="/path/to/sendmail"
 
 ## Defaults for SSL is "Plain" and "Login" and nothing for Non-SSL connections.
 ## Possible values: ["Plain", "Login", "Xoauth2"].

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,7 @@ dependencies = [
  "url",
  "uuid",
  "webauthn-rs",
+ "which",
  "yubico",
 ]
 
@@ -3394,6 +3395,17 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ webauthn-rs = "0.3.2"
 url = "2.3.1"
 
 # Email librariese-Base, Update crates and small change.
-lettre = { version = "0.10.1", features = ["smtp-transport", "builder", "serde", "tokio1-native-tls", "hostname", "tracing", "tokio1"], default-features = false }
+lettre = { version = "0.10.1", features = ["smtp-transport", "sendmail-transport", "builder", "serde", "tokio1-native-tls", "hostname", "tracing", "tokio1"], default-features = false }
 percent-encoding = "2.2.0" # URL encoding library used for URL's in the emails
 email_address = "0.2.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ semver = "1.0.16"
 # Allow overriding the default memory allocator
 # Mainly used for the musl builds, since the default musl malloc is very slow
 mimalloc = { version = "0.1.34", features = ["secure"], default-features = false, optional = true }
+which = "4.4.0"
 
 # Strip debuginfo from the release builds
 # Also enable thin LTO for some optimizations

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::env::consts::EXE_SUFFIX;
 use std::process::exit;
 use std::sync::RwLock;
 
@@ -749,12 +750,12 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         }
 
         if cfg.use_sendmail {
-            let command = cfg.sendmail_command.as_deref().unwrap_or("sendmail");
+            let command = cfg.sendmail_command.clone().unwrap_or_else(|| format!("sendmail{EXE_SUFFIX}"));
 
-            let mut path = std::path::PathBuf::from(command);
+            let mut path = std::path::PathBuf::from(&command);
 
             if !path.is_absolute() {
-                match which::which(command) {
+                match which::which(&command) {
                     Ok(result) => path = result,
                     Err(_) => err!(format!("sendmail command {command:?} not found in $PATH")),
                 }


### PR DESCRIPTION
This PR enables using `lettre`'s `SendmailTransport` in Vaultwarden.

It adds two configuration options:
    - `USE_SENDMAIL` wether to use sendmail instead of directly connecting to a SMTP server
    -  `SENDMAIL_COMMAND` what sendmail command to use. By default the one from the `$PATH` is used, but I think there are cases where it makes sense to specify a different one

Supporting the system MTA allows for more flexible mail configuration without too much effort and does not require packaging any sendmail client as assumed in #2198.

While there are other usecases like sending through a local mailserver without having to create a dedicated SMTP Account as mentioned in #2198, my specific usecase for this is the following:

I have msmtp configured with an account that all applications use without me having to paste the SMTP configuration and credentials into each of their configs and allows me to only have to maintain the one SMTP configuration instead of potentially forgetting one (not fun).

Testing can be done as follows:

```bash
> sudo pacman -S msmtp-mta
> sudo tee /etc/msmtprc << EOF
defaults

account default
auth on
from <from>
host <hostname>
password <passowrd>
tls on
user <username>
EOF
> tee .env << EOF
USE_SENDMAIL = true
SMTP_FROM = "bitwarden@tld"
EOF
> cargo run [...] # run vaultwarden
```

log into vaultwarden, click
User icon in top right > account settings > security > Two-step login > Email > Manage > Send Email
