### PR TITLE
Fix some external_id issues

### DIFF
--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -94,18 +94,11 @@ impl Group {
     }
 
     pub fn set_external_id(&mut self, external_id: Option<String>) {
-        //Check if external id is empty. We don't want to have
-        //empty strings in the database
-        match external_id {
-            Some(external_id) => {
-                if external_id.is_empty() {
-                    self.external_id = None;
-                } else {
-                    self.external_id = Some(external_id)
-                }
-            }
-            None => self.external_id = None,
-        }
+        // Check if external_id is empty. We do not want to have empty strings in the database
+        self.external_id = match external_id {
+            Some(external_id) if !external_id.trim().is_empty() => Some(external_id),
+            _ => None,
+        };
     }
 }
 

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -434,6 +434,7 @@ impl UserOrganization {
             "UserId": self.user_uuid,
             "Name": user.name,
             "Email": user.email,
+            "ExternalId": user.external_id,
             "Groups": groups,
             "Collections": collections,
 
@@ -441,7 +442,7 @@ impl UserOrganization {
             "Type": self.atype,
             "AccessAll": self.access_all,
             "TwoFactorEnabled": twofactor_enabled,
-            "ResetPasswordEnrolled":self.reset_password_key.is_some(),
+            "ResetPasswordEnrolled": self.reset_password_key.is_some(),
 
             "Object": "organizationUserUserDetails",
         })


### PR DESCRIPTION
 - Do not update `externalId` on group updates Groups are only updated via the web-vault currently, and those do not send the `externalId` value, and thus we need to prevent updating it.
 - Refactored some other ExternalId functions
 - Prevent empty `externalId` on `Collections`
 - Return `externalId` for users

Fixes #3685