### PR TITLE
update web-vault to v2024.3.1 (new vertical layout)

### DIFF
--- a/docker/DockerSettings.yaml
+++ b/docker/DockerSettings.yaml
@@ -1,6 +1,6 @@
 ---
-vault_version: "v2024.1.2b"
-vault_image_digest: "sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08"
+vault_version: "v2024.3.0"
+vault_image_digest: "sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25"
 # Cross Compile Docker Helper Scripts v1.3.0
 # We use the linux/amd64 platform shell scripts since there is no difference between the different platform scripts
 xx_image_digest: "sha256:c9609ace652bbe51dd4ce90e0af9d48a4590f1214246da5bc70e46f6dd586edc"

--- a/docker/DockerSettings.yaml
+++ b/docker/DockerSettings.yaml
@@ -1,6 +1,6 @@
 ---
-vault_version: "v2024.3.0"
-vault_image_digest: "sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25"
+vault_version: "v2024.3.1"
+vault_image_digest: "sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5"
 # Cross Compile Docker Helper Scripts v1.3.0
 # We use the linux/amd64 platform shell scripts since there is no difference between the different platform scripts
 xx_image_digest: "sha256:c9609ace652bbe51dd4ce90e0af9d48a4590f1214246da5bc70e46f6dd586edc"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -18,15 +18,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2024.1.2b
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.1.2b
-#     [docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.0
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.0
+#     [docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08
-#     [docker.io/vaultwarden/web-vault:v2024.1.2b]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25
+#     [docker.io/vaultwarden/web-vault:v2024.3.0]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25 as vault
 
 ########################## ALPINE BUILD IMAGES ##########################
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -18,15 +18,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.0
-#     [docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.1
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.1
+#     [docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25
-#     [docker.io/vaultwarden/web-vault:v2024.3.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5
+#     [docker.io/vaultwarden/web-vault:v2024.3.1]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5 as vault
 
 ########################## ALPINE BUILD IMAGES ##########################
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,15 +18,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2024.1.2b
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.1.2b
-#     [docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.0
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.0
+#     [docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08
-#     [docker.io/vaultwarden/web-vault:v2024.1.2b]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25
+#     [docker.io/vaultwarden/web-vault:v2024.3.0]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:798c0c893b6d16728878ff280b49da08863334d1f8dd88895580dc3dba622f08 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25 as vault
 
 ########################## Cross Compile Docker Helper Scripts ##########################
 ## We use the linux/amd64 no matter which Build Platform, since these are all bash scripts

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,15 +18,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.0
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.0
-#     [docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2024.3.1
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2024.3.1
+#     [docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25
-#     [docker.io/vaultwarden/web-vault:v2024.3.0]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5
+#     [docker.io/vaultwarden/web-vault:v2024.3.1]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:dd8bead2edc9cb7edaebd24e7b3455c0a634006022a8762412caec31916d9a25 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:689b1e706f29e1858a5c7e0ec82e40fac793322e5e0ac9102ab09c2620207cd5 as vault
 
 ########################## Cross Compile Docker Helper Scripts ##########################
 ## We use the linux/amd64 no matter which Build Platform, since these are all bash scripts


### PR DESCRIPTION
Update the web-vault to `v2024.3.0` that ships [Bitwarden's new vertical layout](https://bitwarden.com/blog/bitwarden-design-updating-the-navigation-in-the-web-app/):

![preview of the new vertical layout in light mode](https://github.com/dani-garcia/bw_web_builds/assets/509385/2e12eac3-f49a-4b25-9b0d-a3005560a375)

Cf. https://github.com/dani-garcia/bw_web_builds/pull/157 