### PR TITLE
Add mobile push device filter to non-null push uuid

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -403,10 +403,10 @@ async fn delete_user(uuid: &str, token: AdminToken, mut conn: DbConn) -> EmptyRe
 async fn deauth_user(uuid: &str, _token: AdminToken, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
     let mut user = get_user_or_404(uuid, &mut conn).await?;
 
-    nt.send_logout(&user, None, &mut conn).await;
+    nt.send_logout(&user, None).await;
 
     if CONFIG.push_enabled() {
-        for device in Device::find_push_device_by_user(&user.uuid, &mut conn).await {
+        for device in Device::find_push_devices_by_user(&user.uuid, &mut conn).await {
             match unregister_push_device(device.uuid).await {
                 Ok(r) => r,
                 Err(e) => error!("Unable to unregister devices from Bitwarden server: {}", e),
@@ -429,7 +429,7 @@ async fn disable_user(uuid: &str, _token: AdminToken, mut conn: DbConn, nt: Noti
 
     let save_result = user.save(&mut conn).await;
 
-    nt.send_logout(&user, None, &mut conn).await;
+    nt.send_logout(&user, None).await;
 
     save_result
 }

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -343,7 +343,7 @@ async fn post_password(
     // Prevent loging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
-    nt.send_logout(&user, Some(headers.device.uuid), &mut conn).await;
+    nt.send_logout(&user, Some(headers.device.uuid)).await;
 
     save_result
 }
@@ -403,7 +403,7 @@ async fn post_kdf(data: JsonUpcase<ChangeKdfData>, headers: Headers, mut conn: D
     user.set_password(&data.NewMasterPasswordHash, Some(data.Key), true, None);
     let save_result = user.save(&mut conn).await;
 
-    nt.send_logout(&user, Some(headers.device.uuid), &mut conn).await;
+    nt.send_logout(&user, Some(headers.device.uuid)).await;
 
     save_result
 }
@@ -490,7 +490,7 @@ async fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, mut conn: D
     // Prevent loging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
-    nt.send_logout(&user, Some(headers.device.uuid), &mut conn).await;
+    nt.send_logout(&user, Some(headers.device.uuid)).await;
 
     save_result
 }
@@ -513,7 +513,7 @@ async fn post_sstamp(
     user.reset_security_stamp();
     let save_result = user.save(&mut conn).await;
 
-    nt.send_logout(&user, None, &mut conn).await;
+    nt.send_logout(&user, None).await;
 
     save_result
 }
@@ -616,7 +616,7 @@ async fn post_email(
 
     let save_result = user.save(&mut conn).await;
 
-    nt.send_logout(&user, None, &mut conn).await;
+    nt.send_logout(&user, None).await;
 
     save_result
 }

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -2718,7 +2718,7 @@ async fn put_reset_password(
     user.set_password(reset_request.NewMasterPasswordHash.as_str(), Some(reset_request.Key), true, None);
     user.save(&mut conn).await?;
 
-    nt.send_logout(&user, None, &mut conn).await;
+    nt.send_logout(&user, None).await;
 
     log_event(
         EventType::OrganizationUserAdminResetPassword as i32,

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -180,8 +180,14 @@ async fn post_send(data: JsonUpcase<SendData>, headers: Headers, mut conn: DbCon
 
     let mut send = create_send(data, headers.user.uuid)?;
     send.save(&mut conn).await?;
-    nt.send_send_update(UpdateType::SyncSendCreate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendCreate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(Json(send.to_json()))
 }
@@ -253,8 +259,14 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, mut conn: 
 
     // Save the changes in the database
     send.save(&mut conn).await?;
-    nt.send_send_update(UpdateType::SyncSendCreate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendCreate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(Json(send.to_json()))
 }
@@ -337,8 +349,14 @@ async fn post_send_file_v2_data(
             data.data.move_copy_to(file_path).await?
         }
 
-        nt.send_send_update(UpdateType::SyncSendCreate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-            .await;
+        nt.send_send_update(
+            UpdateType::SyncSendCreate,
+            &send,
+            &send.update_users_revision(&mut conn).await,
+            &headers.device.uuid,
+            &mut conn,
+        )
+        .await;
     } else {
         err!("Send not found. Unable to save the file.");
     }
@@ -356,6 +374,7 @@ pub struct SendAccessData {
 async fn post_access(
     access_id: &str,
     data: JsonUpcase<SendAccessData>,
+    headers: Headers,
     mut conn: DbConn,
     ip: ClientIp,
     nt: Notify<'_>,
@@ -400,8 +419,14 @@ async fn post_access(
 
     send.save(&mut conn).await?;
 
-    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendUpdate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(Json(send.to_json_access(&mut conn).await))
 }
@@ -412,6 +437,7 @@ async fn post_access_file(
     file_id: &str,
     data: JsonUpcase<SendAccessData>,
     host: Host,
+    headers: Headers,
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
@@ -452,8 +478,14 @@ async fn post_access_file(
 
     send.save(&mut conn).await?;
 
-    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendUpdate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     let token_claims = crate::auth::generate_send_claims(send_id, file_id);
     let token = crate::auth::encode_jwt(&token_claims);
@@ -535,8 +567,14 @@ async fn put_send(
     }
 
     send.save(&mut conn).await?;
-    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendUpdate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(Json(send.to_json()))
 }
@@ -553,8 +591,14 @@ async fn delete_send(id: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_
     }
 
     send.delete(&mut conn).await?;
-    nt.send_send_update(UpdateType::SyncSendDelete, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendDelete,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(())
 }
@@ -574,8 +618,14 @@ async fn put_remove_password(id: &str, headers: Headers, mut conn: DbConn, nt: N
 
     send.set_password(None);
     send.save(&mut conn).await?;
-    nt.send_send_update(UpdateType::SyncSendUpdate, &send, &send.update_users_revision(&mut conn).await, &mut conn)
-        .await;
+    nt.send_send_update(
+        UpdateType::SyncSendUpdate,
+        &send,
+        &send.update_users_revision(&mut conn).await,
+        &headers.device.uuid,
+        &mut conn,
+    )
+    .await;
 
     Ok(Json(send.to_json()))
 }

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -240,11 +240,11 @@ impl WebSocketUsers {
         self.send_update(&user.uuid, &data).await;
 
         if CONFIG.push_enabled() {
-            push_user_update(ut, user).await;
+            push_user_update(ut, user);
         }
     }
 
-    pub async fn send_logout(&self, user: &User, acting_device_uuid: Option<String>, conn: &mut DbConn) {
+    pub async fn send_logout(&self, user: &User, acting_device_uuid: Option<String>) {
         let data = create_update(
             vec![("UserId".into(), user.uuid.clone().into()), ("Date".into(), serialize_date(user.updated_at))],
             UpdateType::LogOut,
@@ -254,7 +254,7 @@ impl WebSocketUsers {
         self.send_update(&user.uuid, &data).await;
 
         if CONFIG.push_enabled() {
-            push_logout(user, acting_device_uuid, conn).await;
+            push_logout(user, acting_device_uuid);
         }
     }
 
@@ -325,7 +325,14 @@ impl WebSocketUsers {
         }
     }
 
-    pub async fn send_send_update(&self, ut: UpdateType, send: &DbSend, user_uuids: &[String], conn: &mut DbConn) {
+    pub async fn send_send_update(
+        &self,
+        ut: UpdateType,
+        send: &DbSend,
+        user_uuids: &[String],
+        acting_device_uuid: &String,
+        conn: &mut DbConn,
+    ) {
         let user_uuid = convert_option(send.user_uuid.clone());
 
         let data = create_update(
@@ -342,7 +349,7 @@ impl WebSocketUsers {
             self.send_update(uuid, &data).await;
         }
         if CONFIG.push_enabled() && user_uuids.len() == 1 {
-            push_send_update(ut, send, conn).await;
+            push_send_update(ut, send, acting_device_uuid, conn).await;
         }
     }
 }

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -202,7 +202,7 @@ impl Device {
                 .from_db()
         }}
     }
-    pub async fn find_push_device_by_user(user_uuid: &str, conn: &mut DbConn) -> Vec<Self> {
+    pub async fn find_push_devices_by_user(user_uuid: &str, conn: &mut DbConn) -> Vec<Self> {
         db_run! { conn: {
             devices::table
                 .filter(devices::user_uuid.eq(user_uuid))
@@ -210,6 +210,18 @@ impl Device {
                 .load::<DeviceDb>(conn)
                 .expect("Error loading push devices")
                 .from_db()
+        }}
+    }
+
+    pub async fn check_user_has_push_device(user_uuid: &str, conn: &mut DbConn) -> bool {
+        db_run! { conn: {
+            devices::table
+            .filter(devices::user_uuid.eq(user_uuid))
+            .filter(devices::push_token.is_not_null())
+            .count()
+            .first::<i64>(conn)
+            .ok()
+            .unwrap_or(0) != 0
         }}
     }
 }


### PR DESCRIPTION
Partially fixes #3577.

Over time, old devices accumulate in the SQL device table. Even when the device push uuid is NULL, a push request is sent for them when mobile push is active. For my server, this lead to ~100 requests to the Bitwarden push servers without a single active mobile push client, and a request time of ~15 seconds.

This requests adds a filter to prevent mobile push notifications from being sent to clients who did not even register for mobile push.