### PR TITLE
Return 404 when user public_key is empty

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -279,8 +279,9 @@ async fn put_avatar(data: JsonUpcase<AvatarData>, headers: Headers, mut conn: Db
 #[get("/users/<uuid>/public-key")]
 async fn get_public_keys(uuid: &str, _headers: Headers, mut conn: DbConn) -> JsonResult {
     let user = match User::find_by_uuid(uuid, &mut conn).await {
-        Some(user) => user,
-        None => err!("User doesn't exist"),
+        Some(user) if user.public_key.is_some() => user,
+        Some(_) => err_code!("User has no public_key", Status::NotFound.code),
+        None => err_code!("User doesn't exist", Status::NotFound.code),
     };
 
     Ok(Json(json!({


### PR DESCRIPTION
Hey,

So, when working on the SSO PR, I introduced a bug with the `SSO_ACCEPTALL_INVITES`  which made possible for a user to be `UserOrgStatus::Accepted` while not yet having a public key.

What made the issue worse is that then the admin can confirm the user while using a public key with a `null` value.
When the user finally login the vault will be broken and does not load.

So of course fixed the issue, but this change would make it so that the admin can't confirm the user and prevent entering a broken state. Sadly the error is not displayed (be it a `400` or `404`).

Lastly this would be more inline with the official server implementation which In believe throw a `NotFoundException` in this [case](https://github.com/bitwarden/server/blob/aeca1722fc61680715e5b439aea8bf6cc4e7b300/src/Api/Controllers/UsersController.cs#L28).