### PR TITLE
Reopen log file on SIGHUP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,7 +3493,6 @@ dependencies = [
  "pico-args",
  "rand",
  "regex",
- "reopen",
  "reqwest",
  "ring",
  "rmpv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
 dependencies = [
+ "libc",
  "log",
+ "reopen",
  "syslog",
 ]
 
@@ -2349,6 +2351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "reopen"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42cec3acf85845f5b18b3cbb7fec619ccbd4a349f6ecbe1c62ab46d4d98293"
+dependencies = [
+ "autocfg",
+ "libc",
+ "signal-hook",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,6 +3493,7 @@ dependencies = [
  "pico-args",
  "rand",
  "regex",
+ "reopen",
  "reqwest",
  "ring",
  "rmpv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ unstable = []
 [target."cfg(not(windows))".dependencies]
 # Logging
 syslog = "6.1.0"
-reopen = "1.0.3"
 
 [dependencies]
 # Logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,12 @@ unstable = []
 [target."cfg(not(windows))".dependencies]
 # Logging
 syslog = "6.1.0"
+reopen = "1.0.3"
 
 [dependencies]
 # Logging
 log = "0.4.20"
-fern = { version = "0.6.2", features = ["syslog-6"] }
+fern = { version = "0.6.2", features = ["syslog-6", "reopen-1"] }
 tracing = { version = "0.1.37", features = ["log"] } # Needed to have lettre and webauthn-rs trace logging to work
 
 # A `dotenv` implementation for Rust

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,16 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
     }
 
     if let Some(log_file) = CONFIG.log_file() {
-        logger = logger.chain(fern::log_file(log_file)?);
+        #[cfg(windows)]
+        {
+            logger = logger.chain(fern::log_file(log_file)?);
+        }
+        #[cfg(not(windows))]
+        {
+            const SIGHUP: i32 = 1;
+            let path = Path::new(&log_file);
+            logger = logger.chain(fern::log_reopen1(path, [SIGHUP])?);
+        }
     }
 
     #[cfg(not(windows))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,7 +332,7 @@ fn init_logging(level: log::LevelFilter) -> Result<(), fern::InitError> {
         }
         #[cfg(not(windows))]
         {
-            const SIGHUP: i32 = 1;
+            const SIGHUP: i32 = tokio::signal::unix::SignalKind::hangup().as_raw_value();
             let path = Path::new(&log_file);
             logger = logger.chain(fern::log_reopen1(path, [SIGHUP])?);
         }


### PR DESCRIPTION
This change makes Vaultwarden reopen the log file on SIGHUP, enabling proper log rotation without logrotate's copytruncate hack.