### PR TITLE
update web-vault to v2023.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "byteorder"
@@ -1154,9 +1154,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "handlebars"
-version = "4.3.6"
+version = "4.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
 dependencies = [
  "log",
  "pest",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.143"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2221,9 +2221,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -2699,9 +2699,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -2718,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3038,9 +3038,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3188,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3521,9 +3521,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3531,24 +3531,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3558,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3568,22 +3568,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "wasm-streams"
@@ -3600,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,10 @@ dashmap = "5.4.0"
 
 # Async futures
 futures = "0.3.28"
-tokio = { version = "1.28.0", features = ["rt-multi-thread", "fs", "io-util", "parking_lot", "time", "signal"] }
+tokio = { version = "1.28.1", features = ["rt-multi-thread", "fs", "io-util", "parking_lot", "time", "signal"] }
 
 # A generic serialization/deserialization framework
-serde = { version = "1.0.162", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 
 # A safe, extensible ORM and Query builder
@@ -121,7 +121,7 @@ percent-encoding = "2.2.0" # URL encoding library used for URL's in the emails
 email_address = "0.2.4"
 
 # HTML Template library
-handlebars = { version = "4.3.6", features = ["dir_source"] }
+handlebars = { version = "4.3.7", features = ["dir_source"] }
 
 # HTTP client (Used for favicons, version check, DUO and HIBP API)
 reqwest = { version = "0.11.17", features = ["stream", "json", "gzip", "brotli", "socks", "cookies", "trust-dns"] }

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -61,8 +61,8 @@
 # 	https://docs.docker.com/develop/develop-images/multistage-build/
 # 	https://whitfin.io/speeding-up-rust-docker-builds/
 ####################### VAULT BUILD IMAGE  #######################
-{% set vault_version = "v2023.4.0" %}
-{% set vault_image_digest = "sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd" %}
+{% set vault_version = "v2023.4.2" %}
+{% set vault_image_digest = "sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e" %}
 # The web-vault digest specifies a particular web-vault build on Docker Hub.
 # Using the digest instead of the tag name provides better security,
 # as the digest of an image is immutable, whereas a tag name can later

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/amd64/Dockerfile.alpine
+++ b/docker/amd64/Dockerfile.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:x86_64-musl-stable-1.69.0 as build

--- a/docker/amd64/Dockerfile.buildkit
+++ b/docker/amd64/Dockerfile.buildkit
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/amd64/Dockerfile.buildkit.alpine
+++ b/docker/amd64/Dockerfile.buildkit.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:x86_64-musl-stable-1.69.0 as build

--- a/docker/arm64/Dockerfile
+++ b/docker/arm64/Dockerfile
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/arm64/Dockerfile.alpine
+++ b/docker/arm64/Dockerfile.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:aarch64-musl-stable-1.69.0 as build

--- a/docker/arm64/Dockerfile.buildkit
+++ b/docker/arm64/Dockerfile.buildkit
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/arm64/Dockerfile.buildkit.alpine
+++ b/docker/arm64/Dockerfile.buildkit.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:aarch64-musl-stable-1.69.0 as build

--- a/docker/armv6/Dockerfile
+++ b/docker/armv6/Dockerfile
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/armv6/Dockerfile.alpine
+++ b/docker/armv6/Dockerfile.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:arm-musleabi-stable-1.69.0 as build

--- a/docker/armv6/Dockerfile.buildkit
+++ b/docker/armv6/Dockerfile.buildkit
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/armv6/Dockerfile.buildkit.alpine
+++ b/docker/armv6/Dockerfile.buildkit.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:arm-musleabi-stable-1.69.0 as build

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/armv7/Dockerfile.alpine
+++ b/docker/armv7/Dockerfile.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:armv7-musleabihf-stable-1.69.0 as build

--- a/docker/armv7/Dockerfile.buildkit
+++ b/docker/armv7/Dockerfile.buildkit
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/library/rust:1.69.0-bullseye as build

--- a/docker/armv7/Dockerfile.buildkit.alpine
+++ b/docker/armv7/Dockerfile.buildkit.alpine
@@ -15,15 +15,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.0
-#     [docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2023.4.2
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2023.4.2
+#     [docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd
-#     [docker.io/vaultwarden/web-vault:v2023.4.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e
+#     [docker.io/vaultwarden/web-vault:v2023.4.2]
 #
-FROM docker.io/vaultwarden/web-vault@sha256:325db8d4476aab866edac799c149c556e4da256bf0beaa8443bc4d1668a009fd as vault
+FROM docker.io/vaultwarden/web-vault@sha256:33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e as vault
 
 ########################## BUILD IMAGE  ##########################
 FROM docker.io/blackdex/rust-musl:armv7-musleabihf-stable-1.69.0 as build


### PR DESCRIPTION
Update to latest web-vault using [vaultwarden/web-vault:v2023.4.2](https://hub.docker.com/layers/vaultwarden/web-vault/v2023.4.2/images/sha256-33f95dff16d8b62a6c0334ec0e425e5e549e6a826a4d8d3ea1beb95ded6acb0e)