### PR TITLE
Fix typos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
     );
 
     #[cfg(all(not(debug_assertions), feature = "query_logger"))]
-    compile_error!("Query Logging is only allowed during development, it is not intented for production usage!");
+    compile_error!("Query Logging is only allowed during development, it is not intended for production usage!");
 
     // Support $BWRS_VERSION for legacy compatibility, but default to $VW_VERSION.
     // If neither exist, read from git.

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -346,7 +346,7 @@ async fn post_password(
 
     let save_result = user.save(&mut conn).await;
 
-    // Prevent loging out the client where the user requested this endpoint from.
+    // Prevent logging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
     nt.send_logout(&user, Some(headers.device.uuid)).await;
@@ -493,7 +493,7 @@ async fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, mut conn: D
 
     let save_result = user.save(&mut conn).await;
 
-    // Prevent loging out the client where the user requested this endpoint from.
+    // Prevent logging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
     nt.send_logout(&user, Some(headers.device.uuid)).await;
@@ -970,10 +970,10 @@ async fn put_device_token(uuid: &str, data: JsonUpcase<PushToken>, headers: Head
         device.push_uuid = Some(uuid::Uuid::new_v4().to_string());
     }
     if let Err(e) = device.save(&mut conn).await {
-        err!(format!("An error occured while trying to save the device push token: {e}"));
+        err!(format!("An error occurred while trying to save the device push token: {e}"));
     }
     if let Err(e) = register_push_device(headers.user.uuid, device).await {
-        err!(format!("An error occured while proceeding registration of a device: {e}"));
+        err!(format!("An error occurred while proceeding registration of a device: {e}"));
     }
 
     Ok(())

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -1752,7 +1752,7 @@ impl CipherSyncData {
         let cipher_folders: HashMap<String, String>;
         let cipher_favorites: HashSet<String>;
         match sync_type {
-            // User Sync supports Folders and Favorits
+            // User Sync supports Folders and Favorites
             CipherSyncType::User => {
                 // Generate a HashMap with the Cipher UUID as key and the Folder UUID as value
                 cipher_folders = FolderCipher::find_by_user(user_uuid, conn).await.into_iter().collect();
@@ -1760,7 +1760,7 @@ impl CipherSyncData {
                 // Generate a HashSet of all the Cipher UUID's which are marked as favorite
                 cipher_favorites = Favorite::get_all_cipher_uuid_by_user(user_uuid, conn).await.into_iter().collect();
             }
-            // Organization Sync does not support Folders and Favorits.
+            // Organization Sync does not support Folders and Favorites.
             // If these are set, it will cause issues in the web-vault.
             CipherSyncType::Organization => {
                 cipher_folders = HashMap::with_capacity(0);
@@ -1805,7 +1805,7 @@ impl CipherSyncData {
             .map(|collection_group| (collection_group.collections_uuid.clone(), collection_group))
             .collect();
 
-        // Get all organizations that the user has full access to via group assignement
+        // Get all organizations that the user has full access to via group assignment
         let user_group_full_access_for_organizations: HashSet<String> =
             Group::gather_user_organizations_full_access(user_uuid, conn).await.into_iter().collect();
 

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -319,7 +319,7 @@ async fn accept_invite(emer_id: &str, data: JsonUpcase<AcceptData>, headers: Hea
     let claims = decode_emergency_access_invite(token)?;
 
     // This can happen if the user who received the invite used a different email to signup.
-    // Since we do not know if this is intented, we error out here and do nothing with the invite.
+    // Since we do not know if this is intended, we error out here and do nothing with the invite.
     if claims.email != headers.user.email {
         err!("Claim email does not match current users email")
     }

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1520,9 +1520,9 @@ async fn bulk_public_keys(
     let data: OrgBulkIds = data.into_inner().data;
 
     let mut bulk_response = Vec::new();
-    // Check all received UserOrg UUID's and find the matching User to retreive the public-key.
+    // Check all received UserOrg UUID's and find the matching User to retrieve the public-key.
     // If the user does not exists, just ignore it, and do not return any information regarding that UserOrg UUID.
-    // The web-vault will then ignore that user for the folowing steps.
+    // The web-vault will then ignore that user for the following steps.
     for user_org_id in data.Ids {
         match UserOrganization::find_by_uuid_and_org(&user_org_id, org_id, &mut conn).await {
             Some(user_org) => match User::find_by_uuid(&user_org.user_uuid, &mut conn).await {
@@ -1882,7 +1882,7 @@ async fn import(org_id: &str, data: JsonUpcase<OrgImportData>, headers: Headers,
     // This means that this endpoint can end up removing users that were added manually by an admin,
     // as opposed to upstream which only removes auto-imported users.
 
-    // User needs to be admin or owner to use the Directry Connector
+    // User needs to be admin or owner to use the Directory Connector
     match UserOrganization::find_by_user_and_org(&headers.user.uuid, org_id, &mut conn).await {
         Some(user_org) if user_org.atype >= UserOrgType::Admin => { /* Okay, nothing to do */ }
         Some(_) => err!("User has insufficient permissions to use Directory Connector"),
@@ -2897,7 +2897,7 @@ async fn put_reset_password_enrollment(
 
 // This is a new function active since the v2022.9.x clients.
 // It combines the previous two calls done before.
-// We call those two functions here and combine them our selfs.
+// We call those two functions here and combine them our selves.
 //
 // NOTE: It seems clients can't handle uppercase-first keys!!
 //       We need to convert all keys so they have the first character to be a lowercase.

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -2897,7 +2897,7 @@ async fn put_reset_password_enrollment(
 
 // This is a new function active since the v2022.9.x clients.
 // It combines the previous two calls done before.
-// We call those two functions here and combine them our selves.
+// We call those two functions here and combine them ourselves.
 //
 // NOTE: It seems clients can't handle uppercase-first keys!!
 //       We need to convert all keys so they have the first character to be a lowercase.

--- a/src/api/core/two_factor/authenticator.rs
+++ b/src/api/core/two_factor/authenticator.rs
@@ -177,7 +177,7 @@ pub async fn validate_totp_code(
         }
     }
 
-    // Else no valide code received, deny access
+    // Else no valid code received, deny access
     err!(
         format!("Invalid TOTP code! Server time: {} IP: {}", current_time.format("%F %T UTC"), ip.ip),
         ErrorEvent {

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -534,11 +534,11 @@ async fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
     let mut referer = String::new();
 
     if let Ok(content) = resp {
-        // Extract the URL from the respose in case redirects occured (like @ gitlab.com)
+        // Extract the URL from the response in case redirects occurred (like @ gitlab.com)
         let url = content.url().clone();
 
         // Set the referer to be used on the final request, some sites check this.
-        // Mostly used to prevent direct linking and other security resons.
+        // Mostly used to prevent direct linking and other security reasons.
         referer = url.to_string();
 
         // Add the fallback favicon.ico and apple-touch-icon.png to the list with the domain the content responded from.
@@ -638,7 +638,7 @@ fn get_icon_priority(href: &str, sizes: &str) -> u8 {
     }
 }
 
-/// Returns a Tuple with the width and hight as a seperate value extracted from the sizes attribute
+/// Returns a Tuple with the width and height as a separate value extracted from the sizes attribute
 /// It will return 0 for both values if no match has been found.
 ///
 /// # Arguments

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -469,7 +469,7 @@ async fn twofactor_auth(
     TwoFactorIncomplete::mark_incomplete(user_uuid, &device.uuid, &device.name, ip, conn).await?;
 
     let twofactor_ids: Vec<_> = twofactors.iter().map(|tf| tf.atype).collect();
-    let selected_id = data.two_factor_provider.unwrap_or(twofactor_ids[0]); // If we aren't given a two factor provider, asume the first one
+    let selected_id = data.two_factor_provider.unwrap_or(twofactor_ids[0]); // If we aren't given a two factor provider, assume the first one
 
     let twofactor_code = match data.two_factor_token {
         Some(ref code) => code,

--- a/src/api/push.rs
+++ b/src/api/push.rs
@@ -116,7 +116,7 @@ pub async fn unregister_push_device(uuid: String) -> EmptyResult {
         .await
     {
         Ok(r) => r,
-        Err(e) => err!(format!("An error occured during device unregistration: {e}")),
+        Err(e) => err!(format!("An error occurred during device unregistration: {e}")),
     };
     Ok(())
 }
@@ -252,7 +252,7 @@ async fn send_to_push_relay(notification_data: Value) {
         .send()
         .await
     {
-        error!("An error occured while sending a send update to the push relay: {}", e);
+        error!("An error occurred while sending a send update to the push relay: {}", e);
     };
 }
 

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub fn routes() -> Vec<Route> {
-    // If addding more routes here, consider also adding them to
+    // If adding more routes here, consider also adding them to
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log
     let mut routes = routes![attachments, alive, alive_head, static_files];
     if CONFIG.web_vault_enabled() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ macro_rules! make_config {
 
                 if show_overrides && !overrides.is_empty() {
                     // We can't use warn! here because logging isn't setup yet.
-                    println!("[WARNING] The following environment variables are being overriden by the config.json file.");
+                    println!("[WARNING] The following environment variables are being overridden by the config.json file.");
                     println!("[WARNING] Please use the admin panel to make changes to them:");
                     println!("[WARNING] {}\n", overrides.join(", "));
                 }
@@ -164,7 +164,7 @@ macro_rules! make_config {
             )+)+
 
             pub fn prepare_json(&self) -> serde_json::Value {
-                let (def, cfg, overriden) = {
+                let (def, cfg, overridden) = {
                     let inner = &self.inner.read().unwrap();
                     (inner._env.build(), inner.config.clone(), inner._overrides.clone())
                 };
@@ -211,7 +211,7 @@ macro_rules! make_config {
                                 element.insert("default".into(), serde_json::to_value(def.$name).unwrap());
                                 element.insert("type".into(), (_get_form_type(stringify!($ty))).into());
                                 element.insert("doc".into(), (_get_doc(concat!($($doc),+))).into());
-                                element.insert("overridden".into(), (overriden.contains(&paste::paste!(stringify!([<$name:upper>])).into())).into());
+                                element.insert("overridden".into(), (overridden.contains(&paste::paste!(stringify!([<$name:upper>])).into())).into());
                                 element
                             }),
                         )+

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -396,7 +396,7 @@ impl UserOrganization {
         let user = User::find_by_uuid(&self.user_uuid, conn).await.unwrap();
 
         // Because BitWarden want the status to be -1 for revoked users we need to catch that here.
-        // We subtract/add a number so we can restore/activate the user to it's previouse state again.
+        // We subtract/add a number so we can restore/activate the user to it's previous state again.
         let status = if self.status < UserOrgStatus::Revoked as i32 {
             UserOrgStatus::Revoked as i32
         } else {
@@ -475,7 +475,7 @@ impl UserOrganization {
         };
 
         // Because BitWarden want the status to be -1 for revoked users we need to catch that here.
-        // We subtract/add a number so we can restore/activate the user to it's previouse state again.
+        // We subtract/add a number so we can restore/activate the user to it's previous state again.
         let status = if self.status < UserOrgStatus::Revoked as i32 {
             UserOrgStatus::Revoked as i32
         } else {


### PR DESCRIPTION
Fixes typos in the code base, mostly comments.

There's also a typo at https://github.com/dani-garcia/vaultwarden/blob/bc26bfa589c007da9b9be37e1172060f38a948b9/src/api/notifications.rs#L568 but I'm not sure if it is intentional or not, so I left it unfixed for now.