### PR TITLE
Change `String` to `&str` for all Rocket functions and some other fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1516,9 +1516,9 @@ checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a558e3d911bc3c7bfc8c78bc580b404d6e51c1cefbf656e176a94b49b0df40"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
 dependencies = [
  "cc",
  "libc",
@@ -1552,9 +1552,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "lock_api"
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d88dad3f985ec267a3fcb7a1726f5cb1a7e8cad8b646e70a84f967210df23da"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1680,9 +1680,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -1847,9 +1847,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.51"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -2000,9 +2000,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2020,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2033,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -2230,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "quoted_printable"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24039f627d8285853cc90dcddf8c1ebfaa91f834566948872b225b9a28ed1b6"
+checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
 name = "r2d2"
@@ -2356,9 +2356,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "async-compression",
  "base64 0.21.0",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "rocket"
 version = "0.5.0-rc.3"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=a82508b403420bd941c32ddec3ee3e4875f2b8a5#a82508b403420bd941c32ddec3ee3e4875f2b8a5"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=9b0564ed27f90686b333337d9f6ed76484a84b27#9b0564ed27f90686b333337d9f6ed76484a84b27"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "rocket_codegen"
 version = "0.5.0-rc.3"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=a82508b403420bd941c32ddec3ee3e4875f2b8a5#a82508b403420bd941c32ddec3ee3e4875f2b8a5"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=9b0564ed27f90686b333337d9f6ed76484a84b27#9b0564ed27f90686b333337d9f6ed76484a84b27"
 dependencies = [
  "devise",
  "glob",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "rocket_http"
 version = "0.5.0-rc.3"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=a82508b403420bd941c32ddec3ee3e4875f2b8a5#a82508b403420bd941c32ddec3ee3e4875f2b8a5"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=9b0564ed27f90686b333337d9f6ed76484a84b27#9b0564ed27f90686b333337d9f6ed76484a84b27"
 dependencies = [
  "cookie 0.17.0",
  "either",
@@ -2529,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "rocket_ws"
 version = "0.1.0-rc.3"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=a82508b403420bd941c32ddec3ee3e4875f2b8a5#a82508b403420bd941c32ddec3ee3e4875f2b8a5"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=9b0564ed27f90686b333337d9f6ed76484a84b27#9b0564ed27f90686b333337d9f6ed76484a84b27"
 dependencies = [
  "rocket",
  "tokio-tungstenite",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "syslog"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978044cc68150ad5e40083c9f6a725e6fd02d7ba1bcf691ec2ff0d66c0b41acc"
+checksum = "7434e95bcccce1215d30f4bf84fe8c00e8de1b9be4fb736d747ca53d36e7f96f"
 dependencies = [
  "error-chain",
  "hostname",
@@ -3038,9 +3038,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3052,14 +3052,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3177,13 +3177,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3385,9 +3385,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ unstable = []
 
 [target."cfg(not(windows))".dependencies]
 # Logging
-syslog = "6.0.1"
+syslog = "6.1.0"
 
 [dependencies]
 # Logging
@@ -57,7 +57,7 @@ num-derive = "0.3.3"
 # Web framework
 rocket = { version = "0.5.0-rc.3", features = ["tls", "json"], default-features = false }
 # rocket_ws = { version ="0.1.0-rc.3" }
-rocket_ws = { git = 'https://github.com/SergioBenitez/Rocket', rev = "a82508b403420bd941c32ddec3ee3e4875f2b8a5" }
+rocket_ws = { git = 'https://github.com/SergioBenitez/Rocket', rev = "9b0564ed27f90686b333337d9f6ed76484a84b27" }
 
 # WebSockets libraries
 tokio-tungstenite = "0.18.0"
@@ -68,7 +68,7 @@ dashmap = "5.4.0"
 
 # Async futures
 futures = "0.3.28"
-tokio = { version = "1.27.0", features = ["rt-multi-thread", "fs", "io-util", "parking_lot", "time", "signal"] }
+tokio = { version = "1.28.0", features = ["rt-multi-thread", "fs", "io-util", "parking_lot", "time", "signal"] }
 
 # A generic serialization/deserialization framework
 serde = { version = "1.0.160", features = ["derive"] }
@@ -87,7 +87,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 ring = "0.16.20"
 
 # UUID generation
-uuid = { version = "1.3.1", features = ["v4"] }
+uuid = { version = "1.3.2", features = ["v4"] }
 
 # Date and time libraries
 chrono = { version = "0.4.24", features = ["clock", "serde"], default-features = false }
@@ -124,7 +124,7 @@ email_address = "0.2.4"
 handlebars = { version = "4.3.6", features = ["dir_source"] }
 
 # HTTP client (Used for favicons, version check, DUO and HIBP API)
-reqwest = { version = "0.11.16", features = ["stream", "json", "gzip", "brotli", "socks", "cookies", "trust-dns"] }
+reqwest = { version = "0.11.17", features = ["stream", "json", "gzip", "brotli", "socks", "cookies", "trust-dns"] }
 
 # Favicon extraction libraries
 html5gum = "0.5.2"
@@ -140,7 +140,7 @@ cookie = "0.16.2"
 cookie_store = "0.19.0"
 
 # Used by U2F, JWT and PostgreSQL
-openssl = "0.10.51"
+openssl = "0.10.52"
 
 # CLI argument parsing
 pico-args = "0.5.0"
@@ -154,7 +154,7 @@ semver = "1.0.17"
 
 # Allow overriding the default memory allocator
 # Mainly used for the musl builds, since the default musl malloc is very slow
-mimalloc = { version = "0.1.36", features = ["secure"], default-features = false, optional = true }
+mimalloc = { version = "0.1.37", features = ["secure"], default-features = false, optional = true }
 which = "4.4.0"
 
 # Argon2 library with support for the PHC format
@@ -164,8 +164,8 @@ argon2 = "0.5.0"
 rpassword = "7.2.0"
 
 [patch.crates-io]
-rocket = { git = 'https://github.com/SergioBenitez/Rocket', rev = 'a82508b403420bd941c32ddec3ee3e4875f2b8a5' }
-# rocket_ws = { git = 'https://github.com/SergioBenitez/Rocket', rev = 'a82508b403420bd941c32ddec3ee3e4875f2b8a5' }
+rocket = { git = 'https://github.com/SergioBenitez/Rocket', rev = '9b0564ed27f90686b333337d9f6ed76484a84b27' }
+# rocket_ws = { git = 'https://github.com/SergioBenitez/Rocket', rev = '9b0564ed27f90686b333337d9f6ed76484a84b27' }
 
 # Strip debuginfo from the release builds
 # Also enable thin LTO for some optimizations

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -24,8 +24,8 @@ async fn get_folders(headers: Headers, mut conn: DbConn) -> Json<Value> {
 }
 
 #[get("/folders/<uuid>")]
-async fn get_folder(uuid: String, headers: Headers, mut conn: DbConn) -> JsonResult {
-    let folder = match Folder::find_by_uuid(&uuid, &mut conn).await {
+async fn get_folder(uuid: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    let folder = match Folder::find_by_uuid(uuid, &mut conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };
@@ -57,7 +57,7 @@ async fn post_folders(data: JsonUpcase<FolderData>, headers: Headers, mut conn: 
 
 #[post("/folders/<uuid>", data = "<data>")]
 async fn post_folder(
-    uuid: String,
+    uuid: &str,
     data: JsonUpcase<FolderData>,
     headers: Headers,
     conn: DbConn,
@@ -68,7 +68,7 @@ async fn post_folder(
 
 #[put("/folders/<uuid>", data = "<data>")]
 async fn put_folder(
-    uuid: String,
+    uuid: &str,
     data: JsonUpcase<FolderData>,
     headers: Headers,
     mut conn: DbConn,
@@ -76,7 +76,7 @@ async fn put_folder(
 ) -> JsonResult {
     let data: FolderData = data.into_inner().data;
 
-    let mut folder = match Folder::find_by_uuid(&uuid, &mut conn).await {
+    let mut folder = match Folder::find_by_uuid(uuid, &mut conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };
@@ -94,13 +94,13 @@ async fn put_folder(
 }
 
 #[post("/folders/<uuid>/delete")]
-async fn delete_folder_post(uuid: String, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+async fn delete_folder_post(uuid: &str, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
     delete_folder(uuid, headers, conn, nt).await
 }
 
 #[delete("/folders/<uuid>")]
-async fn delete_folder(uuid: String, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
-    let folder = match Folder::find_by_uuid(&uuid, &mut conn).await {
+async fn delete_folder(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    let folder = match Folder::find_by_uuid(uuid, &mut conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),
     };

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -58,7 +58,7 @@ use crate::{
 };
 
 #[put("/devices/identifier/<uuid>/clear-token")]
-fn clear_device_token(uuid: String) -> &'static str {
+fn clear_device_token(uuid: &str) -> &'static str {
     // This endpoint doesn't have auth header
 
     let _ = uuid;
@@ -71,7 +71,7 @@ fn clear_device_token(uuid: String) -> &'static str {
 }
 
 #[put("/devices/identifier/<uuid>/token", data = "<data>")]
-fn put_device_token(uuid: String, data: JsonUpcase<Value>, headers: Headers) -> Json<Value> {
+fn put_device_token(uuid: &str, data: JsonUpcase<Value>, headers: Headers) -> Json<Value> {
     let _data: Value = data.into_inner().data;
     // Data has a single string value "PushToken"
     let _ = uuid;
@@ -170,7 +170,7 @@ async fn put_eq_domains(
 }
 
 #[get("/hibp/breach?<username>")]
-async fn hibp_breach(username: String) -> JsonResult {
+async fn hibp_breach(username: &str) -> JsonResult {
     let url = format!(
         "https://haveibeenpwned.com/api/v3/breachedaccount/{username}?truncateResponse=false&includeUnverified=false"
     );

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -97,15 +97,15 @@ async fn icon_redirect(domain: &str, template: &str) -> Option<Redirect> {
 }
 
 #[get("/<domain>/icon.png")]
-async fn icon_external(domain: String) -> Option<Redirect> {
-    icon_redirect(&domain, &CONFIG._icon_service_url()).await
+async fn icon_external(domain: &str) -> Option<Redirect> {
+    icon_redirect(domain, &CONFIG._icon_service_url()).await
 }
 
 #[get("/<domain>/icon.png")]
-async fn icon_internal(domain: String) -> Cached<(ContentType, Vec<u8>)> {
+async fn icon_internal(domain: &str) -> Cached<(ContentType, Vec<u8>)> {
     const FALLBACK_ICON: &[u8] = include_bytes!("../static/images/fallback-icon.png");
 
-    if !is_valid_domain(&domain) {
+    if !is_valid_domain(domain) {
         warn!("Invalid domain: {}", domain);
         return Cached::ttl(
             (ContentType::new("image", "png"), FALLBACK_ICON.to_vec()),
@@ -114,7 +114,7 @@ async fn icon_internal(domain: String) -> Cached<(ContentType, Vec<u8>)> {
         );
     }
 
-    match get_icon(&domain).await {
+    match get_icon(domain).await {
         Some((icon, icon_type)) => {
             Cached::ttl((ContentType::new("image", icon_type), icon), CONFIG.icon_cache_ttl(), true)
         }

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -111,8 +111,8 @@ fn alive_head(_conn: DbConn) -> EmptyResult {
 }
 
 #[get("/vw_static/<filename>")]
-pub fn static_files(filename: String) -> Result<(ContentType, &'static [u8]), Error> {
-    match filename.as_ref() {
+pub fn static_files(filename: &str) -> Result<(ContentType, &'static [u8]), Error> {
+    match filename {
         "404.png" => Ok((ContentType::PNG, include_bytes!("../static/images/404.png"))),
         "mail-github.png" => Ok((ContentType::PNG, include_bytes!("../static/images/mail-github.png"))),
         "logo-gray.png" => Ok((ContentType::PNG, include_bytes!("../static/images/logo-gray.png"))),

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -573,8 +573,8 @@ async fn send_email(address: &str, subject: &str, body_html: String, body_text: 
     let smtp_from = &CONFIG.smtp_from();
 
     let body = if CONFIG.smtp_embed_images() {
-        let logo_gray_body = Body::new(crate::api::static_files("logo-gray.png".to_string()).unwrap().1.to_vec());
-        let mail_github_body = Body::new(crate::api::static_files("mail-github.png".to_string()).unwrap().1.to_vec());
+        let logo_gray_body = Body::new(crate::api::static_files("logo-gray.png").unwrap().1.to_vec());
+        let mail_github_body = Body::new(crate::api::static_files("mail-github.png").unwrap().1.to_vec());
         MultiPart::alternative().singlepart(SinglePart::plain(body_text)).multipart(
             MultiPart::related()
                 .singlepart(SinglePart::html(body_html))

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
             log::LevelFilter::Off
         };
 
-    // Only show rocket underscore `_` logs when the level is Debug or higher
+    // Only show Rocket underscore `_` logs when the level is Debug or higher
     // Else this will bloat the log output with useless messages.
     let rocket_underscore_level = if level >= log::LevelFilter::Debug {
         log::LevelFilter::Warn
@@ -264,8 +264,13 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         .level_for("rustls::session", log::LevelFilter::Off)
         // Hide failed to close stream messages
         .level_for("hyper::server", log::LevelFilter::Warn)
-        // Silence rocket logs
+        // Silence Rocket `_` logs
         .level_for("_", rocket_underscore_level)
+        .level_for("rocket::response::responder::_", rocket_underscore_level)
+        .level_for("rocket::server::_", rocket_underscore_level)
+        .level_for("vaultwarden::api::admin::_", rocket_underscore_level)
+        .level_for("vaultwarden::api::notifications::_", rocket_underscore_level)
+        // Silence Rocket logs
         .level_for("rocket::launch", log::LevelFilter::Error)
         .level_for("rocket::launch_", log::LevelFilter::Error)
         .level_for("rocket::rocket", log::LevelFilter::Warn)

--- a/src/static/scripts/admin_settings.js
+++ b/src/static/scripts/admin_settings.js
@@ -19,7 +19,7 @@ function smtpTest(event) {
     }
 
     const data = JSON.stringify({ "email": test_email.value });
-    _post(`${BASE_URL}/admin/test/smtp/`,
+    _post(`${BASE_URL}/admin/test/smtp`,
         "SMTP Test email sent correctly",
         "Error sending SMTP test email",
         data, false
@@ -45,7 +45,7 @@ function getFormData() {
 
 function saveConfig(event) {
     const data = JSON.stringify(getFormData());
-    _post(`${BASE_URL}/admin/config/`,
+    _post(`${BASE_URL}/admin/config`,
         "Config saved correctly",
         "Error saving config",
         data

--- a/src/static/scripts/admin_users.js
+++ b/src/static/scripts/admin_users.js
@@ -113,7 +113,7 @@ function inviteUser(event) {
         "email": email.value
     });
     email.value = "";
-    _post(`${BASE_URL}/admin/invite/`,
+    _post(`${BASE_URL}/admin/invite`,
         "User invited correctly",
         "Error inviting user",
         data

--- a/src/util.rs
+++ b/src/util.rs
@@ -231,7 +231,7 @@ impl<'r> FromParam<'r> for SafeString {
 
 // Log all the routes from the main paths list, and the attachments endpoint
 // Effectively ignores, any static file route, and the alive endpoint
-const LOGGED_ROUTES: [&str; 5] = ["/api", "/admin", "/identity", "/icons", "/attachments"];
+const LOGGED_ROUTES: [&str; 7] = ["/api", "/admin", "/identity", "/icons", "/attachments", "/events", "/notifications"];
 
 // Boolean is extra debug, when true, we ignore the whitelist above and also print the mounts
 pub struct BetterLogging(pub bool);
@@ -248,7 +248,7 @@ impl Fairing for BetterLogging {
         if self.0 {
             info!(target: "routes", "Routes loaded:");
             let mut routes: Vec<_> = rocket.routes().collect();
-            routes.sort_by_key(|r| r.uri.path());
+            routes.sort_by_key(|r| r.uri.path().as_str());
             for route in routes {
                 if route.rank < 0 {
                     info!(target: "routes", "{:<6} {}", route.method, route.uri);


### PR DESCRIPTION
During setting the latest commit hash for Rocket and updating all the other crates, there were some messages regarding the usage of `String` for the Rocket endpoint function calls.
I acted upon this message and changed all `String` types to `&str` and modified the code where needed.

This ended up in less `alloc` calls, and probably also a bit less memory usage.

- Updated all the crates and commit hashes
- Modified all `String` to `&str` where applicable
- Prevent some `::_` logs from outputting
- Added some extra routes to be logged
- Fix some admin post endpoints
