### PR TITLE
2FA Confirmation Code Email subject line change to circumvent Google spam blocker

### DIFF
--- a/src/static/templates/email/twofactor_email.hbs
+++ b/src/static/templates/email/twofactor_email.hbs
@@ -1,4 +1,4 @@
-Your Two-step Login Verification Code
+Vaultwarden Confirmation Code
 <!---------------->
 Your two-step verification code is: {{token}}
 

--- a/src/static/templates/email/twofactor_email.html.hbs
+++ b/src/static/templates/email/twofactor_email.html.hbs
@@ -1,4 +1,4 @@
-Your Two-step Login Verification Code
+Vaultwarden Verification Code
 <!---------------->
 {{> email/email_header }}
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">


### PR DESCRIPTION
Changed subject lines in both the regular and HTML version of the 2FA confirmation email because previous subject line ("Your Two-step Login Verification Code") was being blocked by Google's servers.

The new subject line is "Vaultwarden Confirmation Code"

Please comment if a different subject line is preferable for any reason.

I've only tested this subject line with the emailer configured to use a Google SMTP server. If you have Vaultwarden configured to use another email service, please test this template using your email service.

(This is my first Pull Request, so if I've done anything wrong please (gently) let me know!)