### PR TITLE
Allow Authorization header for Web Sockets

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -825,3 +825,26 @@ impl<'r> FromRequest<'r> for ClientIp {
         })
     }
 }
+
+pub struct WsAccessTokenHeader {
+    pub access_token: Option<String>,
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for WsAccessTokenHeader {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let headers = request.headers();
+
+        // Get access_token
+        let access_token = match headers.get_one("Authorization") {
+            Some(a) => a.rsplit("Bearer ").next().map(String::from),
+            None => None,
+        };
+
+        Outcome::Success(Self {
+            access_token,
+        })
+    }
+}


### PR DESCRIPTION
Some clients (Thirdparty) might use the `Authorization` header instead of a query param. We didn't supported this since all the official clients do not seem to use this way of working. But Bitwarden does check both ways.

This PR adds an extra check for this header which can be optional.

Fixes #3776