### PR TITLE
Finer SMTP TLS certificate control

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -528,6 +528,9 @@
 ## Paths to PEM files, separated by semicolons
 # SMTP_ADDITIONAL_ROOT_CERTS=
 
+## Use system root certificate store for TLS host verification
+# SMTP_USE_SYSTEM_ROOT_CERTS=true
+
 ##########################
 ### Rocket settings ###
 ##########################

--- a/.env.template
+++ b/.env.template
@@ -524,6 +524,10 @@
 ## Only use this as a last resort if you are not able to use a valid certificate.
 # SMTP_ACCEPT_INVALID_HOSTNAMES=false
 
+## Accept additional root certs
+## Paths to PEM files, separated by semicolons
+# SMTP_ADDITIONAL_ROOT_CERTS=
+
 ##########################
 ### Rocket settings ###
 ##########################

--- a/src/config.rs
+++ b/src/config.rs
@@ -681,6 +681,8 @@ make_config! {
         smtp_accept_invalid_hostnames: bool,   true,   def,     false;
         /// Accept additional root certs |> Paths to PEM files, separated by semicolons
         smtp_additional_root_certs:    String, true,   option;
+        /// Use system root certificate store for TLS host verification
+        smtp_use_system_root_certs:    bool,   true,   def,     true;
     },
 
     /// Email 2FA Settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -679,6 +679,8 @@ make_config! {
         smtp_accept_invalid_certs:     bool,   true,   def,     false;
         /// Accept Invalid Hostnames (Know the risks!) |> DANGEROUS: Allow invalid hostnames. This option introduces significant vulnerabilities to man-in-the-middle attacks!
         smtp_accept_invalid_hostnames: bool,   true,   def,     false;
+        /// Accept additional root certs |> Paths to PEM files, separated by semicolons
+        smtp_additional_root_certs:    String, true,   option;
     },
 
     /// Email 2FA Settings

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -7,7 +7,7 @@ use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use lettre::{
     message::{Attachment, Body, Mailbox, Message, MultiPart, SinglePart},
     transport::smtp::authentication::{Credentials, Mechanism as SmtpAuthMechanism},
-    transport::smtp::client::{Certificate, Tls, TlsParameters},
+    transport::smtp::client::{Certificate, CertificateStore, Tls, TlsParameters},
     transport::smtp::extension::ClientId,
     Address, AsyncSendmailTransport, AsyncSmtpTransport, AsyncTransport, Tokio1Executor,
 };
@@ -66,6 +66,9 @@ fn smtp_transport() -> AsyncSmtpTransport<Tokio1Executor> {
             for cert in certs {
                 tls_parameters = tls_parameters.add_root_certificate(cert.clone());
             }
+        }
+        if !CONFIG.smtp_use_system_root_certs() {
+            tls_parameters = tls_parameters.certificate_store(CertificateStore::None);
         }
         let tls_parameters = tls_parameters.build().unwrap();
 

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -1,12 +1,13 @@
 use std::str::FromStr;
 
 use chrono::NaiveDateTime;
+use once_cell::sync::Lazy;
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 
 use lettre::{
     message::{Attachment, Body, Mailbox, Message, MultiPart, SinglePart},
     transport::smtp::authentication::{Credentials, Mechanism as SmtpAuthMechanism},
-    transport::smtp::client::{Tls, TlsParameters},
+    transport::smtp::client::{Certificate, Tls, TlsParameters},
     transport::smtp::extension::ClientId,
     Address, AsyncSendmailTransport, AsyncSmtpTransport, AsyncTransport, Tokio1Executor,
 };
@@ -29,6 +30,21 @@ fn sendmail_transport() -> AsyncSendmailTransport<Tokio1Executor> {
     }
 }
 
+static SMTP_ADDITIONAL_ROOT_CERTS: Lazy<Option<Vec<Certificate>>> = Lazy::new(|| {
+    Some(
+        CONFIG
+            .smtp_additional_root_certs()?
+            .split(';')
+            .filter(|path| !path.is_empty())
+            .map(|path| {
+                let cert = std::fs::read(path)
+                    .unwrap_or_else(|e| panic!("Error loading additional SMTP root certificate file {path}.\n{e}"));
+                Certificate::from_pem(&cert).unwrap_or_else(|e| panic!("Error decoding certificate file {path}.\n{e}"))
+            })
+            .collect(),
+    )
+});
+
 fn smtp_transport() -> AsyncSmtpTransport<Tokio1Executor> {
     use std::time::Duration;
     let host = CONFIG.smtp_host().unwrap();
@@ -45,6 +61,11 @@ fn smtp_transport() -> AsyncSmtpTransport<Tokio1Executor> {
         }
         if CONFIG.smtp_accept_invalid_certs() {
             tls_parameters = tls_parameters.dangerous_accept_invalid_certs(true);
+        }
+        if let Some(ref certs) = *SMTP_ADDITIONAL_ROOT_CERTS {
+            for cert in certs {
+                tls_parameters = tls_parameters.add_root_certificate(cert.clone());
+            }
         }
         let tls_parameters = tls_parameters.build().unwrap();
 


### PR DESCRIPTION
This PR adds two new SMTP configurations regarding TLS:
- `SMTP_ADDITIONAL_ROOT_CERTS` allows an admin to add new root certificates that Vaultwarden accepts for the SMTP server. This can be useful if the SMTP server only offers a self-signed certificate. Example: `SMTP_ADDITIONAL_ROOT_CERTS=/etc/ssl/certs/mail1.pem;/etc/ssl/certs/mail2.pem`
- `SMTP_USE_SYSTEM_ROOT_CERTS` disables the system's root certificate store for TLS. This can be used in combination with `SMTP_ADDITIONAL_ROOT_CERTS` for certificate pinning.