### PR TITLE
Several small fixes for open issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -2010,9 +2010,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2042,18 +2042,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.28.0+1.1.1w"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce95ee1f6f999dfb95b8afd43ebe442758ea2104d1ccb99a94c30db22ae701f"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
@@ -2606,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
  "getrandom",
@@ -3619,9 +3619,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -3723,7 +3723,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
- "openssl-sys",
  "paste",
  "percent-encoding",
  "pico-args",
@@ -4104,9 +4103,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
 dependencies = [
  "memchr",
 ]
@@ -4148,18 +4147,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
+checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
+checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libsqlite3-sys = { version = "0.27.0", features = ["bundled"], optional = true }
 
 # Crypto-related libraries
 rand = { version = "0.8.5", features = ["small_rng"] }
-ring = "0.17.6"
+ring = "0.17.7"
 
 # UUID generation
 uuid = { version = "1.6.1", features = ["v4"] }
@@ -139,10 +139,7 @@ cookie = "0.16.2"
 cookie_store = "0.19.1"
 
 # Used by U2F, JWT and PostgreSQL
-openssl = "=0.10.57"
-# Set openssl-sys fixed to v0.9.92 to prevent building issues with musl, arm and 32bit pointer width
-# It will force add a dynamically linked library which prevents the build from being static
-openssl-sys = "=0.9.92"
+openssl = "0.10.61"
 
 # CLI argument parsing
 pico-args = "0.5.0"

--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,11 @@ fn run(args: &[&str]) -> Result<String, std::io::Error> {
 ///    - env!("GIT_REV")
 ///    - env!("VW_VERSION")
 fn version_from_git_info() -> Result<String, std::io::Error> {
+    // Rerun when these paths are changed.
+    // Someone could have checked-out a tag or specific commit, but no other files changed.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags/");
+
     // The exact tag for the current commit, can be empty when
     // the current commit doesn't have an associated tag
     let exact_tag = run(&["git", "describe", "--abbrev=0", "--tags", "--exact-match"]).ok();

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -7,6 +7,16 @@
 
 CONFIG_FILE="${DATA_FOLDER}"/config.json
 
+# Check if there is a .env file configured
+# If that is the case, load it into the environment before running any check
+if [ -z "${ENV_FILE}" ]; then
+    ENV_FILE=".env"
+fi
+if [ -r "${ENV_FILE}" ]; then
+    # shellcheck disable=SC1090
+    . "${ENV_FILE}"
+fi
+
 # Given a config key, return the corresponding config value from the
 # config file. If the key doesn't exist, return an empty string.
 get_config_val() {

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -849,7 +849,6 @@ async fn put_cipher_share_selected(
     nt: Notify<'_>,
 ) -> EmptyResult {
     let mut data: ShareSelectedCipherData = data.into_inner().data;
-    let mut cipher_ids: Vec<String> = Vec::new();
 
     if data.Ciphers.is_empty() {
         err!("You must select at least one cipher.")
@@ -860,10 +859,9 @@ async fn put_cipher_share_selected(
     }
 
     for cipher in data.Ciphers.iter() {
-        match cipher.Id {
-            Some(ref id) => cipher_ids.push(id.to_string()),
-            None => err!("Request missing ids field"),
-        };
+        if cipher.Id.is_none() {
+            err!("Request missing ids field")
+        }
     }
 
     while let Some(cipher) = data.Ciphers.pop() {

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -18,6 +18,7 @@ pub fn routes() -> Vec<Route> {
         get_grantees,
         get_emergency_access,
         put_emergency_access,
+        post_emergency_access,
         delete_emergency_access,
         post_delete_emergency_access,
         send_invite,

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -214,7 +214,7 @@ impl UserOrganization {
     }
 
     pub fn restore(&mut self) -> bool {
-        if self.status < UserOrgStatus::Accepted as i32 {
+        if self.status < UserOrgStatus::Invited as i32 {
             self.status += ACTIVATE_REVOKE_DIFF;
             return true;
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -363,15 +363,7 @@ pub fn write_file(path: &str, content: &[u8]) -> Result<(), crate::error::Error>
 }
 
 pub fn delete_file(path: &str) -> IOResult<()> {
-    let res = fs::remove_file(path);
-
-    if let Some(parent) = Path::new(path).parent() {
-        // If the directory isn't empty, this returns an error, which we ignore
-        // We only want to delete the folder if it's empty
-        fs::remove_dir(parent).ok();
-    }
-
-    res
+    fs::remove_file(path)
 }
 
 pub fn get_display_size(size: i32) -> String {


### PR DESCRIPTION
### Fix healthcheck when using an ENV file

If someone is using a `.env` file or configured the `ENV_FILE` variable
to use that as it's configuration, this was missed by the healthcheck.

So, `DOMAIN` and `ROCKET_TLS` were not seen, and not used in these cases.

This commit fixes this by checking for this file and if it exists, then
it will load those variables first.

Fixes #4112

---

### Do not delete dir on file delete

Previously during a `delete_file` check we also tried to delete the
parent directory and ignored all errors, like not being empty for
example.

Since this function is called `delete_file` and does not mention
anything in regards to a directory i have removed that code and it will
now only delete the file and leave the rest as-is.

If this somehow is still needed or wanted, which i do not think we want,
then we should create a new function.

Fixes #4081

---

### Check some `.git` paths to force a rebuild

When a checked-out repo switches to a specific tag, and that tag does
not have anything else changed in the files except the tag, it could
happen that the build process doesn't see any changes, while it could be
that the version string needs to be different.

This commit ensures that if some specific paths are changed within the
.git directory, cargo will be triggered to rebuild.

Fixes #4087

---

### Remove useless variable

During some refactoring this seems to be overlooked.
This variable gets filled but isn't used at all afterwards.

Fixes #4105

---

### Fix BWDC when re-run with cleared cache

Using the BWDC with a cleared cache caused invited users to be converted
to accepted users.

The problem was a wrong check for the `restore` function.

Fixes #4114

---

### Add missing route

While there was a function and a derive, this endpoint wasn't part of
the routes. Since Bitwarden does have this endpoint ill add the route
instead of deleting it.

Fixes #4076
Fixes #4144

---

### Update crates to update the openssl crate

Because of a bug in the openssl-sys crate we pinned the version to an
older version. This issue has been fixed and was released 2 days ago.

This commit updates the openssl crates including others.
This should also fix the issues with building Vaultwarden using newer
versions of LibreSSL.

And also fixes the security/dependabot tickets.

Fixes #4051
