### PR TITLE
Fix issue with MariaDB/MySQL migrations

### DIFF
--- a/migrations/mysql/2023-10-21-221242_add_cipher_key/up.sql
+++ b/migrations/mysql/2023-10-21-221242_add_cipher_key/up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE ciphers 
-ADD COLUMN "key" TEXT;
+ALTER TABLE ciphers
+ADD COLUMN `key` TEXT;


### PR DESCRIPTION
MariaDB/MySQL doesn't like the normal `"` quotes around the column name. This needs to be a backtick **`**.

This PR changes the migration script to fix this issue.

Fixes #3993