### PR TITLE
feat: Support for storing passkeys in the vault

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -210,7 +210,8 @@ pub struct CipherData {
     Login = 1,
     SecureNote = 2,
     Card = 3,
-    Identity = 4
+    Identity = 4,
+    Fido2Key = 5
     */
     pub Type: i32,
     pub Name: String,
@@ -222,6 +223,7 @@ pub struct CipherData {
     SecureNote: Option<Value>,
     Card: Option<Value>,
     Identity: Option<Value>,
+    Fido2Key: Option<Value>,
 
     Favorite: Option<bool>,
     Reprompt: Option<i32>,
@@ -464,6 +466,7 @@ pub async fn update_cipher_from_data(
         2 => data.SecureNote,
         3 => data.Card,
         4 => data.Identity,
+        5 => data.Fido2Key,
         _ => err!("Invalid type"),
     };
 

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -27,7 +27,8 @@ db_object! {
         Login = 1,
         SecureNote = 2,
         Card = 3,
-        Identity = 4
+        Identity = 4,
+        Fido2key = 5
         */
         pub atype: i32,
         pub name: String,
@@ -223,6 +224,7 @@ impl Cipher {
             "SecureNote": null,
             "Card": null,
             "Identity": null,
+            "Fido2Key": null,
         });
 
         // These values are only needed for user/default syncs
@@ -251,6 +253,7 @@ impl Cipher {
             2 => "SecureNote",
             3 => "Card",
             4 => "Identity",
+            5 => "Fido2Key",
             _ => panic!("Wrong type"),
         };
 


### PR DESCRIPTION
# Implements the ability to store passkeys in the vault

## How to test
1. Checkout [this branch](https://github.com/bitwarden/server/tree/EC-598-beeep-properly-store-passkeys-in-bitwarden), then install dependencies with `npm i` (`npm ci` didn't worked, where `npm i` somehow worked in my case)
2. Enable feature flag for the extension. As I didn't figured out how to do this properly, I changed the values [there](https://github.com/bitwarden/clients/pull/4715/files#diff-ee9271bfbbddd589f955418cf1fc8a360ea76819afe2400d96d2f8a79dc3dd6dR41-R43) and [there](https://github.com/bitwarden/clients/pull/4715/files#diff-ee9271bfbbddd589f955418cf1fc8a360ea76819afe2400d96d2f8a79dc3dd6dR194-R196) to make them always return true
3. Follow the [docs](https://contributing.bitwarden.com/getting-started/clients/browser/#build-instructions) to build and install the modified extension in your browser (I installed it in a custom profile)
4. Go to a website supporting passkeys. I used [passkeys.io](https://passkeys.io), and also tested against [webauthn.io](https://webauthn.io) but any website supporting webauthn should actually work, then register your key

## Demo
https://github.com/dani-garcia/vaultwarden/assets/45696571/4c5bbfd6-3302-4ce2-9a2f-146e5653ce1b

## Notes
Upstream PR: bitwarden/server#2679
Tested on `Brave 1.54.65 Chromium: 114.0.5735.133 (Official build) nightly (64 bits) `
The feature isn't released yet, but there shouldn't be any big changes as Vaultwarden doesn't type the properties of ciphers the way upstream server does