### PR TITLE
policy data should be `null` not an empty object

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1652,7 +1652,7 @@ async fn get_policy(org_id: &str, pol_type: i32, _headers: AdminHeaders, mut con
 
     let policy = match OrgPolicy::find_by_org_and_type(org_id, pol_type_enum, &mut conn).await {
         Some(p) => p,
-        None => OrgPolicy::new(String::from(org_id), pol_type_enum, "{}".to_string()),
+        None => OrgPolicy::new(String::from(org_id), pol_type_enum, "null".to_string()),
     };
 
     Ok(Json(policy.to_json()))


### PR DESCRIPTION
The web-vault will throw an error in the web console when editing new policies with an empty data field (like "Require two-step login", "Single organization", "Remove individual vault" and "Remove Send")
![error-messages-in-incognito-mode](https://user-images.githubusercontent.com/509385/237051925-e0e92ff5-efcb-4ab4-9ad1-21484379971c.png)