### PR TITLE
Roll the refresh_token

### DIFF
--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -1,4 +1,5 @@
 use chrono::{NaiveDateTime, Utc};
+use data_encoding::BASE64URL;
 
 use crate::{crypto, CONFIG};
 use core::fmt;
@@ -60,11 +61,8 @@ impl Device {
     }
 
     pub fn refresh_tokens(&mut self, user: &super::User, scope: Vec<String>) -> (String, i64) {
-        // If there is no refresh token, we create one
-        if self.refresh_token.is_empty() {
-            use data_encoding::BASE64URL;
-            self.refresh_token = crypto::encode_random_bytes::<64>(BASE64URL);
-        }
+        // Roll the refresh_token to prevent reuse
+        self.refresh_token = crypto::encode_random_bytes::<64>(BASE64URL);
 
         // Update the expiration of the device and the last update date
         let time_now = Utc::now();


### PR DESCRIPTION
Hey,

We recently discussed the `refresh_token` in the SSO PR and during this discussion it occurred to me that the long lived `refresh_token` could be rolled as is done by some SSO client.

This is handled / expected by the Bitwarden clients since the response `_refresh_login` contain the potentially updated [refresh_token](https://github.com/dani-garcia/vaultwarden/blob/bb2412d0339e1da5dee99fc566a2b2aab5d2808c/src/api/identity.rs#L122).