### PR TITLE
Update GHA Workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,10 @@ name: Release
 
 on:
   push:
-    paths:
-      - ".github/workflows/release.yml"
-      - "src/**"
-      - "migrations/**"
-      - "docker/**"
-      - "Cargo.*"
-      - "build.rs"
-      - "diesel.toml"
-      - "rust-toolchain.toml"
-
-    branches: # Only on paths above
+    branches:
       - main
 
-    tags: # Always, regardless of paths above
+    tags:
       - '*'
 
 jobs:
@@ -239,28 +229,28 @@ jobs:
 
       # Upload artifacts to Github Actions
       - name: "Upload amd64 artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-amd64
           path: vaultwarden-amd64
 
       - name: "Upload arm64 artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-arm64
           path: vaultwarden-arm64
 
       - name: "Upload armv7 artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv7
           path: vaultwarden-armv7
 
       - name: "Upload armv6 artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv6

--- a/.github/workflows/releasecache-cleanup.yml
+++ b/.github/workflows/releasecache-cleanup.yml
@@ -14,10 +14,11 @@ jobs:
   releasecache-cleanup:
     name: Releasecache Cleanup
     runs-on: ubuntu-22.04
+    continue-on-error: true
     timeout-minutes: 30
     steps:
       - name: Delete vaultwarden-buildcache containers
-        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20 # v4.1.1
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: 'vaultwarden-buildcache'
           package-type: 'container'


### PR DESCRIPTION
- Update the workflow GH Actions.
- Configured the release workflow to always run on main/tag as discussed in #4226

Closes #4226