### PR TITLE
Small improvements around email change

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -559,6 +559,8 @@ async fn post_email_token(data: JsonUpcase<EmailTokenData>, headers: Headers, mu
         if let Err(e) = mail::send_change_email(&data.NewEmail, &token).await {
             error!("Error sending change-email email: {:#?}", e);
         }
+    } else {
+        debug!("Email change request for user ({}) to email ({}) with token ({})", user.uuid, data.NewEmail, token);
     }
 
     user.email_new = Some(data.NewEmail);

--- a/src/static/templates/email/change_email.hbs
+++ b/src/static/templates/email/change_email.hbs
@@ -2,5 +2,5 @@ Your Email Change
 <!---------------->
 To finalize changing your email address enter the following code in web vault: {{token}}
 
-If you did not try to change an email address, you can safely ignore this email.
+If you did not try to change your email address, contact your administrator.
 {{> email/email_footer_text }}

--- a/src/static/templates/email/change_email.html.hbs
+++ b/src/static/templates/email/change_email.html.hbs
@@ -9,7 +9,7 @@ Your Email Change
    </tr>
    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
       <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
-         If you did not try to change an email address, you can safely ignore this email.
+         If you did not try to change your email address, contact your administrator.
       </td>
    </tr>
 </table>


### PR DESCRIPTION
Hey,

Was recently testing some code change around the change email code for the SSO PR and found those minor points:

 - Adding a log to be able to obtain the email change token without having to configure SMTP.
 - Change the language in the email change; if the user is not the one at the origin of the request then it means something fishy is going on since the master password should be required to trigger the email change.