### PR TITLE
New config option disable email change

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -97,6 +97,10 @@
 ## Disabled by default. Also check the EVENT_CLEANUP_SCHEDULE and EVENTS_DAYS_RETAIN settings.
 # ORG_EVENTS_ENABLED=false
 
+## Controls whether users can change their email.
+## This setting applies globally to all users
+# EMAIL_CHANGE_ALLOWED=true
+
 ## Number of days to retain events stored in the database.
 ## If unset (the default), events are kept indefinitely and the scheduled job is disabled!
 # EVENTS_DAYS_RETAIN=

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -533,6 +533,10 @@ struct EmailTokenData {
 
 #[post("/accounts/email-token", data = "<data>")]
 async fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    if !CONFIG.email_change_allowed() {
+        err!("Email change is not allowed.");
+    }
+
     let data: EmailTokenData = data.into_inner().data;
     let mut user = headers.user;
 
@@ -579,6 +583,10 @@ async fn post_email(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    if !CONFIG.email_change_allowed() {
+        err!("Email change is not allowed.");
+    }
+
     let data: ChangeEmailData = data.into_inner().data;
     let mut user = headers.user;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,6 +480,8 @@ make_config! {
         invitation_expiration_hours: u32, false, def, 120;
         /// Allow emergency access |> Controls whether users can enable emergency access to their accounts. This setting applies globally to all users.
         emergency_access_allowed:    bool,   true,   def,    true;
+        /// Allow email change |> Controls whether users can change their email. This setting applies globally to all users.
+        email_change_allowed:    bool,   true,   def,    true;
         /// Password iterations |> Number of server-side passwords hashing iterations for the password hash.
         /// The default for new users. If changed, it will be updated during login for existing users.
         password_iterations:    i32,    true,   def,    600_000;


### PR DESCRIPTION
Added new configuration option to prevent users from changing their email.
By default is set to allow it.