### PR TITLE
always return KdfMemory and KdfParallelism

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -803,15 +803,12 @@ pub async fn _prelogin(data: JsonUpcase<PreloginData>, mut conn: DbConn) -> Json
         None => (User::CLIENT_KDF_TYPE_DEFAULT, User::CLIENT_KDF_ITER_DEFAULT, None, None),
     };
 
-    let mut result = json!({
+    let result = json!({
         "Kdf": kdf_type,
         "KdfIterations": kdf_iter,
+        "KdfMemory": kdf_mem,
+        "KdfParallelism": kdf_para,
     });
-
-    if kdf_type == UserKdfType::Argon2id as i32 {
-        result["KdfMemory"] = Value::Number(kdf_mem.expect("Argon2 memory parameter is required.").into());
-        result["KdfParallelism"] = Value::Number(kdf_para.expect("Argon2 parallelism parameter is required.").into());
-    }
 
     Json(result)
 }

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -169,8 +169,8 @@ pub async fn _register(data: JsonUpcase<RegisterData>, mut conn: DbConn) -> Json
         user.client_kdf_iter = client_kdf_iter;
     }
 
-    user.client_kdf_parallelism = data.KdfMemory;
-    user.client_kdf_memory = data.KdfParallelism;
+    user.client_kdf_memory = data.KdfMemory;
+    user.client_kdf_parallelism = data.KdfParallelism;
 
     user.set_password(&data.MasterPasswordHash, Some(data.Key), true, None);
     user.password_hint = password_hint;
@@ -389,6 +389,9 @@ async fn post_kdf(data: JsonUpcase<ChangeKdfData>, headers: Headers, mut conn: D
         } else {
             err!("Argon2 parallelism parameter is required.")
         }
+    } else {
+        user.client_kdf_memory = None;
+        user.client_kdf_parallelism = None;
     }
     user.client_kdf_iter = data.KdfIterations;
     user.client_kdf_type = data.Kdf;

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -628,20 +628,14 @@ async fn takeover_emergency_access(emer_id: String, headers: Headers, mut conn: 
         None => err!("Grantor user not found."),
     };
 
-    let mut result = json!({
+    let result = json!({
         "Kdf": grantor_user.client_kdf_type,
         "KdfIterations": grantor_user.client_kdf_iter,
+        "KdfMemory": grantor_user.client_kdf_memory,
+        "KdfParallelism": grantor_user.client_kdf_parallelism,
         "KeyEncrypted": &emergency_access.key_encrypted,
         "Object": "emergencyAccessTakeover",
     });
-
-    if grantor_user.client_kdf_type == UserKdfType::Argon2id as i32 {
-        result["KdfMemory"] =
-            Value::Number(grantor_user.client_kdf_memory.expect("Argon2 memory parameter is required.").into());
-        result["KdfParallelism"] = Value::Number(
-            grantor_user.client_kdf_parallelism.expect("Argon2 parallelism parameter is required.").into(),
-        );
-    }
 
     Ok(Json(result))
 }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -107,7 +107,7 @@ async fn _refresh_login(data: ConnectData, conn: &mut DbConn) -> JsonResult {
     let (access_token, expires_in) = device.refresh_tokens(&user, orgs, scope_vec);
     device.save(conn).await?;
 
-    let mut result = json!({
+    let result = json!({
         "access_token": access_token,
         "expires_in": expires_in,
         "token_type": "Bearer",
@@ -117,17 +117,12 @@ async fn _refresh_login(data: ConnectData, conn: &mut DbConn) -> JsonResult {
 
         "Kdf": user.client_kdf_type,
         "KdfIterations": user.client_kdf_iter,
+        "KdfMemory": user.client_kdf_memory,
+        "KdfParallelism": user.client_kdf_parallelism,
         "ResetMasterPassword": false, // TODO: according to official server seems something like: user.password_hash.is_empty(), but would need testing
         "scope": scope,
         "unofficialServer": true,
     });
-
-    if user.client_kdf_type == UserKdfType::Argon2id as i32 {
-        result["KdfMemory"] =
-            Value::Number(user.client_kdf_memory.expect("Argon2 memory parameter is required.").into());
-        result["KdfParallelism"] =
-            Value::Number(user.client_kdf_parallelism.expect("Argon2 parallelism parameter is required.").into());
-    }
 
     Ok(Json(result))
 }
@@ -260,6 +255,8 @@ async fn _password_login(
 
         "Kdf": user.client_kdf_type,
         "KdfIterations": user.client_kdf_iter,
+        "KdfMemory": user.client_kdf_memory,
+        "KdfParallelism": user.client_kdf_parallelism,
         "ResetMasterPassword": false,// TODO: Same as above
         "scope": scope,
         "unofficialServer": true,
@@ -267,13 +264,6 @@ async fn _password_login(
 
     if let Some(token) = twofactor_token {
         result["TwoFactorToken"] = Value::String(token);
-    }
-
-    if user.client_kdf_type == UserKdfType::Argon2id as i32 {
-        result["KdfMemory"] =
-            Value::Number(user.client_kdf_memory.expect("Argon2 memory parameter is required.").into());
-        result["KdfParallelism"] =
-            Value::Number(user.client_kdf_parallelism.expect("Argon2 parallelism parameter is required.").into());
     }
 
     info!("User {} logged in successfully. IP: {}", username, ip.ip);
@@ -360,7 +350,7 @@ async fn _api_key_login(
 
     // Note: No refresh_token is returned. The CLI just repeats the
     // client_credentials login flow when the existing token expires.
-    let mut result = json!({
+    let result = json!({
         "access_token": access_token,
         "expires_in": expires_in,
         "token_type": "Bearer",
@@ -369,17 +359,12 @@ async fn _api_key_login(
 
         "Kdf": user.client_kdf_type,
         "KdfIterations": user.client_kdf_iter,
+        "KdfMemory": user.client_kdf_memory,
+        "KdfParallelism": user.client_kdf_parallelism,
         "ResetMasterPassword": false, // TODO: Same as above
         "scope": scope,
         "unofficialServer": true,
     });
-
-    if user.client_kdf_type == UserKdfType::Argon2id as i32 {
-        result["KdfMemory"] =
-            Value::Number(user.client_kdf_memory.expect("Argon2 memory parameter is required.").into());
-        result["KdfParallelism"] =
-            Value::Number(user.client_kdf_parallelism.expect("Argon2 parallelism parameter is required.").into());
-    }
 
     Ok(Json(result))
 }


### PR DESCRIPTION
As discussed in #3390 we could simplify the login logic a bit because the client will ignore the value of theses fields in case of `PBKDF2` (whether they are unset or set to any value from trying out `Argon2id` as KDF)

With `Argon2id` those fields should never be `null` but always in a valid state. Be aware that if they are `null` the client will assume the bitwarden presets (i.e. m=64 and p=4) and if the fields are set to something else (not sure how this would happen but it's technically possible with a sqlite database) the login would most likely fail.

So there should not be a reason to panic.

Disclaimer: I've only tested this change with the web-vault. Since this seems to be also the behavior of vault.bitwarden.com I'm assuming that the other clients will not behave differently in this regard.