### PR TITLE
Increase secure notes length to match LastPass.

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -380,8 +380,8 @@ pub async fn update_cipher_from_data(
     }
 
     if let Some(note) = &data.Notes {
-        if note.len() > 10_000 {
-            err!("The field Notes exceeds the maximum encrypted value length of 10000 characters.")
+        if note.len() > 50_000 {
+            err!("The field Notes exceeds the maximum encrypted value length of 50000 characters.")
         }
     }
 

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -82,11 +82,11 @@ impl Cipher {
         let mut validation_errors = serde_json::Map::new();
         for (index, cipher) in cipher_data.iter().enumerate() {
             if let Some(note) = &cipher.Notes {
-                if note.len() > 10_000 {
+                if note.len() > 50_000 {
                     validation_errors.insert(
                         format!("Ciphers[{index}].Notes"),
                         serde_json::to_value([
-                            "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
+                            "The field Notes exceeds the maximum encrypted value length of 50000 characters.",
                         ])
                         .unwrap(),
                     );


### PR DESCRIPTION
As users are migrating from LastPass, I am seeing more and more people hitting the max length of 10,000 on the "Notes" field, which applies to both CipherType.Login and CipherType.SecureNote.

This default is too low, and by being significantly lower than competing products, needlessly complicates the transition.

This is not helped by how unhelpful the import process is on web (showing errors in console only, silently dropping items), which is a PR for another day. By merging this, we can ensure that one of the most common drop-offs is fixed.

45,000 matches LastPass. As we know that the encrypted length can be longer than the raw text, I have increased this to 50,000 so there is a healthy buffer to account for this inflation.

Mirrors PR at https://github.com/bitwarden/server/pull/2625