### PR TITLE
don't nullify key when editing emergency access

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -123,7 +123,9 @@ async fn post_emergency_access(
 
     emergency_access.atype = new_type;
     emergency_access.wait_time_days = data.WaitTimeDays;
-    emergency_access.key_encrypted = data.KeyEncrypted;
+    if data.KeyEncrypted.is_some() {
+        emergency_access.key_encrypted = data.KeyEncrypted;
+    }
 
     emergency_access.save(&mut conn).await?;
     Ok(Json(emergency_access.to_json()))


### PR DESCRIPTION
I've looked into this some more and the client [does not send the key](https://github.com/bitwarden/clients/blob/7ebedbecfbbdfe17b011ca6490bf98fdd5116016/apps/web/src/app/settings/emergency-access-add-edit.component.ts#L74-L78) while editing an emergency access contact, so the field would be emptied on a change of the wait days or access level.

This simple fix should hopefully prevent issues like #3196 where the key has been set to `NULL`.

Closes #3196 