### PR TITLE
Fix trailing slash not getting removed from domain

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -283,7 +283,8 @@ impl<'r> FromRequest<'r> for Host {
 
         // Get host
         let host = if CONFIG.domain_set() {
-            CONFIG.domain()
+            // Remove trailing slash if it exists since we're getting a host
+            CONFIG.domain().trim_end_matches('/').to_string()
         } else if let Some(referer) = headers.get_one("Referer") {
             referer.to_string()
         } else {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -283,8 +283,7 @@ impl<'r> FromRequest<'r> for Host {
 
         // Get host
         let host = if CONFIG.domain_set() {
-            // Remove trailing slash if it exists since we're getting a host
-            CONFIG.domain().trim_end_matches('/').to_string()
+            CONFIG.domain()
         } else if let Some(referer) = headers.get_one("Referer") {
             referer.to_string()
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -401,7 +401,8 @@ make_config! {
     /// General settings
     settings {
         /// Domain URL |> This needs to be set to the URL used to access the server, including 'http[s]://'
-        /// and port, if it's different than the default. Some server functions don't work correctly without this value
+        /// and port, if it's different than the default, but excluding a trailing slash.
+        /// Some server functions don't work correctly without this value
         domain:                 String, true,   def,    "http://localhost".to_string();
         /// Domain Set |> Indicates if the domain is set by the admin. Otherwise the default will be used.
         domain_set:             bool,   false,  def,    false;

--- a/src/config.rs
+++ b/src/config.rs
@@ -401,8 +401,7 @@ make_config! {
     /// General settings
     settings {
         /// Domain URL |> This needs to be set to the URL used to access the server, including 'http[s]://'
-        /// and port, if it's different than the default. Don't include a trailing slash.
-        /// Some server functions don't work correctly without this value
+        /// and port, if it's different than the default. Some server functions don't work correctly without this value
         domain:                 String, true,   def,    "http://localhost".to_string();
         /// Domain Set |> Indicates if the domain is set by the admin. Otherwise the default will be used.
         domain_set:             bool,   false,  def,    false;

--- a/src/config.rs
+++ b/src/config.rs
@@ -401,7 +401,7 @@ make_config! {
     /// General settings
     settings {
         /// Domain URL |> This needs to be set to the URL used to access the server, including 'http[s]://'
-        /// and port, if it's different than the default, but excluding a trailing slash.
+        /// and port, if it's different than the default. Don't include a trailing slash.
         /// Some server functions don't work correctly without this value
         domain:                 String, true,   def,    "http://localhost".to_string();
         /// Domain Set |> Indicates if the domain is set by the admin. Otherwise the default will be used.

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,13 +141,7 @@ macro_rules! make_config {
                 )+)+
                 config.domain_set = _domain_set;
 
-                if config.domain_set {
-                    if config.domain.ends_with('/') {
-                        println!("[WARNING] The configured domain ends with a trailing slash.");
-                        println!("[WARNING] The trailing slash is getting removed.");
-                        config.domain = config.domain.trim_end_matches('/').to_string();
-                    }
-                }
+                config.domain = config.domain.trim_end_matches('/').to_string();
 
                 config.signups_domains_whitelist = config.signups_domains_whitelist.trim().to_lowercase();
                 config.org_creation_users = config.org_creation_users.trim().to_lowercase();

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,14 @@ macro_rules! make_config {
                 )+)+
                 config.domain_set = _domain_set;
 
+                if config.domain_set {
+                    if config.domain.ends_with('/') {
+                        println!("[WARNING] The configured domain ends with a trailing slash.");
+                        println!("[WARNING] The trailing slash is getting removed.");
+                        config.domain = config.domain.trim_end_matches('/').to_string();
+                    }
+                }
+
                 config.signups_domains_whitelist = config.signups_domains_whitelist.trim().to_lowercase();
                 config.org_creation_users = config.org_creation_users.trim().to_lowercase();
 


### PR DESCRIPTION
Bitwarden send won't work if the domain includes a trailing slash. This should be documented, as it may lead to confusion among users.