### PR TITLE
refactor: replace panic with a graceful exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,11 +66,11 @@ async fn main() -> Result<(), Error> {
 
     use log::LevelFilter as LF;
     let level = LF::from_str(&CONFIG.log_level()).unwrap_or_else(|_| {
-        let mut valid_log_levels = "".to_string();
+        let mut valid_log_levels = String::new();
         LF::iter().fold(true, |first, elem| {
             let mut joinstr = ", ".to_string();
             if first {
-                joinstr = "".to_string();
+                joinstr = String::new();
             }
             valid_log_levels = format!("{}{}{}", valid_log_levels, joinstr, elem.as_str().to_lowercase());
             false

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,15 +66,7 @@ async fn main() -> Result<(), Error> {
 
     use log::LevelFilter as LF;
     let level = LF::from_str(&CONFIG.log_level()).unwrap_or_else(|_| {
-        let mut valid_log_levels = String::new();
-        LF::iter().fold(true, |first, elem| {
-            let mut joinstr = ", ".to_string();
-            if first {
-                joinstr = String::new();
-            }
-            valid_log_levels = format!("{}{}{}", valid_log_levels, joinstr, elem.as_str().to_lowercase());
-            false
-        });
+        let valid_log_levels = LF::iter().map(|lvl| lvl.as_str().to_lowercase()).collect::<Vec<String>>().join(", ");
         println!("Log level must be one of the following: {valid_log_levels}");
         exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,19 @@ async fn main() -> Result<(), Error> {
     launch_info();
 
     use log::LevelFilter as LF;
-    let level = LF::from_str(&CONFIG.log_level()).expect("Valid log level");
+    let level = LF::from_str(&CONFIG.log_level()).unwrap_or_else(|_| {
+        let mut valid_log_levels = "".to_string();
+        LF::iter().fold(true, |first, elem| {
+            let mut joinstr = ", ".to_string();
+            if first {
+                joinstr = "".to_string();
+            }
+            valid_log_levels = format!("{}{}{}", valid_log_levels, joinstr, elem.as_str().to_lowercase());
+            false
+        });
+        println!("Log level must be oe of the following: {valid_log_levels}");
+        exit(1);
+    });
     init_logging(level).ok();
 
     let extra_debug = matches!(level, LF::Trace | LF::Debug);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Error> {
             valid_log_levels = format!("{}{}{}", valid_log_levels, joinstr, elem.as_str().to_lowercase());
             false
         });
-        println!("Log level must be oe of the following: {valid_log_levels}");
+        println!("Log level must be one of the following: {valid_log_levels}");
         exit(1);
     });
     init_logging(level).ok();


### PR DESCRIPTION
This change replaces the panic when a wrong log level is used with an error message and a graceful exit.

Please note that I did not hardcode the levels, because I rather dislike hardcoding options, if there's a way to retrieve the list dynamically. ~~It makes the code by 9 lines longer, but it is more futureproof.~~

Either way, if this is not wanted, I can still hardcode the list.

see https://github.com/dani-garcia/vaultwarden/discussions/4393#discussioncomment-8656343