### PR TITLE
Change the codegen-units for low resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ panic = "abort"
 inherits = "release"
 strip = "symbols"
 lto = "thin"
-codegen-units = 1
+codegen-units = 16
 
 # Linting config
 [lints.rust]


### PR DESCRIPTION
It seems (as disscusses here #4320) a single codegen unit makes it still crash. This sets it to the default 16 Rust uses for the release profile.