### PR TITLE
prevent side effects if groups are disabled

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -294,7 +294,7 @@ async fn post_organization(
 async fn get_user_collections(headers: Headers, mut conn: DbConn) -> Json<Value> {
     Json(json!({
         "Data":
-            Collection::find_by_user_uuid(headers.user.uuid.clone(), &mut conn).await
+            Collection::find_by_user_uuid(headers.user.uuid, &mut conn).await
             .iter()
             .map(Collection::to_json)
             .collect::<Value>(),

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::{CollectionGroup, User, UserOrgStatus, UserOrgType, UserOrganization};
+use crate::CONFIG;
 
 db_object! {
     #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
@@ -181,47 +182,74 @@ impl Collection {
     }
 
     pub async fn find_by_user_uuid(user_uuid: String, conn: &mut DbConn) -> Vec<Self> {
-        db_run! { conn: {
-            collections::table
-            .left_join(users_collections::table.on(
-                users_collections::collection_uuid.eq(collections::uuid).and(
-                    users_collections::user_uuid.eq(user_uuid.clone())
+        if CONFIG.org_groups_enabled() {
+            db_run! { conn: {
+                collections::table
+                .left_join(users_collections::table.on(
+                    users_collections::collection_uuid.eq(collections::uuid).and(
+                        users_collections::user_uuid.eq(user_uuid.clone())
+                    )
+                ))
+                .left_join(users_organizations::table.on(
+                    collections::org_uuid.eq(users_organizations::org_uuid).and(
+                        users_organizations::user_uuid.eq(user_uuid.clone())
+                    )
+                ))
+                .left_join(groups_users::table.on(
+                    groups_users::users_organizations_uuid.eq(users_organizations::uuid)
+                ))
+                .left_join(groups::table.on(
+                    groups::uuid.eq(groups_users::groups_uuid)
+                ))
+                .left_join(collections_groups::table.on(
+                    collections_groups::groups_uuid.eq(groups_users::groups_uuid).and(
+                        collections_groups::collections_uuid.eq(collections::uuid)
+                    )
+                ))
+                .filter(
+                    users_organizations::status.eq(UserOrgStatus::Confirmed as i32)
                 )
-            ))
-            .left_join(users_organizations::table.on(
-                collections::org_uuid.eq(users_organizations::org_uuid).and(
-                    users_organizations::user_uuid.eq(user_uuid.clone())
-                )
-            ))
-            .left_join(groups_users::table.on(
-                groups_users::users_organizations_uuid.eq(users_organizations::uuid)
-            ))
-            .left_join(groups::table.on(
-                groups::uuid.eq(groups_users::groups_uuid)
-            ))
-            .left_join(collections_groups::table.on(
-                collections_groups::groups_uuid.eq(groups_users::groups_uuid).and(
-                    collections_groups::collections_uuid.eq(collections::uuid)
-                )
-            ))
-            .filter(
-                users_organizations::status.eq(UserOrgStatus::Confirmed as i32)
-            )
-            .filter(
-                users_collections::user_uuid.eq(user_uuid).or( // Directly accessed collection
-                    users_organizations::access_all.eq(true) // access_all in Organization
-                ).or(
-                    groups::access_all.eq(true) // access_all in groups
-                ).or( // access via groups
-                    groups_users::users_organizations_uuid.eq(users_organizations::uuid).and(
-                        collections_groups::collections_uuid.is_not_null()
+                .filter(
+                    users_collections::user_uuid.eq(user_uuid).or( // Directly accessed collection
+                        users_organizations::access_all.eq(true) // access_all in Organization
+                    ).or(
+                        groups::access_all.eq(true) // access_all in groups
+                    ).or( // access via groups
+                        groups_users::users_organizations_uuid.eq(users_organizations::uuid).and(
+                            collections_groups::collections_uuid.is_not_null()
+                        )
                     )
                 )
-            )
-            .select(collections::all_columns)
-            .distinct()
-            .load::<CollectionDb>(conn).expect("Error loading collections").from_db()
-        }}
+                .select(collections::all_columns)
+                .distinct()
+                .load::<CollectionDb>(conn).expect("Error loading collections").from_db()
+            }}
+        } else {
+            db_run! { conn: {
+                collections::table
+                .left_join(users_collections::table.on(
+                    users_collections::collection_uuid.eq(collections::uuid).and(
+                        users_collections::user_uuid.eq(user_uuid.clone())
+                    )
+                ))
+                .left_join(users_organizations::table.on(
+                    collections::org_uuid.eq(users_organizations::org_uuid).and(
+                        users_organizations::user_uuid.eq(user_uuid.clone())
+                    )
+                ))
+                .filter(
+                    users_organizations::status.eq(UserOrgStatus::Confirmed as i32)
+                )
+                .filter(
+                    users_collections::user_uuid.eq(user_uuid).or( // Directly accessed collection
+                        users_organizations::access_all.eq(true) // access_all in Organization
+                    )
+                )
+                .select(collections::all_columns)
+                .distinct()
+                .load::<CollectionDb>(conn).expect("Error loading collections").from_db()
+            }}
+        }
     }
 
     // Check if a user has access to a specific collection
@@ -277,45 +305,70 @@ impl Collection {
     }
 
     pub async fn find_by_uuid_and_user(uuid: &str, user_uuid: String, conn: &mut DbConn) -> Option<Self> {
-        db_run! { conn: {
-            collections::table
-            .left_join(users_collections::table.on(
-                users_collections::collection_uuid.eq(collections::uuid).and(
-                    users_collections::user_uuid.eq(user_uuid.clone())
-                )
-            ))
-            .left_join(users_organizations::table.on(
-                collections::org_uuid.eq(users_organizations::org_uuid).and(
-                    users_organizations::user_uuid.eq(user_uuid)
-                )
-            ))
-            .left_join(groups_users::table.on(
-                groups_users::users_organizations_uuid.eq(users_organizations::uuid)
-            ))
-            .left_join(groups::table.on(
-                groups::uuid.eq(groups_users::groups_uuid)
-            ))
-            .left_join(collections_groups::table.on(
-                collections_groups::groups_uuid.eq(groups_users::groups_uuid).and(
-                    collections_groups::collections_uuid.eq(collections::uuid)
-                )
-            ))
-            .filter(collections::uuid.eq(uuid))
-            .filter(
-                users_collections::collection_uuid.eq(uuid).or( // Directly accessed collection
-                    users_organizations::access_all.eq(true).or( // access_all in Organization
-                        users_organizations::atype.le(UserOrgType::Admin as i32) // Org admin or owner
-                )).or(
-                    groups::access_all.eq(true) // access_all in groups
-                ).or( // access via groups
-                    groups_users::users_organizations_uuid.eq(users_organizations::uuid).and(
-                        collections_groups::collections_uuid.is_not_null()
+        if CONFIG.org_groups_enabled() {
+            db_run! { conn: {
+                collections::table
+                .left_join(users_collections::table.on(
+                    users_collections::collection_uuid.eq(collections::uuid).and(
+                        users_collections::user_uuid.eq(user_uuid.clone())
                     )
-                )
-            ).select(collections::all_columns)
-            .first::<CollectionDb>(conn).ok()
-            .from_db()
-        }}
+                ))
+                .left_join(users_organizations::table.on(
+                    collections::org_uuid.eq(users_organizations::org_uuid).and(
+                        users_organizations::user_uuid.eq(user_uuid)
+                    )
+                ))
+                .left_join(groups_users::table.on(
+                    groups_users::users_organizations_uuid.eq(users_organizations::uuid)
+                ))
+                .left_join(groups::table.on(
+                    groups::uuid.eq(groups_users::groups_uuid)
+                ))
+                .left_join(collections_groups::table.on(
+                    collections_groups::groups_uuid.eq(groups_users::groups_uuid).and(
+                        collections_groups::collections_uuid.eq(collections::uuid)
+                    )
+                ))
+                .filter(collections::uuid.eq(uuid))
+                .filter(
+                    users_collections::collection_uuid.eq(uuid).or( // Directly accessed collection
+                        users_organizations::access_all.eq(true).or( // access_all in Organization
+                            users_organizations::atype.le(UserOrgType::Admin as i32) // Org admin or owner
+                    )).or(
+                        groups::access_all.eq(true) // access_all in groups
+                    ).or( // access via groups
+                        groups_users::users_organizations_uuid.eq(users_organizations::uuid).and(
+                            collections_groups::collections_uuid.is_not_null()
+                        )
+                    )
+                ).select(collections::all_columns)
+                .first::<CollectionDb>(conn).ok()
+                .from_db()
+            }}
+        } else {
+            db_run! { conn: {
+                collections::table
+                .left_join(users_collections::table.on(
+                    users_collections::collection_uuid.eq(collections::uuid).and(
+                        users_collections::user_uuid.eq(user_uuid.clone())
+                    )
+                ))
+                .left_join(users_organizations::table.on(
+                    collections::org_uuid.eq(users_organizations::org_uuid).and(
+                        users_organizations::user_uuid.eq(user_uuid)
+                    )
+                ))
+                .filter(collections::uuid.eq(uuid))
+                .filter(
+                    users_collections::collection_uuid.eq(uuid).or( // Directly accessed collection
+                        users_organizations::access_all.eq(true).or( // access_all in Organization
+                            users_organizations::atype.le(UserOrgType::Admin as i32) // Org admin or owner
+                    ))
+                ).select(collections::all_columns)
+                .first::<CollectionDb>(conn).ok()
+                .from_db()
+            }}
+        }
     }
 
     pub async fn is_writable_by_user(&self, user_uuid: &str, conn: &mut DbConn) -> bool {


### PR DESCRIPTION
while working on #3754 I noticed that if I disable groups the collections and ciphers that I had access to via a group are still shown because the queries don't take into account if the groups are enabled or not.