### PR TITLE
Fix Org API Key generation on PosgreSQL

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -804,7 +804,7 @@ impl OrganizationApiKey {
                 let value = OrganizationApiKeyDb::to_db(self);
                 diesel::insert_into(organization_api_key::table)
                     .values(&value)
-                    .on_conflict(organization_api_key::uuid)
+                    .on_conflict((organization_api_key::uuid, organization_api_key::org_uuid))
                     .do_update()
                     .set(&value)
                     .execute(conn)


### PR DESCRIPTION
Using PostgreSQL creating or rotating the Org API Key failed because of some query mismatch. This PR fixes that.

Fixes https://github.com/dani-garcia/vaultwarden/discussions/3671#discussioncomment-6400394