### PR TITLE
Pass in collection ids to notifier when sharing cipher.

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -568,7 +568,7 @@ async fn post_rotatekey(data: JsonUpcase<KeyData>, headers: Headers, mut conn: D
             // Prevent triggering cipher updates via WebSockets by settings UpdateType::None
             // The user sessions are invalidated because all the ciphers were re-encrypted and thus triggering an update could cause issues.
             // We force the users to logout after the user has been saved to try and prevent these issues.
-            update_cipher_from_data(&mut saved_cipher, cipher_data, &headers, false, &mut conn, &nt, UpdateType::None)
+            update_cipher_from_data(&mut saved_cipher, cipher_data, &headers, None, &mut conn, &nt, UpdateType::None)
                 .await?
         }
     }

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1618,7 +1618,7 @@ async fn post_org_import(
     let mut ciphers = Vec::new();
     for cipher_data in data.Ciphers {
         let mut cipher = Cipher::new(cipher_data.Type, cipher_data.Name.clone());
-        update_cipher_from_data(&mut cipher, cipher_data, &headers, false, &mut conn, &nt, UpdateType::None).await.ok();
+        update_cipher_from_data(&mut cipher, cipher_data, &headers, None, &mut conn, &nt, UpdateType::None).await.ok();
         ciphers.push(cipher);
     }
 


### PR DESCRIPTION
(sorry about hitting publish too soon).

This PR fixes a bug where moving a cipher from a personal vault to an organization does not attach the collection ids of which the cipher is now a member. 

The front-end relies on these if the notification type is `NotificationType.SyncCipherUpdate` (https://github.com/bitwarden/clients/blob/91f1d9fb86142805d0774182c3ee6234e13946e3/libs/common/src/services/notifications.service.ts#L150) which in turn controls `isEdit` in `syncUpsertCipher` (https://github.com/bitwarden/clients/blob/91f1d9fb86142805d0774182c3ee6234e13946e3/libs/common/src/vault/services/sync/sync.service.ts#L177). If `isEdit` is `true` (we moved a cipher, we didn't create one) we need the `collectionIds` otherwise `shouldUpdate` remains `false` (https://github.com/bitwarden/clients/blob/91f1d9fb86142805d0774182c3ee6234e13946e3/libs/common/src/vault/services/sync/sync.service.ts#L213).

This causes a client on the receiving side to fail to properly update its view, requiring a manual refresh. 

Before:

https://github.com/dani-garcia/vaultwarden/assets/864376/d2e0d455-2bd6-476f-823c-b357f0bd2f15



After:


https://github.com/dani-garcia/vaultwarden/assets/864376/8e08a0bd-9ea6-4bda-b1e8-67ab7e68514a



I chose `Option<Vec<String>>` because that's what the notifier service takes, even though technically we could do `Vec<String>` but that makes it much uglier for other consumers. Passing in `None` is much nicer than `vec![]`. 

