### PR TITLE
Fix healthcheck when using .env file

### DIFF
--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,17 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Use the value of the corresponding env var (if present),
 # or a default value otherwise.
-: "${DATA_FOLDER:="data"}"
+: "${DATA_FOLDER:="/data"}"
 : "${ROCKET_PORT:="80"}"
+: "${ENV_FILE:="/.env"}"
 
 CONFIG_FILE="${DATA_FOLDER}"/config.json
 
-# Check if there is a .env file configured
+# Check if the $ENV_FILE file exist and is readable
 # If that is the case, load it into the environment before running any check
-if [ -z "${ENV_FILE}" ]; then
-    ENV_FILE=".env"
-fi
 if [ -r "${ENV_FILE}" ]; then
     # shellcheck disable=SC1090
     . "${ENV_FILE}"


### PR DESCRIPTION
It seems Debian based images see the `.env` file in the `pwd` path, but sourcing it via `. .env` breaks. It does work if you provide the full path `/.env`. Changed the default to `/.env`.

Alpine does not have an issue with both ways.

Fixes #4295