### PR TITLE
Fix sending out multiple websocket notifications

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -715,6 +715,7 @@ impl UserOrganization {
                 )
             )
             .select(users_organizations::all_columns)
+            .distinct()
             .load::<UserOrganizationDb>(conn).expect("Error loading user organizations").from_db()
         }}
     }


### PR DESCRIPTION
For some reason I encountered a strange bug which resulted in sending out multiple websocket notifications for the exact same user.

Added a `distinct()` for the query to filter out multiple uuid's.