### PR TITLE
Update version for clients as well

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -198,8 +198,8 @@ fn config() -> Json<Value> {
         // This means they expect a version that closely matches the Bitwarden server version
         // We should make sure that we keep this updated when we support the new server features
         // Version history:
-        // - Individual cipher key encryption: 2023.9.1
-        "version": "2023.9.1",
+        // - Individual cipher key encryption: 2023.10.0
+        "version": "2023.10.0",
         "gitHash": option_env!("GIT_REV"),
         "server": {
           "name": "Vaultwarden",


### PR DESCRIPTION
I've noticed an old version reference in the Firefox extension.
![Screenshot from 2023-11-07 18 54 26](https://github.com/dani-garcia/vaultwarden/assets/3606313/53dfac0e-6017-449b-9419-44c69ee8b208)

Close if this is intentional 