### PR TITLE
change WEBSOCKET_ENABLED default value to true

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,7 +66,7 @@
 # WEB_VAULT_ENABLED=true
 
 ## Enables websocket notifications
-# WEBSOCKET_ENABLED=false
+# WEBSOCKET_ENABLED=true
 
 ## Controls the WebSocket server address and port
 # WEBSOCKET_ADDRESS=0.0.0.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,7 +371,7 @@ make_config! {
     },
     ws {
         /// Enable websocket notifications
-        websocket_enabled:      bool,   false,  def,    false;
+        websocket_enabled:      bool,   false,  def,    true;
         /// Websocket address
         websocket_address:      String, false,  def,    "0.0.0.0".to_string();
         /// Websocket port


### PR DESCRIPTION
Currently `WEBSOCKET_ENABLED` defaults to `false`, which causes the inability to log into BitWarden apps (iOS & Android). The only thing I saw in the wiki about this ENV_VAR was related to getting notifications [wiki](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-WebSocket-notifications). In fact the wiki specifically mentions how it doesn't affect mobile because of push notifications. 

Proposing the default value be changed to `true` because neither iOS nor Android apps can log in without `WEBSOCKET_ENABLED=true` env var and this seems like a reasonable baseline setting.