### PR TITLE
Add Protected Actions Check

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use crate::{
     api::{
         core::log_user_event, register_push_device, unregister_push_device, AnonymousNotify, EmptyResult, JsonResult,
-        JsonUpcase, Notify, NumberOrString, PasswordData, UpdateType,
+        JsonUpcase, Notify, NumberOrString, PasswordOrOtpData, UpdateType,
     },
     auth::{decode_delete, decode_invite, decode_verify_email, ClientHeaders, Headers},
     crypto,
@@ -503,17 +503,15 @@ async fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, mut conn: D
 
 #[post("/accounts/security-stamp", data = "<data>")]
 async fn post_sstamp(
-    data: JsonUpcase<PasswordData>,
+    data: JsonUpcase<PasswordOrOtpData>,
     headers: Headers,
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
-    let data: PasswordData = data.into_inner().data;
+    let data: PasswordOrOtpData = data.into_inner().data;
     let mut user = headers.user;
 
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password")
-    }
+    data.validate(&user, true, &mut conn).await?;
 
     Device::delete_all_by_user(&user.uuid, &mut conn).await?;
     user.reset_security_stamp();
@@ -736,18 +734,16 @@ async fn post_delete_recover_token(data: JsonUpcase<DeleteRecoverTokenData>, mut
 }
 
 #[post("/accounts/delete", data = "<data>")]
-async fn post_delete_account(data: JsonUpcase<PasswordData>, headers: Headers, conn: DbConn) -> EmptyResult {
+async fn post_delete_account(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, conn: DbConn) -> EmptyResult {
     delete_account(data, headers, conn).await
 }
 
 #[delete("/accounts", data = "<data>")]
-async fn delete_account(data: JsonUpcase<PasswordData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
-    let data: PasswordData = data.into_inner().data;
+async fn delete_account(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    let data: PasswordOrOtpData = data.into_inner().data;
     let user = headers.user;
 
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password")
-    }
+    data.validate(&user, true, &mut conn).await?;
 
     user.delete(&mut conn).await
 }
@@ -854,20 +850,13 @@ fn verify_password(data: JsonUpcase<SecretVerificationRequest>, headers: Headers
     Ok(())
 }
 
-async fn _api_key(
-    data: JsonUpcase<SecretVerificationRequest>,
-    rotate: bool,
-    headers: Headers,
-    mut conn: DbConn,
-) -> JsonResult {
+async fn _api_key(data: JsonUpcase<PasswordOrOtpData>, rotate: bool, headers: Headers, mut conn: DbConn) -> JsonResult {
     use crate::util::format_date;
 
-    let data: SecretVerificationRequest = data.into_inner().data;
+    let data: PasswordOrOtpData = data.into_inner().data;
     let mut user = headers.user;
 
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password")
-    }
+    data.validate(&user, true, &mut conn).await?;
 
     if rotate || user.api_key.is_none() {
         user.api_key = Some(crypto::generate_api_key());
@@ -882,12 +871,12 @@ async fn _api_key(
 }
 
 #[post("/accounts/api-key", data = "<data>")]
-async fn api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn api_key(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, conn: DbConn) -> JsonResult {
     _api_key(data, false, headers, conn).await
 }
 
 #[post("/accounts/rotate-api-key", data = "<data>")]
-async fn rotate_api_key(data: JsonUpcase<SecretVerificationRequest>, headers: Headers, conn: DbConn) -> JsonResult {
+async fn rotate_api_key(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, conn: DbConn) -> JsonResult {
     _api_key(data, true, headers, conn).await
 }
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -6,7 +6,8 @@ use serde_json::Value;
 use crate::{
     api::{
         core::{log_event, CipherSyncData, CipherSyncType},
-        EmptyResult, JsonResult, JsonUpcase, JsonUpcaseVec, JsonVec, Notify, NumberOrString, PasswordData, UpdateType,
+        EmptyResult, JsonResult, JsonUpcase, JsonUpcaseVec, JsonVec, Notify, NumberOrString, PasswordOrOtpData,
+        UpdateType,
     },
     auth::{decode_invite, AdminHeaders, Headers, ManagerHeaders, ManagerHeadersLoose, OwnerHeaders},
     db::{models::*, DbConn},
@@ -186,16 +187,13 @@ async fn create_organization(headers: Headers, data: JsonUpcase<OrgData>, mut co
 #[delete("/organizations/<org_id>", data = "<data>")]
 async fn delete_organization(
     org_id: &str,
-    data: JsonUpcase<PasswordData>,
+    data: JsonUpcase<PasswordOrOtpData>,
     headers: OwnerHeaders,
     mut conn: DbConn,
 ) -> EmptyResult {
-    let data: PasswordData = data.into_inner().data;
-    let password_hash = data.MasterPasswordHash;
+    let data: PasswordOrOtpData = data.into_inner().data;
 
-    if !headers.user.check_valid_password(&password_hash) {
-        err!("Invalid password")
-    }
+    data.validate(&headers.user, true, &mut conn).await?;
 
     match Organization::find_by_uuid(org_id, &mut conn).await {
         None => err!("Organization not found"),
@@ -206,7 +204,7 @@ async fn delete_organization(
 #[post("/organizations/<org_id>/delete", data = "<data>")]
 async fn post_delete_organization(
     org_id: &str,
-    data: JsonUpcase<PasswordData>,
+    data: JsonUpcase<PasswordOrOtpData>,
     headers: OwnerHeaders,
     conn: DbConn,
 ) -> EmptyResult {
@@ -2945,18 +2943,16 @@ async fn get_org_export(org_id: &str, headers: AdminHeaders, mut conn: DbConn) -
 
 async fn _api_key(
     org_id: &str,
-    data: JsonUpcase<PasswordData>,
+    data: JsonUpcase<PasswordOrOtpData>,
     rotate: bool,
     headers: AdminHeaders,
-    conn: DbConn,
+    mut conn: DbConn,
 ) -> JsonResult {
-    let data: PasswordData = data.into_inner().data;
+    let data: PasswordOrOtpData = data.into_inner().data;
     let user = headers.user;
 
-    // Validate the admin users password
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password")
-    }
+    // Validate the admin users password/otp
+    data.validate(&user, true, &mut conn).await?;
 
     let org_api_key = match OrganizationApiKey::find_by_org_uuid(org_id, &conn).await {
         Some(mut org_api_key) => {
@@ -2983,14 +2979,14 @@ async fn _api_key(
 }
 
 #[post("/organizations/<org_id>/api-key", data = "<data>")]
-async fn api_key(org_id: &str, data: JsonUpcase<PasswordData>, headers: AdminHeaders, conn: DbConn) -> JsonResult {
+async fn api_key(org_id: &str, data: JsonUpcase<PasswordOrOtpData>, headers: AdminHeaders, conn: DbConn) -> JsonResult {
     _api_key(org_id, data, false, headers, conn).await
 }
 
 #[post("/organizations/<org_id>/rotate-api-key", data = "<data>")]
 async fn rotate_api_key(
     org_id: &str,
-    data: JsonUpcase<PasswordData>,
+    data: JsonUpcase<PasswordOrOtpData>,
     headers: AdminHeaders,
     conn: DbConn,
 ) -> JsonResult {

--- a/src/api/core/two_factor/protected_actions.rs
+++ b/src/api/core/two_factor/protected_actions.rs
@@ -1,0 +1,142 @@
+use chrono::{Duration, NaiveDateTime, Utc};
+use rocket::Route;
+
+use crate::{
+    api::{EmptyResult, JsonUpcase},
+    auth::Headers,
+    crypto,
+    db::{
+        models::{TwoFactor, TwoFactorType},
+        DbConn,
+    },
+    error::{Error, MapResult},
+    mail, CONFIG,
+};
+
+pub fn routes() -> Vec<Route> {
+    routes![request_otp, verify_otp]
+}
+
+/// Data stored in the TwoFactor table in the db
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProtectedActionData {
+    /// Token issued to validate the protected action
+    pub token: String,
+    /// UNIX timestamp of token issue.
+    pub token_sent: i64,
+    // The total amount of attempts
+    pub attempts: u8,
+}
+
+impl ProtectedActionData {
+    pub fn new(token: String) -> Self {
+        Self {
+            token,
+            token_sent: Utc::now().naive_utc().timestamp(),
+            attempts: 0,
+        }
+    }
+
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+
+    pub fn from_json(string: &str) -> Result<Self, Error> {
+        let res: Result<Self, crate::serde_json::Error> = serde_json::from_str(string);
+        match res {
+            Ok(x) => Ok(x),
+            Err(_) => err!("Could not decode ProtectedActionData from string"),
+        }
+    }
+
+    pub fn add_attempt(&mut self) {
+        self.attempts += 1;
+    }
+}
+
+#[post("/accounts/request-otp")]
+async fn request_otp(headers: Headers, mut conn: DbConn) -> EmptyResult {
+    if !CONFIG.mail_enabled() {
+        err!("Email is disabled for this server. Either enable email or login using your master password instead of login via device.");
+    }
+
+    let user = headers.user;
+
+    // Only one Protected Action per user is allowed to take place, delete the previous one
+    if let Some(pa) =
+        TwoFactor::find_by_user_and_type(&user.uuid, TwoFactorType::ProtectedActions as i32, &mut conn).await
+    {
+        pa.delete(&mut conn).await?;
+    }
+
+    let generated_token = crypto::generate_email_token(CONFIG.email_token_size());
+    let pa_data = ProtectedActionData::new(generated_token);
+
+    // Uses EmailVerificationChallenge as type to show that it's not verified yet.
+    let twofactor = TwoFactor::new(user.uuid, TwoFactorType::ProtectedActions, pa_data.to_json());
+    twofactor.save(&mut conn).await?;
+
+    mail::send_protected_action_token(&user.email, &pa_data.token).await?;
+
+    Ok(())
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[allow(non_snake_case)]
+struct ProtectedActionVerify {
+    OTP: String,
+}
+
+#[post("/accounts/verify-otp", data = "<data>")]
+async fn verify_otp(data: JsonUpcase<ProtectedActionVerify>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    if !CONFIG.mail_enabled() {
+        err!("Email is disabled for this server. Either enable email or login using your master password instead of login via device.");
+    }
+
+    let user = headers.user;
+    let data: ProtectedActionVerify = data.into_inner().data;
+
+    // Delete the token after one validation attempt
+    // This endpoint only gets called for the vault export, and doesn't need a second attempt
+    validate_protected_action_otp(&data.OTP, &user.uuid, true, &mut conn).await
+}
+
+pub async fn validate_protected_action_otp(
+    otp: &str,
+    user_uuid: &str,
+    delete_if_valid: bool,
+    conn: &mut DbConn,
+) -> EmptyResult {
+    let pa = TwoFactor::find_by_user_and_type(user_uuid, TwoFactorType::ProtectedActions as i32, conn)
+        .await
+        .map_res("Protected action token not found, try sending the code again or restart the process")?;
+    let mut pa_data = ProtectedActionData::from_json(&pa.data)?;
+
+    pa_data.add_attempt();
+    // Delete the token after x attempts if it has been used too many times
+    // We use the 6, which should be more then enough for invalid attempts and multiple valid checks
+    if pa_data.attempts > 6 {
+        pa.delete(conn).await?;
+        err!("Token has expired")
+    }
+
+    // Check if the token has expired (Using the email 2fa expiration time)
+    let date =
+        NaiveDateTime::from_timestamp_opt(pa_data.token_sent, 0).expect("Protected Action token timestamp invalid.");
+    let max_time = CONFIG.email_expiration_time() as i64;
+    if date + Duration::seconds(max_time) < Utc::now().naive_utc() {
+        pa.delete(conn).await?;
+        err!("Token has expired")
+    }
+
+    if !crypto::ct_eq(&pa_data.token, otp) {
+        pa.save(conn).await?;
+        err!("Token is invalid")
+    }
+
+    if delete_if_valid {
+        pa.delete(conn).await?;
+    }
+
+    Ok(())
+}

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -6,7 +6,7 @@ use yubico::{config::Config, verify};
 use crate::{
     api::{
         core::{log_user_event, two_factor::_generate_recover_code},
-        EmptyResult, JsonResult, JsonUpcase, PasswordData,
+        EmptyResult, JsonResult, JsonUpcase, PasswordOrOtpData,
     },
     auth::Headers,
     db::{
@@ -24,13 +24,14 @@ pub fn routes() -> Vec<Route> {
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
 struct EnableYubikeyData {
-    MasterPasswordHash: String,
     Key1: Option<String>,
     Key2: Option<String>,
     Key3: Option<String>,
     Key4: Option<String>,
     Key5: Option<String>,
     Nfc: bool,
+    MasterPasswordHash: Option<String>,
+    Otp: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -83,16 +84,14 @@ async fn verify_yubikey_otp(otp: String) -> EmptyResult {
 }
 
 #[post("/two-factor/get-yubikey", data = "<data>")]
-async fn generate_yubikey(data: JsonUpcase<PasswordData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+async fn generate_yubikey(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, mut conn: DbConn) -> JsonResult {
     // Make sure the credentials are set
     get_yubico_credentials()?;
 
-    let data: PasswordData = data.into_inner().data;
+    let data: PasswordOrOtpData = data.into_inner().data;
     let user = headers.user;
 
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password");
-    }
+    data.validate(&user, false, &mut conn).await?;
 
     let user_uuid = &user.uuid;
     let yubikey_type = TwoFactorType::YubiKey as i32;
@@ -122,9 +121,12 @@ async fn activate_yubikey(data: JsonUpcase<EnableYubikeyData>, headers: Headers,
     let data: EnableYubikeyData = data.into_inner().data;
     let mut user = headers.user;
 
-    if !user.check_valid_password(&data.MasterPasswordHash) {
-        err!("Invalid password");
+    PasswordOrOtpData {
+        MasterPasswordHash: data.MasterPasswordHash.clone(),
+        Otp: data.Otp.clone(),
     }
+    .validate(&user, true, &mut conn)
+    .await?;
 
     // Check if we already have some data
     let mut yubikey_data =

--- a/src/config.rs
+++ b/src/config.rs
@@ -1243,17 +1243,18 @@ where
     reg!("email/invite_accepted", ".html");
     reg!("email/invite_confirmed", ".html");
     reg!("email/new_device_logged_in", ".html");
+    reg!("email/protected_action", ".html");
     reg!("email/pw_hint_none", ".html");
     reg!("email/pw_hint_some", ".html");
     reg!("email/send_2fa_removed_from_org", ".html");
-    reg!("email/send_single_org_removed_from_org", ".html");
-    reg!("email/send_org_invite", ".html");
     reg!("email/send_emergency_access_invite", ".html");
+    reg!("email/send_org_invite", ".html");
+    reg!("email/send_single_org_removed_from_org", ".html");
+    reg!("email/smtp_test", ".html");
     reg!("email/twofactor_email", ".html");
     reg!("email/verify_email", ".html");
-    reg!("email/welcome", ".html");
     reg!("email/welcome_must_verify", ".html");
-    reg!("email/smtp_test", ".html");
+    reg!("email/welcome", ".html");
 
     reg!("admin/base");
     reg!("admin/login");

--- a/src/db/models/two_factor.rs
+++ b/src/db/models/two_factor.rs
@@ -34,6 +34,9 @@ pub enum TwoFactorType {
     EmailVerificationChallenge = 1002,
     WebauthnRegisterChallenge = 1003,
     WebauthnLoginChallenge = 1004,
+
+    // Special type for Protected Actions verification via email
+    ProtectedActions = 2000,
 }
 
 /// Local methods

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -517,6 +517,19 @@ pub async fn send_admin_reset_password(address: &str, user_name: &str, org_name:
     send_email(address, &subject, body_html, body_text).await
 }
 
+pub async fn send_protected_action_token(address: &str, token: &str) -> EmptyResult {
+    let (subject, body_html, body_text) = get_text(
+        "email/protected_action",
+        json!({
+            "url": CONFIG.domain(),
+            "img_src": CONFIG._smtp_img_src(),
+            "token": token,
+        }),
+    )?;
+
+    send_email(address, &subject, body_html, body_text).await
+}
+
 async fn send_with_selected_transport(email: Message) -> EmptyResult {
     if CONFIG.use_sendmail() {
         match sendmail_transport().send(email).await {

--- a/src/static/templates/email/protected_action.hbs
+++ b/src/static/templates/email/protected_action.hbs
@@ -1,0 +1,6 @@
+Your Vaultwarden Verification Code
+<!---------------->
+Your email verification code is: {{token}}
+
+Use this code to complete the protected action in Vaultwarden.
+{{> email/email_footer_text }}

--- a/src/static/templates/email/protected_action.html.hbs
+++ b/src/static/templates/email/protected_action.html.hbs
@@ -1,0 +1,16 @@
+Your Vaultwarden Verification Code
+<!---------------->
+{{> email/email_header }}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Your email verification code is: <b>{{token}}</b>
+        </td>
+    </tr>
+    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
+            Use this code to complete the protected action in Vaultwarden.
+        </td>
+    </tr>
+</table>
+{{> email/email_footer }}


### PR DESCRIPTION
Since the feature `Login with device` some actions done via the web-vault need to be verified via an OTP instead of providing the MasterPassword.

This only happens if a user used the `Login with device` on a device which uses either Biometrics login or PIN. These actions prevent the athorizing device to send the MasterPasswordHash. When this happens, the web-vault requests an OTP to be filled-in and this OTP is send to the users email address which is the same as the email address to login.

The only way to bypass this is by logging in with the your password, in those cases a password is requested instead of an OTP.

In case SMTP is not enabled, it will show an error message telling to user to login using there password.

Fixes #4042