### PR TITLE
Fix Collection Read Only access for groups

### DIFF
--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -64,6 +64,8 @@ impl Collection {
                 Some(_) => {
                     if let Some(uc) = cipher_sync_data.user_collections.get(&self.uuid) {
                         (uc.read_only, uc.hide_passwords)
+                    } else if let Some(cg) = cipher_sync_data.user_collections_groups.get(&self.uuid) {
+                        (cg.read_only, cg.hide_passwords)
                     } else {
                         (false, false)
                     }


### PR DESCRIPTION
Previously only user rights where checked for collection when adding a new entry. 

The problem was with a group with only read-only access, the user had the collection in his collection list when adding a new entry as explained in issue #3249  .

Fixes #3249 
