### PR TITLE
fix push device registration

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -268,7 +268,9 @@ async fn _password_login(
     }
 
     // register push device
-    register_push_device(&mut device, conn).await?;
+    if !new_device {
+        register_push_device(&mut device, conn).await?;
+    }
 
     // Common
     // ---


### PR DESCRIPTION
Don't try to register a push device when the device is new
It will be registered when the push token is saved

fixes #4296