### PR TITLE
Fix UserOrg status during LDAP Import

### DIFF
--- a/src/api/core/public.rs
+++ b/src/api/core/public.rs
@@ -85,7 +85,7 @@ async fn ldap_import(data: JsonUpcase<OrgImportData>, token: PublicToken, mut co
                     new_user
                 }
             };
-            let user_org_status = if CONFIG.mail_enabled() {
+            let user_org_status = if CONFIG.mail_enabled() || user.password_hash.is_empty() {
                 UserOrgStatus::Invited as i32
             } else {
                 UserOrgStatus::Accepted as i32 // Automatically mark user as accepted if no email invites


### PR DESCRIPTION
When a user does not have an account yet and SMTP was disabled it would set the UserOrg status still to Accepted, though that would make it possible to verify the user by the Org Admin's.
This would fail, since the user didn't actually crated his account, and therefor no PublicKey existed.

This PR fixes this behaviour by checking if the password is empty and if so, puts the user to an `Invited` state instead of `Accepted`.

Fixes #3737