### PR TITLE
JWT Refresh Token

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -110,7 +110,9 @@ async fn _refresh_login(data: ConnectData, conn: &mut DbConn) -> JsonResult {
     // ---
     // let orgs = UserOrganization::find_confirmed_by_user(&user.uuid, conn).await;
     match auth::refresh_tokens(&refresh_token, conn).await {
-        Err(err) => err_code!(err.to_string(), Status::Unauthorized.code),
+        Err(err) => {
+            err_code!(format!("Unable to refresh login credentials: {}", err.message()), Status::Unauthorized.code)
+        }
         Ok((mut device, user, auth_tokens)) => {
             // Save to update `device.updated_at` to track usage
             device.save(conn).await?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,7 +35,7 @@ pub use crate::api::{
 use crate::db::{models::User, DbConn};
 
 // Type aliases for API methods results
-type ApiResult<T> = Result<T, crate::error::Error>;
+pub type ApiResult<T> = Result<T, crate::error::Error>;
 pub type JsonResult = ApiResult<Json<Value>>;
 pub type EmptyResult = ApiResult<()>;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1068,7 +1068,7 @@ pub async fn refresh_tokens(refresh_token: &str, conn: &mut DbConn) -> ApiResult
     let time_now = Utc::now();
 
     let refresh_claims = match decode_refresh(refresh_token) {
-        Err(err) => err!(format!("Impossible to read refresh_token: {err}")),
+        Err(err) => err_silent!(format!("Impossible to read refresh_token: {}", err.message())),
         Ok(claims) => claims,
     };
 
@@ -1092,7 +1092,7 @@ pub async fn refresh_tokens(refresh_token: &str, conn: &mut DbConn) -> ApiResult
 
     let auth_tokens = match refresh_claims.sub {
         AuthMethod::Password => AuthTokens::new(&device, &user, refresh_claims.sub),
-        _ => err!("Invalid auth method cannot refresh token"),
+        _ => err!("Invalid auth method, cannot refresh token"),
     };
 
     Ok((device, user, auth_tokens))

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,10 @@ impl Error {
     pub fn get_event(&self) -> &Option<ErrorEvent> {
         &self.event
     }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
 }
 
 pub trait MapResult<S> {


### PR DESCRIPTION
To facilitate  review decided to move out the switch to a JWT refresh_token from the sso PR https://github.com/dani-garcia/vaultwarden/pull/3899.

Without the SSO logic it's not the most useful still :
 - Add an expiration on the `refresh_token` (work like an idle timer reset when a new access_token is generated).
 - Store the information of the `AuthMethod` in the token (`Password` ...).