### PR TITLE
Make the admin session lifetime adjustable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -335,6 +335,9 @@
 ## Allow a burst of requests of up to this size, while maintaining the average indicated by `ADMIN_RATELIMIT_SECONDS`.
 # ADMIN_RATELIMIT_MAX_BURST=3
 
+## Set the lifetime of the cookie that is used to authorize admin requests to this value (in minutes).
+# ADMIN_COOKIE_LIFETIME=20
+
 ## Yubico (Yubikey) Settings
 ## Set your Client ID and Secret Key for Yubikey OTP
 ## You can generate it here: https://upgrade.yubico.com/getapikey/

--- a/.env.template
+++ b/.env.template
@@ -335,8 +335,8 @@
 ## Allow a burst of requests of up to this size, while maintaining the average indicated by `ADMIN_RATELIMIT_SECONDS`.
 # ADMIN_RATELIMIT_MAX_BURST=3
 
-## Set the lifetime of the cookie that is used to authorize admin requests to this value (in minutes).
-# ADMIN_COOKIE_LIFETIME=20
+## Set the lifetime of admin sessions to this value (in minutes).
+# ADMIN_SESSION_LIFETIME=20
 
 ## Yubico (Yubikey) Settings
 ## Set your Client ID and Secret Key for Yubikey OTP

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -183,7 +183,7 @@ fn post_admin_login(data: Form<LoginForm>, cookies: &CookieJar<'_>, ip: ClientIp
 
         let cookie = Cookie::build(COOKIE_NAME, jwt)
             .path(admin_path())
-            .max_age(rocket::time::Duration::minutes(20))
+            .max_age(rocket::time::Duration::minutes(CONFIG.admin_cookie_lifetime()))
             .same_site(SameSite::Strict)
             .http_only(true)
             .finish();

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -183,7 +183,7 @@ fn post_admin_login(data: Form<LoginForm>, cookies: &CookieJar<'_>, ip: ClientIp
 
         let cookie = Cookie::build(COOKIE_NAME, jwt)
             .path(admin_path())
-            .max_age(rocket::time::Duration::minutes(CONFIG.admin_cookie_lifetime()))
+            .max_age(rocket::time::Duration::minutes(CONFIG.admin_session_lifetime()))
             .same_site(SameSite::Strict)
             .http_only(true)
             .finish();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -241,7 +241,7 @@ pub fn generate_admin_claims() -> BasicJwtClaims {
     let time_now = Utc::now().naive_utc();
     BasicJwtClaims {
         nbf: time_now.timestamp(),
-        exp: (time_now + Duration::minutes(20)).timestamp(),
+        exp: (time_now + Duration::minutes(CONFIG.admin_cookie_lifetime())).timestamp(),
         iss: JWT_ADMIN_ISSUER.to_string(),
         sub: "admin_panel".to_string(),
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -241,7 +241,7 @@ pub fn generate_admin_claims() -> BasicJwtClaims {
     let time_now = Utc::now().naive_utc();
     BasicJwtClaims {
         nbf: time_now.timestamp(),
-        exp: (time_now + Duration::minutes(CONFIG.admin_cookie_lifetime())).timestamp(),
+        exp: (time_now + Duration::minutes(CONFIG.admin_session_lifetime())).timestamp(),
         iss: JWT_ADMIN_ISSUER.to_string(),
         sub: "admin_panel".to_string(),
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,6 +581,9 @@ make_config! {
         /// Max burst size for admin login requests |> Allow a burst of requests of up to this size, while maintaining the average indicated by `admin_ratelimit_seconds`
         admin_ratelimit_max_burst:     u32, false, def, 3;
 
+        /// Admin cookie lifetime |> Set the lifetime of the cookie that is used to authorize admin requests to this value (in minutes).
+        admin_cookie_lifetime:  i64,    true,   def,    20;
+
         /// Enable groups (BETA!) (Know the risks!) |> Enables groups support for organizations (Currently contains known issues!).
         org_groups_enabled:     bool,   false,  def,    false;
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,8 +581,8 @@ make_config! {
         /// Max burst size for admin login requests |> Allow a burst of requests of up to this size, while maintaining the average indicated by `admin_ratelimit_seconds`
         admin_ratelimit_max_burst:     u32, false, def, 3;
 
-        /// Admin cookie lifetime |> Set the lifetime of the cookie that is used to authorize admin requests to this value (in minutes).
-        admin_cookie_lifetime:  i64,    true,   def,    20;
+        /// Admin session lifetime |> Set the lifetime of admin sessions to this value (in minutes).
+        admin_session_lifetime:        i64, true,  def, 20;
 
         /// Enable groups (BETA!) (Know the risks!) |> Enables groups support for organizations (Currently contains known issues!).
         org_groups_enabled:     bool,   false,  def,    false;


### PR DESCRIPTION
In my opinion, it may be useful if this value is adjustable to personal needs. For example, I want to access the Admin API programmatically and accordingly I want to set this value to as short as possible. Others may want to set the value higher if they often spend a long time in the Admin UI or something.