### PR TITLE
Fix env templateto ensure compatibility with systemd's EnvironmentFile parsing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -477,13 +477,18 @@
 # SMTP_HOST=smtp.domain.tld
 # SMTP_FROM=vaultwarden@domain.tld
 # SMTP_FROM_NAME=Vaultwarden
-## ("starttls", "force_tls", "off") Enable a secure connection. Default is "starttls" (Explicit - ports 587 or 25), "force_tls" (Implicit - port 465) or "off", no encryption (port 25)
-# SMTP_SECURITY=starttls
-## Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 (submissions) is used for encrypted submission (Implicit TLS).
-# SMTP_PORT=587
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
 # SMTP_TIMEOUT=15
+
+## Choose the type of secure connection for SMTP. The default is "starttls".
+## The available options are:
+## - "starttls": The default port is 587.
+## - "force_tls": The default port is 465.
+## - "off": The default port is 25.
+## Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 (submissions) is used for encrypted submission (Implicit TLS).
+# SMTP_SECURITY=starttls
+# SMTP_PORT=587
 
 # Whether to send mail via the `sendmail` command
 # USE_SENDMAIL=false
@@ -526,8 +531,8 @@
 ## Rocket specific settings
 ## See https://rocket.rs/v0.5/guide/configuration/ for more details.
 # ROCKET_ADDRESS=0.0.0.0
-## Defaults to 80 in the Docker images, or 8000 otherwise.
-# ROCKET_PORT=80
+## The default port is 8000, unless running in a Docker container, in which case it is 80.
+# ROCKET_PORT=8000
 # ROCKET_TLS={certs="/path/to/certs.pem",key="/path/to/key.pem"}
 
 

--- a/.env.template
+++ b/.env.template
@@ -477,8 +477,10 @@
 # SMTP_HOST=smtp.domain.tld
 # SMTP_FROM=vaultwarden@domain.tld
 # SMTP_FROM_NAME=Vaultwarden
-# SMTP_SECURITY=starttls # ("starttls", "force_tls", "off") Enable a secure connection. Default is "starttls" (Explicit - ports 587 or 25), "force_tls" (Implicit - port 465) or "off", no encryption (port 25)
-# SMTP_PORT=587          # Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 (submissions) is used for encrypted submission (Implicit TLS).
+## ("starttls", "force_tls", "off") Enable a secure connection. Default is "starttls" (Explicit - ports 587 or 25), "force_tls" (Implicit - port 465) or "off", no encryption (port 25)
+# SMTP_SECURITY=starttls
+## Ports 587 (submission) and 25 (smtp) are standard without encryption and with encryption via STARTTLS (Explicit TLS). Port 465 (submissions) is used for encrypted submission (Implicit TLS).
+# SMTP_PORT=587
 # SMTP_USERNAME=username
 # SMTP_PASSWORD=password
 # SMTP_TIMEOUT=15
@@ -524,7 +526,8 @@
 ## Rocket specific settings
 ## See https://rocket.rs/v0.5/guide/configuration/ for more details.
 # ROCKET_ADDRESS=0.0.0.0
-# ROCKET_PORT=80  # Defaults to 80 in the Docker images, or 8000 otherwise.
+## Defaults to 80 in the Docker images, or 8000 otherwise.
+# ROCKET_PORT=80
 # ROCKET_TLS={certs="/path/to/certs.pem",key="/path/to/key.pem"}
 
 


### PR DESCRIPTION
This commit addresses an issue in the Vaultwarden project's `.env.template` file where comments explaining environment variable options were incorrectly placed on the same line as the variable definitions. Systemd's `EnvironmentFile` directive only recognizes comment symbols (#) at the beginning of a line. Therefore, explanatory comments placed on the same line as environment variable definitions can lead to misinterpretations or errors when the file is used in a systemd service file.
