### PR TITLE
Allow to override log level for specific target

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -362,8 +362,9 @@
 ## Log level
 ## Change the verbosity of the log output
 ## Valid values are "trace", "debug", "info", "warn", "error" and "off"
-## Setting it to "trace" or "debug" would also show logs for mounted
-## routes and static file, websocket and alive requests
+## Setting it to "trace" or "debug" would also show logs for mounted routes and static file, websocket and alive requests
+## For a specific module append a comma separated `path::to::module=log_level`
+## For example, to only see debug logs for icons use: LOG_LEVEL="info,vaultwarden::api::icons=debug"
 # LOG_LEVEL=info
 
 ## Token for the admin interface, preferably an Argon2 PCH string

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,8 +576,9 @@ make_config! {
         use_syslog:             bool,   false,  def,    false;
         /// Log file path
         log_file:               String, false,  option;
-        /// Log level
-        log_level:              String, false,  def,    "Info".to_string();
+        /// Log level |> Valid values are "trace", "debug", "info", "warn", "error" and "off"
+        /// For a specific module append it as a comma separated value "info,path::to::module=debug"
+        log_level:              String, false,  def,    "info".to_string();
 
         /// Enable DB WAL |> Turning this off might lead to worse performance, but might help if using vaultwarden on some exotic filesystems,
         /// that do not support WAL. Please make sure you read project wiki on the topic before changing this setting.


### PR DESCRIPTION
Useful for either silencing some target when running in `debug` or switching `debug` only for a specific target,

With this a good chunk of the default overrides could be moved to the conf, cf:

```rust
        // Hide unknown certificate errors if using self-signed
        .level_for("rustls::session", log::LevelFilter::Off)
        // Hide failed to close stream messages
        .level_for("hyper::server", log::LevelFilter::Warn)
        // Silence Rocket `_` logs
        .level_for("_", rocket_underscore_level)
        .level_for("rocket::response::responder::_", rocket_underscore_level)
        .level_for("rocket::server::_", rocket_underscore_level)
        .level_for("vaultwarden::api::admin::_", rocket_underscore_level)
        .level_for("vaultwarden::api::notifications::_", rocket_underscore_level)
        // Silence Rocket logs
        .level_for("rocket::launch", log::LevelFilter::Error)
        .level_for("rocket::launch_", log::LevelFilter::Error)
        .level_for("rocket::rocket", log::LevelFilter::Warn)
        .level_for("rocket::server", log::LevelFilter::Warn)
        .level_for("rocket::fairing::fairings", log::LevelFilter::Warn)
        .level_for("rocket::shield::shield", log::LevelFilter::Warn)
        .level_for("hyper::proto", log::LevelFilter::Off)
        .level_for("hyper::client", log::LevelFilter::Off)
        // Filter handlebars logs
        .level_for("handlebars::render", handlebars_level)
        // Prevent cookie_store logs
        .level_for("cookie_store", log::LevelFilter::Off)
        // Variable level for trust-dns used by reqwest
        .level_for("trust_dns_resolver::name_server::name_server", trust_dns_level)
        .level_for("trust_dns_proto::xfer", trust_dns_level)
        .level_for("diesel_logger", diesel_logger_level)
```