### PR TITLE
Add confirmation for removing 2FA and deauthing sessions in admin panel

### DIFF
--- a/src/static/scripts/admin_users.js
+++ b/src/static/scripts/admin_users.js
@@ -32,10 +32,13 @@ function remove2fa(event) {
         alert("Required parameters not found!");
         return false;
     }
-    _post(`${BASE_URL}/admin/users/${id}/remove-2fa`,
-        "2FA removed correctly",
-        "Error removing 2FA"
-    );
+    const confirmed = confirm(`Are you sure you want to remove 2FA for "${email}"?`);
+    if (confirmed) {
+        _post(`${BASE_URL}/admin/users/${id}/remove-2fa`,
+            "2FA removed correctly",
+            "Error removing 2FA"
+        );
+    }
 }
 
 function deauthUser(event) {
@@ -46,10 +49,13 @@ function deauthUser(event) {
         alert("Required parameters not found!");
         return false;
     }
-    _post(`${BASE_URL}/admin/users/${id}/deauth`,
-        "Sessions deauthorized correctly",
-        "Error deauthorizing sessions"
-    );
+    const confirmed = confirm(`Are you sure you want to deauthorize sessions for "${email}"?`);
+    if (confirmed) {
+        _post(`${BASE_URL}/admin/users/${id}/deauth`,
+            "Sessions deauthorized correctly",
+            "Error deauthorizing sessions"
+        );
+    }
 }
 
 function disableUser(event) {


### PR DESCRIPTION
As someone who has inadvertently pressed "Remove all 2FA" instead of "Deauthorize sessions" one too many times (and had to re-add all my YubiKeys) - there should be a confirmation prompt before taking either of those actions.

Regardless of my accidental misclicks - any action that modifies user state should be protected by a confirmation prompt.