### PR TITLE
Fix public api for domains with path prefix

### DIFF
--- a/src/api/core/public.rs
+++ b/src/api/core/public.rs
@@ -216,12 +216,8 @@ impl<'r> FromRequest<'r> for PublicToken {
         if time_now > claims.exp {
             err_handler!("Token expired");
         }
-        // Check if claims.iss is host|claims.scope[0]
-        let host = match auth::Host::from_request(request).await {
-            Outcome::Success(host) => host,
-            _ => err_handler!("Error getting Host"),
-        };
-        let complete_host = format!("{}|{}", host.host, claims.scope[0]);
+        // Check if claims.iss is domain|claims.scope[0]
+        let complete_host = format!("{}|{}", CONFIG.domain_origin(), claims.scope[0]);
         if complete_host != claims.iss {
             err_handler!("Token not issued by this server");
         }


### PR DESCRIPTION
Vaultwarden is currently unable to handle the Bitwarden Directory Connector when the base domain includes a path prefix.
Example:
  `DOMAIN=https://example.com/` -> works
  `DOMAIN=https://example.com/vault/` -> doesn't work
Vaultwarden rejects the token issued seconds before with the error message `"Token not issued by this server"`.
This message is thrown when the token issuer check fails. When a organization api token is issued, the iss attribute follows the scheme `"domain_origin|scope"`. But when the issuer is checked in api/core/public.rs, the iss attribute is expected to contain `"domain|scope"`.
When using a domain with path prefix this leads to conflicts. To fix this I replaced the domain check through a domain_origin check as issued in auth.rs.