### PR TITLE
fix emergency access invites

### DIFF
--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -209,7 +209,7 @@ async fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Heade
         err!("You can not set yourself as an emergency contact.")
     }
 
-    let grantee_user = match User::find_by_mail(&email, &mut conn).await {
+    let (grantee_user, new_user) = match User::find_by_mail(&email, &mut conn).await {
         None => {
             if !CONFIG.invitations_allowed() {
                 err!(format!("Grantee user does not exist: {}", &email))
@@ -226,9 +226,10 @@ async fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Heade
 
             let mut user = User::new(email.clone());
             user.save(&mut conn).await?;
-            user
+            (user, true)
         }
-        Some(user) => user,
+        Some(user) if user.password_hash.is_empty() => (user, true),
+        Some(user) => (user, false),
     };
 
     if EmergencyAccess::find_by_grantor_uuid_and_grantee_uuid_or_email(
@@ -256,15 +257,9 @@ async fn send_invite(data: JsonUpcase<EmergencyAccessInviteData>, headers: Heade
             &grantor_user.email,
         )
         .await?;
-    } else {
-        // Automatically mark user as accepted if no email invites
-        match User::find_by_mail(&email, &mut conn).await {
-            Some(user) => match accept_invite_process(&user.uuid, &mut new_emergency_access, &email, &mut conn).await {
-                Ok(v) => v,
-                Err(e) => err!(e.to_string()),
-            },
-            None => err!("Grantee user not found."),
-        }
+    } else if !new_user {
+        // if mail is not enabled immediately accept the invitation for existing users
+        new_emergency_access.accept_invite(&grantee_user.uuid, &email, &mut conn).await?;
     }
 
     Ok(())
@@ -308,17 +303,12 @@ async fn resend_invite(emer_id: &str, headers: Headers, mut conn: DbConn) -> Emp
             &grantor_user.email,
         )
         .await?;
-    } else {
-        if Invitation::find_by_mail(&email, &mut conn).await.is_none() {
-            let invitation = Invitation::new(&email);
-            invitation.save(&mut conn).await?;
-        }
-
-        // Automatically mark user as accepted if no email invites
-        match accept_invite_process(&grantee_user.uuid, &mut emergency_access, &email, &mut conn).await {
-            Ok(v) => v,
-            Err(e) => err!(e.to_string()),
-        }
+    } else if !grantee_user.password_hash.is_empty() {
+        // accept the invitation for existing user
+        emergency_access.accept_invite(&grantee_user.uuid, &email, &mut conn).await?;
+    } else if CONFIG.invitations_allowed() && Invitation::find_by_mail(&email, &mut conn).await.is_none() {
+        let invitation = Invitation::new(&email);
+        invitation.save(&mut conn).await?;
     }
 
     Ok(())
@@ -367,10 +357,7 @@ async fn accept_invite(emer_id: &str, data: JsonUpcase<AcceptData>, headers: Hea
         && grantor_user.name == claims.grantor_name
         && grantor_user.email == claims.grantor_email
     {
-        match accept_invite_process(&grantee_user.uuid, &mut emergency_access, &grantee_user.email, &mut conn).await {
-            Ok(v) => v,
-            Err(e) => err!(e.to_string()),
-        }
+        emergency_access.accept_invite(&grantee_user.uuid, &grantee_user.email, &mut conn).await?;
 
         if CONFIG.mail_enabled() {
             mail::send_emergency_access_invite_accepted(&grantor_user.email, &grantee_user.email).await?;
@@ -380,26 +367,6 @@ async fn accept_invite(emer_id: &str, data: JsonUpcase<AcceptData>, headers: Hea
     } else {
         err!("Emergency access invitation error.")
     }
-}
-
-async fn accept_invite_process(
-    grantee_uuid: &str,
-    emergency_access: &mut EmergencyAccess,
-    grantee_email: &str,
-    conn: &mut DbConn,
-) -> EmptyResult {
-    if emergency_access.email.is_none() || emergency_access.email.as_ref().unwrap() != grantee_email {
-        err!("User email does not match invite.");
-    }
-
-    if emergency_access.status == EmergencyAccessStatus::Accepted as i32 {
-        err!("Emergency contact already accepted.");
-    }
-
-    emergency_access.status = EmergencyAccessStatus::Accepted as i32;
-    emergency_access.grantee_uuid = Some(String::from(grantee_uuid));
-    emergency_access.email = None;
-    emergency_access.save(conn).await
 }
 
 #[derive(Deserialize)]

--- a/src/db/models/emergency_access.rs
+++ b/src/db/models/emergency_access.rs
@@ -214,6 +214,13 @@ impl EmergencyAccess {
         Ok(())
     }
 
+    pub async fn delete_all_by_grantee_email(grantee_email: &str, conn: &mut DbConn) -> EmptyResult {
+        for ea in Self::find_all_invited_by_grantee_email(grantee_email, conn).await {
+            ea.delete(conn).await?;
+        }
+        Ok(())
+    }
+
     pub async fn delete(self, conn: &mut DbConn) -> EmptyResult {
         User::update_uuid_revision(&self.grantor_uuid, conn).await;
 

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -311,6 +311,7 @@ impl User {
 
         Send::delete_all_by_user(&self.uuid, conn).await?;
         EmergencyAccess::delete_all_by_user(&self.uuid, conn).await?;
+        EmergencyAccess::delete_all_by_grantee_email(&self.email, conn).await?;
         UserOrganization::delete_all_by_user(&self.uuid, conn).await?;
         Cipher::delete_all_by_user(&self.uuid, conn).await?;
         Favorite::delete_all_by_user(&self.uuid, conn).await?;


### PR DESCRIPTION
When mail is disabled instead of accepting emergency access for all invited users automatically, we only accept the emergency access invitation immediately if the user already exists and has a `password_hash`. For invited users any open emergency access invitations will be accepted on registration.

Also prevent invited emergency access contacts to register if emergency access is disabled (this is only relevant for when mail is enabled, if mail is disabled they would have an Invitation entry).

This should address the issue reported in https://github.com/dani-garcia/vaultwarden/discussions/3183 without any breaking changes (i.e. this will not disable the emergency access feature when mail is disabled).