### PR TITLE
release optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,10 +168,14 @@ rocket = { git = 'https://github.com/SergioBenitez/Rocket', rev = 'ce441b5f46fdf
 # rocket_ws = { git = 'https://github.com/SergioBenitez/Rocket', rev = 'ce441b5f46fdf5cd99cb32b8b8638835e4c2a5fa' } # v0.5 branch
 
 # Strip debuginfo from the release builds
-# Also enable thin LTO for some optimizations
+# Also enable fat LTO, opt-level 3, codegen-units 1 for best optimization
 [profile.release]
-strip = "debuginfo"
-lto = "thin"
+opt-level = 3
+debug = false
+panic = "unwind"
+lto = true
+codegen-units = 1
+strip = true
 
 # Always build argon2 using opt-level 3
 # This is a huge speed improvement during testing


### PR DESCRIPTION
This optimization is not only for size but also runtime. Who doesn't want to use less CPU cycles? ;-)

Since releases are not done that often and usually via build machines and pipelines, I don't see it as an issue that the build time doubled.

That being said, if this is too extreme for a default release, I can also add another profile (e.g. called `production` or something similar).

| Description         | Change | Before   | After     |
|---------------------|--------|----------|-----------|
| Build time          | +110%  | 5min 31s | 11min 34s |
| Binary size (bytes) |  -42%  | 49466432 | 28576480  |

Build command: `cargo build --features sqlite,mysql,postgresql --release`

