### PR TITLE
Add additional build target which optimizes for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,3 +180,12 @@ split-debuginfo = "unpacked"
 # This is a huge speed improvement during testing
 [profile.dev.package.argon2]
 opt-level = 3
+
+# Optimize for size
+[profile.release-micro]
+inherits = "release"
+opt-level = "z"
+strip = "symbols"
+lto = "fat"
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
OpenWRT (https://openwrt.org) is a project which builds and distributes firmware for embedded devies like routers, access points, and so on. These devices are usually very limited in terms of storage. Therefore, **optimizing binaries for size** at the cost of execution speed is usually desired. As I intend to provide a vaultwarden package for OpenWRT this change would help significantly.

This PR adds an additional build-target, namely "release-micro", which implements several parameters which optimize in favor of binary size.

The following parameters were chosen:
- opt-level "z": Optimize for size with disabled loop vectorization
- strip "symbols": Strip debuginfo and symbols from binary
- lto "fat": Enable link-time optimizations across all crates
- codegen-units 1: Disable parallelization of code generation to allow for additional optimizations
- panic "abort": Abort on Panic() instead of unwinding

All these build parameters significantly reduce the binary size from >40MB to <15MB - the actual amount depends on the target architecture.

I would like to upstream this new build target to keep our build environment simple. Other projects which deploy vaultwarden on size-constrained environments may benefit from this change too.