### PR TITLE
Fix attachment upload size check

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -1123,11 +1123,11 @@ async fn save_attachment(
         // the client. Upstream allows +/- 1 MiB deviation from this
         // size, but it's not clear when or why this is needed.
         const LEEWAY: i64 = 1024 * 1024; // 1 MiB
-        let Some(min_size) = attachment.file_size.checked_add(LEEWAY) else {
-            err!("Invalid attachment size min")
-        };
-        let Some(max_size) = attachment.file_size.checked_sub(LEEWAY) else {
+        let Some(max_size) = attachment.file_size.checked_add(LEEWAY) else {
             err!("Invalid attachment size max")
+        };
+        let Some(min_size) = attachment.file_size.checked_sub(LEEWAY) else {
+            err!("Invalid attachment size min")
         };
 
         if min_size <= size && size <= max_size {


### PR DESCRIPTION
The min/max were reversed with the `add` and `sub` functions. This caused the files to always be out of bounds in the check.

Fixes #4281