### PR TITLE
automatically use email address as 2fa provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -448,6 +448,11 @@
 ##
 ## Maximum attempts before an email token is reset and a new email will need to be sent.
 # EMAIL_ATTEMPTS_LIMIT=3
+##
+## Setup email 2FA regardless of any organization policy
+# EMAIL_2FA_ENFORCE_ON_VERIFIED_INVITE=false
+## Automatically setup email 2FA as fallback provider when needed
+# EMAIL_2FA_AUTO_FALLBACK=false
 
 ## Other MFA/2FA settings
 ## Disable 2FA remember

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1071,7 +1071,7 @@ async fn accept_invite(
     let claims = decode_invite(&data.Token)?;
 
     match User::find_by_mail(&claims.email, &mut conn).await {
-        Some(_) => {
+        Some(user) => {
             Invitation::take(&claims.email, &mut conn).await;
 
             if let (Some(user_org), Some(org)) = (&claims.user_org_id, &claims.org_id) {
@@ -1095,7 +1095,11 @@ async fn accept_invite(
                     match OrgPolicy::is_user_allowed(&user_org.user_uuid, org_id, false, &mut conn).await {
                         Ok(_) => {}
                         Err(OrgPolicyErr::TwoFactorMissing) => {
-                            err!("You cannot join this organization until you enable two-step login on your user account");
+                            if CONFIG.email_2fa_auto_fallback() {
+                                two_factor::email::activate_email_2fa(&user, &mut conn).await?;
+                            } else {
+                                err!("You cannot join this organization until you enable two-step login on your user account");
+                            }
                         }
                         Err(OrgPolicyErr::SingleOrgEnforced) => {
                             err!("You cannot join this organization because you are a member of an organization which forbids it");
@@ -1220,10 +1224,14 @@ async fn _confirm_invite(
         match OrgPolicy::is_user_allowed(&user_to_confirm.user_uuid, org_id, true, conn).await {
             Ok(_) => {}
             Err(OrgPolicyErr::TwoFactorMissing) => {
-                err!("You cannot confirm this user because it has no two-step login method activated");
+                if CONFIG.email_2fa_auto_fallback() {
+                    two_factor::email::find_and_activate_email_2fa(&user_to_confirm.user_uuid, conn).await?;
+                } else {
+                    err!("You cannot confirm this user because they have not setup 2FA");
+                }
             }
             Err(OrgPolicyErr::SingleOrgEnforced) => {
-                err!("You cannot confirm this user because it is a member of an organization which forbids it");
+                err!("You cannot confirm this user because they are a member of an organization which forbids it");
             }
         }
     }
@@ -1351,10 +1359,14 @@ async fn edit_user(
         match OrgPolicy::is_user_allowed(&user_to_edit.user_uuid, org_id, true, &mut conn).await {
             Ok(_) => {}
             Err(OrgPolicyErr::TwoFactorMissing) => {
-                err!("You cannot modify this user to this type because it has no two-step login method activated");
+                if CONFIG.email_2fa_auto_fallback() {
+                    two_factor::email::find_and_activate_email_2fa(&user_to_edit.user_uuid, &mut conn).await?;
+                } else {
+                    err!("You cannot modify this user to this type because they have not setup 2FA");
+                }
             }
             Err(OrgPolicyErr::SingleOrgEnforced) => {
-                err!("You cannot modify this user to this type because it is a member of an organization which forbids it");
+                err!("You cannot modify this user to this type because they are a member of an organization which forbids it");
             }
         }
     }
@@ -2151,10 +2163,14 @@ async fn _restore_organization_user(
                 match OrgPolicy::is_user_allowed(&user_org.user_uuid, org_id, false, conn).await {
                     Ok(_) => {}
                     Err(OrgPolicyErr::TwoFactorMissing) => {
-                        err!("You cannot restore this user because it has no two-step login method activated");
+                        if CONFIG.email_2fa_auto_fallback() {
+                            two_factor::email::find_and_activate_email_2fa(&user_org.user_uuid, conn).await?;
+                        } else {
+                            err!("You cannot restore this user because they have not setup 2FA");
+                        }
                     }
                     Err(OrgPolicyErr::SingleOrgEnforced) => {
-                        err!("You cannot restore this user because it is a member of an organization which forbids it");
+                        err!("You cannot restore this user because they are a member of an organization which forbids it");
                     }
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,6 +691,10 @@ make_config! {
         email_expiration_time:  u64,    true,   def,      600;
         /// Maximum attempts |> Maximum attempts before an email token is reset and a new email will need to be sent
         email_attempts_limit:   u64,    true,   def,      3;
+        /// Automatically enforce at login |> Setup email 2FA provider regardless of any organization policy
+        email_2fa_enforce_on_verified_invite: bool,   true,   def,      false;
+        /// Auto-enable 2FA (Know the risks!) |> Automatically setup email 2FA as fallback provider when needed
+        email_2fa_auto_fallback: bool,  true,   def,      false;
     },
 }
 
@@ -891,6 +895,13 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
 
     if cfg._enable_email_2fa && !(cfg.smtp_host.is_some() || cfg.use_sendmail) {
         err!("To enable email 2FA, a mail transport must be configured")
+    }
+
+    if !cfg._enable_email_2fa && cfg.email_2fa_enforce_on_verified_invite {
+        err!("To enforce email 2FA on verified invitations, email 2fa has to be enabled!");
+    }
+    if !cfg._enable_email_2fa && cfg.email_2fa_auto_fallback {
+        err!("To use email 2FA as automatic fallback, email 2fa has to be enabled!");
     }
 
     // Check if the icon blacklist regex is valid

--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -340,4 +340,11 @@ impl OrgPolicy {
         }
         false
     }
+
+    pub async fn is_enabled_by_org(org_uuid: &str, policy_type: OrgPolicyType, conn: &mut DbConn) -> bool {
+        if let Some(policy) = OrgPolicy::find_by_org_and_type(org_uuid, policy_type, conn).await {
+            return policy.enabled;
+        }
+        false
+    }
 }


### PR DESCRIPTION
When an organization policy requires a 2FA provider the registration via the organizations invite link should add the email address as 2FA provider. You can also skip the policy check if you set `EMAIL_2FA_ENFORCE_ON_VERIFIED_INVITE=true` (e.g. so that email provider is added to users that are invited via the `/admin` panel).

This should fix #4303, however I've also added a way to ensure that the email address will be used automatically as fallback 2FA provider whenever needed (which you have to opt in by setting `EMAIL_2FA_AUTO_FALLBACK=true`). I'd consider this an experimental feature as it would be Vaultwarden only.

If you don't want your users to enable email 2FA provider at all, you should set `_ENABLE_EMAIL_2FA=false` to disable email as 2FA provider entirely.