### PR TITLE
Prevent generating an error during ws close

### DIFF
--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -164,6 +164,11 @@ fn websockets_hub<'r>(
                                             continue;
                                         }
                                     }
+
+                                    // Prevent sending anything back when a `Close` Message is received.
+                                    // Just break the loop
+                                    Message::Close(_) => break,
+
                                     // Just echo anything else the client sends
                                     _ => yield message,
                                 }
@@ -230,6 +235,11 @@ fn anonymous_websockets_hub<'r>(
                                             continue;
                                         }
                                     }
+
+                                    // Prevent sending anything back when a `Close` Message is received.
+                                    // Just break the loop
+                                    Message::Close(_) => break,
+
                                     // Just echo anything else the client sends
                                     _ => yield message,
                                 }


### PR DESCRIPTION
When a WebSocket connection was closing it was sending a message after it was closed already. This generated an error in the logs. While this error didn't harm any of the functionallity of Vaultwarden it isn't nice to see them of course.

This PR Fixes this by catching the close message and breaks the loop at that point. This prevents the `_` catch-all from replying the close message back to the client, which was causing the error message.

Fixes #4090