### PR TITLE
Fix #3413: push to users accessing the collections using groups

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -273,15 +273,18 @@ impl Cipher {
             None => {
                 // Belongs to Organization, need to update affected users
                 if let Some(ref org_uuid) = self.organization_uuid {
-                    for user_org in UserOrganization::find_by_cipher_and_org(&self.uuid, org_uuid, conn).await.iter() {
-                        User::update_uuid_revision(&user_org.user_uuid, conn).await;
-                        user_uuids.push(user_org.user_uuid.clone());
+                    // users having access to the collection
+                    let mut collection_users =
+                        UserOrganization::find_by_cipher_and_org(&self.uuid, org_uuid, conn).await;
+                    if CONFIG.org_groups_enabled() {
+                        // members of a group having access to the collection
+                        let group_users =
+                            UserOrganization::find_by_cipher_and_org_with_group(&self.uuid, org_uuid, conn).await;
+                        collection_users.extend(group_users);
                     }
-                    for user_org in
-                        UserOrganization::find_by_cipher_and_org_with_group(&self.uuid, org_uuid, conn).await.iter()
-                    {
+                    for user_org in collection_users {
                         User::update_uuid_revision(&user_org.user_uuid, conn).await;
-                        user_uuids.push(user_org.user_uuid.clone());
+                        user_uuids.push(user_org.user_uuid.clone())
                     }
                 }
             }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -275,7 +275,13 @@ impl Cipher {
                 if let Some(ref org_uuid) = self.organization_uuid {
                     for user_org in UserOrganization::find_by_cipher_and_org(&self.uuid, org_uuid, conn).await.iter() {
                         User::update_uuid_revision(&user_org.user_uuid, conn).await;
-                        user_uuids.push(user_org.user_uuid.clone())
+                        user_uuids.push(user_org.user_uuid.clone());
+                    }
+                    for user_org in
+                        UserOrganization::find_by_cipher_and_org_with_group(&self.uuid, org_uuid, conn).await.iter()
+                    {
+                        User::update_uuid_revision(&user_org.user_uuid, conn).await;
+                        user_uuids.push(user_org.user_uuid.clone());
                     }
                 }
             }

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -769,6 +769,32 @@ impl UserOrganization {
         }}
     }
 
+    pub async fn find_by_cipher_and_org_with_group(cipher_uuid: &str, org_uuid: &str, conn: &mut DbConn) -> Vec<Self> {
+        db_run! { conn: {
+            users_organizations::table
+            .filter(users_organizations::org_uuid.eq(org_uuid))
+            .inner_join(groups_users::table.on(
+                groups_users::users_organizations_uuid.eq(users_organizations::uuid)
+            ))
+            .left_join(collections_groups::table.on(
+                collections_groups::groups_uuid.eq(groups_users::groups_uuid)
+            ))
+            .left_join(groups::table.on(groups::uuid.eq(groups_users::groups_uuid)))
+            .left_join(ciphers_collections::table.on(
+                    ciphers_collections::collection_uuid.eq(collections_groups::collections_uuid).and(ciphers_collections::cipher_uuid.eq(&cipher_uuid))
+
+                ))
+            .filter(
+                    groups::access_all.eq(true).or( // AccessAll via groups
+                        ciphers_collections::cipher_uuid.eq(&cipher_uuid) // ..or access to collection via group
+                    )
+                )
+                .select(users_organizations::all_columns)
+                .distinct()
+            .load::<UserOrganizationDb>(conn).expect("Error loading user organizations with groups").from_db()
+        }}
+    }
+
     pub async fn user_has_ge_admin_access_to_cipher(user_uuid: &str, cipher_uuid: &str, conn: &mut DbConn) -> bool {
         db_run! { conn: {
             users_organizations::table


### PR DESCRIPTION
I bet it can be done with a single query within the `find_by_cipher_and_org` function but I didn't managed to get it work (the `filter` gets complicated, adding `groups::access_all.eq(true)` works but I can't figure out how to check if the user is in a group that has access to the collection).

Basically it retrieves the users having access to the cipher with a group that either has access to all collections or is bound to the cipher's collection. Then users uuid are used to push changes to clients.