### PR TITLE
fix version when compiled at a specific commit

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -72,7 +72,7 @@ fn version_from_git_info() -> Result<String, std::io::Error> {
     // Combined version
     if let Some(exact) = exact_tag {
         Ok(exact)
-    } else if &branch != "main" && &branch != "master" {
+    } else if &branch != "main" && &branch != "master" && &branch != "HEAD" {
         Ok(format!("{last_tag}-{rev_short} ({branch})"))
     } else {
         Ok(format!("{last_tag}-{rev_short}"))


### PR DESCRIPTION
When a specific commit is checked out from the main branch, the vaultwarden version is reported as `vaultwarden x.y.z-githash (HEAD)`. This is a problem, because the admin interface reports this as a version from a branch called HEAD, while in reality the commit was from the main branch.