### PR TITLE
Fix small issues

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -479,21 +479,9 @@ mod postgresql_migrations {
     pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/postgresql");
 
     pub fn run_migrations() -> Result<(), super::Error> {
-        use diesel::{Connection, RunQueryDsl};
+        use diesel::Connection;
         // Make sure the database is up to date (create if it doesn't exist, or run the migrations)
         let mut connection = diesel::pg::PgConnection::establish(&crate::CONFIG.database_url())?;
-        // Disable Foreign Key Checks during migration
-
-        // FIXME: Per https://www.postgresql.org/docs/12/sql-set-constraints.html,
-        // "SET CONSTRAINTS sets the behavior of constraint checking within the
-        // current transaction", so this setting probably won't take effect for
-        // any of the migrations since it's being run outside of a transaction.
-        // Migrations that need to disable foreign key checks should run this
-        // from within the migration script itself.
-        diesel::sql_query("SET CONSTRAINTS ALL DEFERRED")
-            .execute(&mut connection)
-            .expect("Failed to disable Foreign Key Checks during migrations");
-
         connection.run_pending_migrations(MIGRATIONS).expect("Error running migrations");
         Ok(())
     }


### PR DESCRIPTION
## Do not send extra headers for Upgrade connection

During a WebSocket connection we currently also send several headers
which could cause issues with some reverse proxy, or with the CloudFlare
tunnel for example. This PR resolves these issues.

Fixes #3881

## Remove SET CONSTRAINTS during postgres migration

The PostgreSQL migrations do not need this setting.
I tested this by running an old Vaultwarden instance (v1.18.0) on a new
PostrgreSQL database, created a few users and some vault items, after
that run the new code and it doesn't break.

Fixes #3930