### PR TITLE
Add extra (unsupported) container build arch's

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -65,13 +65,14 @@ RUN mkdir -pv "${CARGO_HOME}" \
 RUN USER=root cargo new --bin /app
 WORKDIR /app
 
-# Shared variables across Debian and Alpine
+# Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
     # To be able to build the armv6 image with mimalloc we need to tell the linker to also look for libatomic
     if [[ "${TARGETARCH}${TARGETVARIANT}" == "armv6" ]] ; then echo "export RUSTFLAGS='-Clink-arg=-latomic'" >> /env-cargo ; fi && \
     # Output the current contents of the file
     cat /env-cargo
 
+# Configure the DB ARG as late as possible to not invalidate the cached layers above
 # Enable MiMalloc to improve performance on Alpine builds
 ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -88,9 +88,17 @@ RUN mkdir -pv "${CARGO_HOME}" \
 RUN USER=root cargo new --bin /app
 WORKDIR /app
 
-# Environment variables for cargo across Debian and Alpine
+# Environment variables for Cargo on Debian based builds
+ARG ARCH_OPENSSL_LIB_DIR \
+    ARCH_OPENSSL_INCLUDE_DIR
+
 RUN source /env-cargo && \
     if xx-info is-cross ; then \
+        # Some special variables if needed to override some build paths
+        if [[ -n "${ARCH_OPENSSL_LIB_DIR}" && -n "${ARCH_OPENSSL_INCLUDE_DIR}" ]]; then \
+            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_LIB_DIR=${ARCH_OPENSSL_LIB_DIR}" >> /env-cargo && \
+            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_INCLUDE_DIR=${ARCH_OPENSSL_INCLUDE_DIR}" >> /env-cargo ; \
+        fi && \
         # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
         # Because of this we generate the needed environment variables here which we can load in the needed steps.
         echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -108,9 +108,17 @@ RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 {% if base == "debian" %}
-# Environment variables for cargo across Debian and Alpine
+# Environment variables for Cargo on Debian based builds
+ARG ARCH_OPENSSL_LIB_DIR \
+    ARCH_OPENSSL_INCLUDE_DIR
+
 RUN source /env-cargo && \
     if xx-info is-cross ; then \
+        # Some special variables if needed to override some build paths
+        if [[ -n "${ARCH_OPENSSL_LIB_DIR}" && -n "${ARCH_OPENSSL_INCLUDE_DIR}" ]]; then \
+            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_LIB_DIR=${ARCH_OPENSSL_LIB_DIR}" >> /env-cargo && \
+            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_INCLUDE_DIR=${ARCH_OPENSSL_INCLUDE_DIR}" >> /env-cargo ; \
+        fi && \
         # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
         # Because of this we generate the needed environment variables here which we can load in the needed steps.
         echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
@@ -126,13 +134,14 @@ RUN source /env-cargo && \
 # Configure the DB ARG as late as possible to not invalidate the cached layers above
 ARG DB=sqlite,mysql,postgresql
 {% elif base == "alpine" %}
-# Shared variables across Debian and Alpine
+# Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
     # To be able to build the armv6 image with mimalloc we need to tell the linker to also look for libatomic
     if [[ "${TARGETARCH}${TARGETVARIANT}" == "armv6" ]] ; then echo "export RUSTFLAGS='-Clink-arg=-latomic'" >> /env-cargo ; fi && \
     # Output the current contents of the file
     cat /env-cargo
 
+# Configure the DB ARG as late as possible to not invalidate the cached layers above
 # Enable MiMalloc to improve performance on Alpine builds
 ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 {% endif %}

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,6 +11,11 @@ With just these two files we can build both Debian and Alpine images for the fol
  - armv7 (linux/arm/v7)
  - armv6 (linux/arm/v6)
 
+Some unsupported platforms for Debian based images. These are not built and tested by default and are only provided to make it easier for users to build for these architectures.
+- 386     (linux/386)
+- ppc64le (linux/ppc64le)
+- s390x   (linux/s390x)
+
 To build these containers you need to enable QEMU binfmt support to be able to run/emulate architectures which are different then your host.<br>
 This ensures the container build process can run binaries from other architectures.<br>
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -125,6 +125,40 @@ target "debian-armv6" {
   tags = generate_tags("", "-armv6")
 }
 
+// ==== Start of unsupported Debian architecture targets ===
+// These are provided just to help users build for these rare platforms
+// They will not be built by default
+target "debian-386" {
+  inherits = ["debian"]
+  platforms = ["linux/386"]
+  tags = generate_tags("", "-386")
+  args = {
+    ARCH_OPENSSL_LIB_DIR = "/usr/lib/i386-linux-gnu"
+    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/i386-linux-gnu"
+  }
+}
+
+target "debian-ppc64le" {
+  inherits = ["debian"]
+  platforms = ["linux/ppc64le"]
+  tags = generate_tags("", "-ppc64le")
+  args = {
+    ARCH_OPENSSL_LIB_DIR = "/usr/lib/powerpc64le-linux-gnu"
+    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/powerpc64le-linux-gnu"
+  }
+}
+
+target "debian-s390x" {
+  inherits = ["debian"]
+  platforms = ["linux/s390x"]
+  tags = generate_tags("", "-s390x")
+  args = {
+    ARCH_OPENSSL_LIB_DIR = "/usr/lib/s390x-linux-gnu"
+    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/s390x-linux-gnu"
+  }
+}
+// ==== End of unsupported Debian architecture targets ===
+
 // A Group to build all platforms individually for local testing
 group "debian-all" {
   targets = ["debian-amd64", "debian-arm64", "debian-armv7", "debian-armv6"]


### PR DESCRIPTION
There was a PR (#4370) to add i686/i386 support for Vaultwarden. That specific PR was not a viable way of adding this.

This PR adds extra architectures for Debian based containers which we will not support by default. Those images will not be build and pushed to our container registries.

Added the following architectures:
 - linux/386
 - linux/ppc64le
 - linux/s390x

Again, there will be no major support for these architectures, but it will allow people who use these architectures to build a Debian based binary more easily

Closes #4370
