### PR TITLE
add UserDecryptionOptions to login response

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -280,6 +280,10 @@ async fn _password_login(
         "ResetMasterPassword": false,// TODO: Same as above
         "scope": scope,
         "unofficialServer": true,
+        "UserDecryptionOptions": {
+            "HasMasterPassword": !user.password_hash.is_empty(),
+            "Object": "userDecryptionOptions"
+        },
     });
 
     if let Some(token) = twofactor_token {


### PR DESCRIPTION
needed for web-v2023.8.2+ compatibility due to the inclusion of the new [trusted device encryption](https://github.com/bitwarden/clients/commit/bf2cc019c55ae17b948e3988f852d10b03125fc2) feature. without this change, the web vault will assume that you don't have a master password set and force you to set one:

![Screenshot 2023-08-29 at 23-36-26 Set master password Vaultwarden Web](https://github.com/dani-garcia/vaultwarden/assets/509385/402a9a7c-b485-47c7-a450-65a4f2382dd2)