### PR TITLE
Fix missing alpine tag during buildx bake

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -216,7 +216,13 @@ function "generate_tags" {
   result = flatten([
     for registry in get_container_registries() :
       [for base_tag in get_base_tags() :
-        concat(["${registry}:${base_tag}${suffix}${platform}"])]
+        concat(
+          # If the base_tag contains latest, and the suffix contains `-alpine` add a `:alpine` tag too
+          base_tag == "latest" ? suffix == "-alpine" ? ["${registry}:alpine${platform}"] : [] : [],
+          # The default tagging strategy
+          ["${registry}:${base_tag}${suffix}${platform}"]
+        )
+      ]
   ])
 }
 


### PR DESCRIPTION
The bake recipt was missing the single `:alpine` tag for the alpine builds when we were releasing a `stable/latest` version of Vaultwarden.

This PR fixes this by checking for those conditions and add the `:alpine` tag too.

We will keep the `:latest-alpine` also, which i find even nicer then just `:alpine`

Fixes #4035