### PR TITLE
add new secretsmanager plan for web-v2023.8.x

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -60,6 +60,7 @@ pub fn routes() -> Vec<Route> {
         put_policy,
         get_organization_tax,
         get_plans,
+        get_plans_all,
         get_plans_tax_rates,
         import,
         post_org_keys,
@@ -1810,10 +1811,26 @@ fn get_plans() -> Json<Value> {
             "Product": 0,
             "Name": "Free",
             "NameLocalizationKey": "planNameFree",
+            "BitwardenProduct": 0,
+            "MaxUsers": 0,
+            "DescriptionLocalizationKey": "planDescFree"
+        },{
+            "Object": "plan",
+            "Type": 0,
+            "Product": 1,
+            "Name": "Free",
+            "NameLocalizationKey": "planNameFree",
+            "BitwardenProduct": 1,
+            "MaxUsers": 0,
             "DescriptionLocalizationKey": "planDescFree"
         }],
         "ContinuationToken": null
     }))
+}
+
+#[get("/plans/all")]
+fn get_plans_all() -> Json<Value> {
+    get_plans()
 }
 
 #[get("/plans/sales-tax-rates")]


### PR DESCRIPTION
in `web-v2023.8.x` the [`getPlans()`](https://github.com/bitwarden/clients/blob/627b39f6f378528107eacaa4053d79f8f3c14608/libs/common/src/services/api.service.ts#L891-L894) call was changed from `/plans/` to `/plans/all` and the form to create new organizations also [requires a bitwardenProduct](https://github.com/bitwarden/clients/blob/b403f2bcc79426abb9d8f02c391b7c8158876960/apps/web/src/app/billing/settings/organization-plans.component.ts#L140) to differentiate between plans for PasswordManager and the SecretsManager. by adding a second plan with `"BitwardenProduct": 1` this should work again.