### PR TITLE
Updated docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Pull the docker image and mount a volume from the host for persistent storage:
 
 ```sh
 docker pull vaultwarden/server:latest
-docker run -d --name vaultwarden -v /vw-data/:/data/ -p 80:80 vaultwarden/server:latest
+docker run -d --name vaultwarden -v /vw-data/:/data/ --restart unless-stopped -p 80:80 vaultwarden/server:latest
 ```
 This will preserve any persistent data under /vw-data/, you can adapt the path to whatever suits you.
 


### PR DESCRIPTION
I added `--restart unless-stopped` to the docker run command to let vaultwarden restart itself after a crash for example.
I added it to my run command because I found vaultwarden stopped for unknown reasons (maybe because docker tries to safe resources if this is a thing).

And you don't have to manual start the container on every server restart.