### PR TITLE
Allow customizing the featureStates

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -391,9 +391,8 @@
 # AUTHENTICATOR_DISABLE_TIME_DRIFT=false
 
 ## Client Settings
-## En- or disable experimental feature flags for clients.
-## This is a comma-separated list of flags, e.g. "flag1,flag2,^flag3".
-## To disable a feature prepend a caret (^) to the flag name.
+## Enable experimental feature flags for clients.
+## This is a comma-separated list of flags, e.g. "flag1,flag2,flag3".
 ##
 ## The following flags are available:
 ## - "autofill-overlay": Add an overlay menu to form fields for quick access to credentials.

--- a/.env.template
+++ b/.env.template
@@ -399,7 +399,7 @@
 ## - "autofill-v2": Use the new autofill implementation.
 ## - "browser-fileless-import": Directly import credentials from other providers without a file.
 ## - "fido2-vault-credentials": Enable the use of FIDO2 security keys as second factor.
-## EXPERIMENTAL_CLIENT_FEATURE_FLAGS=^autofill-v2,fido2-vault-credentials
+## EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 
 ## Rocket specific settings
 ## See https://rocket.rs/v0.4/guide/configuration/ for more details.

--- a/.env.template
+++ b/.env.template
@@ -390,6 +390,18 @@
 ## In any case, if a code has been used it can not be used again, also codes which predates it will be invalid.
 # AUTHENTICATOR_DISABLE_TIME_DRIFT=false
 
+## Client Settings
+## En- or disable experimental feature flags for clients.
+## This is a comma-separated list of flags, e.g. "flag1,flag2,^flag3".
+## To disable a feature prepend a caret (^) to the flag name.
+##
+## The following flags are available:
+## - "autofill-overlay": Add an overlay menu to form fields for quick access to credentials.
+## - "autofill-v2": Use the new autofill implementation.
+## - "browser-fileless-import": Directly import credentials from other providers without a file.
+## - "fido2-vault-credentials": Enable the use of FIDO2 security keys as second factor.
+## EXPERIMENTAL_CLIENT_FEATURE_FLAGS=^autofill-v2,fido2-vault-credentials
+
 ## Rocket specific settings
 ## See https://rocket.rs/v0.4/guide/configuration/ for more details.
 # ROCKET_ADDRESS=0.0.0.0

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -213,7 +213,7 @@ fn config() -> Json<Value> {
           "notifications": format!("{domain}/notifications"),
           "sso": "",
         },
-        "feature_states": feature_states,
+        "featureStates": feature_states,
         "object": "config",
     }))
 }

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -54,7 +54,7 @@ use crate::{
     auth::Headers,
     db::DbConn,
     error::Error,
-    util::{get_reqwest_client, parse_feature_flags},
+    util::{get_reqwest_client, parse_experimental_client_feature_flags},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -192,8 +192,8 @@ fn version() -> Json<&'static str> {
 #[get("/config")]
 fn config() -> Json<Value> {
     let domain = crate::CONFIG.domain();
-    let feature_states = parse_feature_flags(&crate::CONFIG.feature_flags());
-    let mut config = json!({
+    let feature_states = parse_experimental_client_feature_flags(&crate::CONFIG.experimental_client_feature_flags());
+    Json(json!({
         // Note: The clients use this version to handle backwards compatibility concerns
         // This means they expect a version that closely matches the Bitwarden server version
         // We should make sure that we keep this updated when we support the new server features
@@ -213,10 +213,9 @@ fn config() -> Json<Value> {
           "notifications": format!("{domain}/notifications"),
           "sso": "",
         },
+        "feature_states": feature_states,
         "object": "config",
-    });
-    config["featureStates"] = serde_json::to_value(feature_states).unwrap();
-    Json(config)
+    }))
 }
 
 pub fn catchers() -> Vec<Catcher> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -757,17 +757,11 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
     }
 
     const SUPPORTED_FLAGS: &[&str] = &[
+        "autofill-overlay",
+        "autofill-v2",
+        "browser-fileless-import",
         "display-kdf-iteration-warning",
         "fido2-vault-credentials",
-        "trusted-device-encryption",
-        "passwordless-login",
-        "autofill-v2",
-        "autofill-overlay",
-        "browser-fileless-import",
-        "item-share",
-        "flexible-collections",
-        "flexible-collections-v-1",
-        "bulk-collection-access",
     ];
     for flag in parse_feature_flags(&cfg.feature_flags).keys() {
         if !SUPPORTED_FLAGS.contains(&flag.as_str()) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -756,12 +756,8 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         )
     }
 
