### PR TITLE
fix: use black text for update badge (better contrast)

### DIFF
--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -23,7 +23,7 @@
                     {{#if page_data.web_vault_enabled}}
                     <dt class="col-sm-5">Web Installed
                         <span class="badge bg-success d-none" id="web-success" title="Latest version is installed.">Ok</span>
-                        <span class="badge bg-warning d-none" id="web-warning" title="There seems to be an update available.">Update</span>
+                        <span class="badge bg-warning text-dark d-none" id="web-warning" title="There seems to be an update available.">Update</span>
                     </dt>
                     <dd class="col-sm-7">
                         <span id="web-installed">{{page_data.web_vault_version}}</span>


### PR DESCRIPTION
# Before

<img width="203" alt="image" src="https://github.com/dani-garcia/vaultwarden/assets/223439/02645657-3cfa-477b-aa19-14066aa772ec">

# After

<img width="209" alt="image" src="https://github.com/dani-garcia/vaultwarden/assets/223439/038387b9-1809-4523-9146-79067ebf96fe">

----

Fixes #4176