### PR TITLE
Update Key Rotation web-vault v2024.3.x

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -205,7 +205,7 @@ pub struct CipherData {
     // Folder id is not included in import
     FolderId: Option<String>,
     // TODO: Some of these might appear all the time, no need for Option
-    OrganizationId: Option<String>,
+    pub OrganizationId: Option<String>,
 
     Key: Option<String>,
 

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -191,14 +191,17 @@ fn version() -> Json<&'static str> {
 #[get("/config")]
 fn config() -> Json<Value> {
     let domain = crate::CONFIG.domain();
-    let feature_states = parse_experimental_client_feature_flags(&crate::CONFIG.experimental_client_feature_flags());
+    let mut feature_states =
+        parse_experimental_client_feature_flags(&crate::CONFIG.experimental_client_feature_flags());
+    // Force the new key rotation feature
+    feature_states.insert("key-rotation-improvements".to_string(), true);
     Json(json!({
         // Note: The clients use this version to handle backwards compatibility concerns
         // This means they expect a version that closely matches the Bitwarden server version
         // We should make sure that we keep this updated when we support the new server features
         // Version history:
         // - Individual cipher key encryption: 2023.9.1
-        "version": "2023.9.1",
+        "version": "2024.2.0",
         "gitHash": option_env!("GIT_REV"),
         "server": {
           "name": "Vaultwarden",


### PR DESCRIPTION
Key rotation was changed since 2024.1.x.
Multiple other items were added to be rotated like password-reset and emergency-access data to be part of just one POST instead of having multiple.

See: https://github.com/dani-garcia/bw_web_builds/pull/157