-    const KNOWN_FLAGS: &[&str] = &[
-        "autofill-overlay",
-        "autofill-v2",
-        "browser-fileless-import",
-        "fido2-vault-credentials",
-    ];
+    const KNOWN_FLAGS: &[&str] =
+        &["autofill-overlay", "autofill-v2", "browser-fileless-import", "fido2-vault-credentials"];
     for flag in parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags).keys() {
         if !KNOWN_FLAGS.contains(&flag.as_str()) {
             err!(format!("The experimental client feature flag {flag:?} is unrecognized. Please ensure the feature flag is spelled correctly, a caret (^) is used for disabling and that it is supported in this version."));

--- a/src/config.rs
+++ b/src/config.rs
@@ -758,7 +758,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         &["autofill-overlay", "autofill-v2", "browser-fileless-import", "fido2-vault-credentials"];
     for flag in parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags).keys() {
         if !KNOWN_FLAGS.contains(&flag.as_str()) {
-            err!(format!("The experimental client feature flag {flag:?} is unrecognized. Please ensure the feature flag is spelled correctly and that it is supported in this version."));
+            warn!("The experimental client feature flag {flag:?} is unrecognized. Please ensure the feature flag is spelled correctly and that it is supported in this version.");
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -547,6 +547,9 @@ make_config! {
         /// TOTP codes of the previous and next 30 seconds will be invalid.
         authenticator_disable_time_drift: bool, true, def, false;
 
+        /// Customize the enabled feature flags on the clients |> This is a comma separated list of feature flags to enable.
+        feature_flags: String, false, def, "fido2-vault-credentials".to_string();
+
         /// Require new device emails |> When a user logs in an email is required to be sent.
         /// If sending the email fails the login attempt will fail.
         require_device_email:   bool,   true,   def,     false;
@@ -749,6 +752,27 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
             # added to your configuration.                                                         #\n\
             ########################################################################################\n"
         )
+    }
+
+    let feature_flags = cfg.feature_flags.to_lowercase();
+    let features = feature_flags.split(',').map(|f| f.trim()).collect::<Vec<_>>();
+    let supported_flags = vec![
+        "display-kdf-iteration-warning",
+        "fido2-vault-credentials",
+        "trusted-device-encryption",
+        "passwordless-login",
+        "autofill-v2",
+        "autofill-overlay",
+        "browser-fileless-import",
+        "item-share",
+        "flexible-collections",
+        "flexible-collections-v-1",
+        "bulk-collection-access",
+    ];
+    for feature in features {
+        if !supported_flags.contains(&feature) {
+            err!(format!("Feature flag {feature:?} is not supported."));
+        }
     }
 
     if cfg._enable_duo

--- a/src/config.rs
+++ b/src/config.rs
@@ -547,10 +547,8 @@ make_config! {
         /// TOTP codes of the previous and next 30 seconds will be invalid.
         authenticator_disable_time_drift: bool, true, def, false;
 
-        /// Customize the enabled feature flags on the clients |> This is a comma separated list of feature flags to en-/disable.
-        /// Features are enabled by default which can be overridden by prefixing the feature with a `^`.
-        /// Autofill v2 is disabled by default because it is causing issues https://github.com/dani-garcia/vaultwarden/discussions/4052
-        experimental_client_feature_flags: String, false, def, "^autofill-v2,fido2-vault-credentials".to_string();
+        /// Customize the enabled feature flags on the clients |> This is a comma separated list of feature flags to enable.
+        experimental_client_feature_flags: String, false, def, "fido2-vault-credentials".to_string();
 
         /// Require new device emails |> When a user logs in an email is required to be sent.
         /// If sending the email fails the login attempt will fail.
@@ -760,7 +758,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         &["autofill-overlay", "autofill-v2", "browser-fileless-import", "fido2-vault-credentials"];
     for flag in parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags).keys() {
         if !KNOWN_FLAGS.contains(&flag.as_str()) {
-            err!(format!("The experimental client feature flag {flag:?} is unrecognized. Please ensure the feature flag is spelled correctly, a caret (^) is used for disabling and that it is supported in this version."));
+            err!(format!("The experimental client feature flag {flag:?} is unrecognized. Please ensure the feature flag is spelled correctly and that it is supported in this version."));
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -751,7 +751,8 @@ pub fn convert_json_key_lcase_first(src_json: Value) -> Value {
 
 /// Parses the experimental client feature flags string into a HashMap.
 pub fn parse_experimental_client_feature_flags(experimental_client_feature_flags: &str) -> HashMap<String, bool> {
-    let feature_states = experimental_client_feature_flags.to_lowercase().split(',').map(|f| (f.trim().to_owned(), true)).collect();
+    let feature_states =
+        experimental_client_feature_flags.to_lowercase().split(',').map(|f| (f.trim().to_owned(), true)).collect();
 
     feature_states
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -756,13 +756,7 @@ pub fn parse_experimental_client_feature_flags(experimental_client_feature_flags
     let mut feature_states: HashMap<String, bool> = HashMap::new();
 
     for feature in features {
-        let is_enabled = !feature.starts_with('^');
-        let flag = if is_enabled {
-            feature
-        } else {
-            &feature[1..]
-        };
-        feature_states.insert(flag.to_string(), is_enabled);
+        feature_states.insert(feature.to_string(), true);
     }
 
     feature_states

--- a/src/util.rs
+++ b/src/util.rs
@@ -749,14 +749,14 @@ pub fn convert_json_key_lcase_first(src_json: Value) -> Value {
     }
 }
 
-/// Parses the feature flags string into a HashMap.
-pub fn parse_feature_flags(feature_flags: &str) -> HashMap<String, bool> {
-    let feature_flags_lowercase = feature_flags.to_lowercase();
-    let features = feature_flags_lowercase.split(',').map(|f| f.trim()).collect::<Vec<_>>();
+/// Parses the experimental client feature flags string into a HashMap.
+pub fn parse_experimental_client_feature_flags(experimental_client_feature_flags: &str) -> HashMap<String, bool> {
+    let experimental_client_feature_flags_lowercase = experimental_client_feature_flags.to_lowercase();
+    let features = experimental_client_feature_flags_lowercase.split(',').map(|f| f.trim()).collect::<Vec<_>>();
     let mut feature_states: HashMap<String, bool> = HashMap::new();
 
     for feature in features {
-        let is_enabled = !feature.starts_with('!');
+        let is_enabled = !feature.starts_with('^');
         let flag = if is_enabled {
             feature
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@
 // Web Headers and caching
 //
 use std::{
+    collections::HashMap,
     io::{Cursor, ErrorKind},
     ops::Deref,
 };
@@ -746,4 +747,19 @@ pub fn convert_json_key_lcase_first(src_json: Value) -> Value {
 
         value => value,
     }
+}
+
+/// Parses the feature flags string into a HashMap.
+pub fn parse_feature_flags(feature_flags: &str) -> HashMap<String, bool> {
+    let feature_flags_lowercase = feature_flags.to_lowercase();
+    let features = feature_flags_lowercase.split(',').map(|f| f.trim()).collect::<Vec<_>>();
+    let mut feature_states: HashMap<String, bool> = HashMap::new();
+
+    for feature in features {
+        let is_enabled = !feature.starts_with('!');
+        let flag = if is_enabled { feature } else { &feature[1..] };
+        feature_states.insert(flag.to_string(), is_enabled);
+    }
+
+    feature_states
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -751,13 +751,7 @@ pub fn convert_json_key_lcase_first(src_json: Value) -> Value {
 
 /// Parses the experimental client feature flags string into a HashMap.
 pub fn parse_experimental_client_feature_flags(experimental_client_feature_flags: &str) -> HashMap<String, bool> {
-    let experimental_client_feature_flags_lowercase = experimental_client_feature_flags.to_lowercase();
-    let features = experimental_client_feature_flags_lowercase.split(',').map(|f| f.trim()).collect::<Vec<_>>();
-    let mut feature_states: HashMap<String, bool> = HashMap::new();
-
-    for feature in features {
-        feature_states.insert(feature.to_string(), true);
-    }
+    let feature_states = experimental_client_feature_flags.to_lowercase().split(',').map(|f| (f.trim().to_owned(), true)).collect();
 
     feature_states
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -757,7 +757,11 @@ pub fn parse_feature_flags(feature_flags: &str) -> HashMap<String, bool> {
 
     for feature in features {
         let is_enabled = !feature.starts_with('!');
-        let flag = if is_enabled { feature } else { &feature[1..] };
+        let flag = if is_enabled {
+            feature
+        } else {
+            &feature[1..]
+        };
         feature_states.insert(flag.to_string(), is_enabled);
     }
 


### PR DESCRIPTION
Instead of statically disabling autofill-v2 and enabling fido2-vault-credentials let the user decide which features to en-/disable.

By default the above mentioned standard values are used but can be changed by specifying a comma separated list of any of the currently available in the bitwarden clients: https://github.com/bitwarden/clients/blob/00fd45a678956c76dde6caa76e8ba266c204471c/libs/common/src/enums/feature-flag.enum.ts

~To disable a feature just prepend an exclamation mark (!). The default value is: `!autofill-v2,fido2-vault-credentials`~