### PR TITLE
Optimize Dockerfiles

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -58,8 +58,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 
 # Create CARGO_HOME folder and don't download rust docs
-RUN mkdir -pv "${CARGO_HOME}" \
-    && rustup set profile minimal
+RUN mkdir -pv "${CARGO_HOME}" && \
+    rustup set profile minimal
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -72,20 +72,17 @@ RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
     # Output the current contents of the file
     cat /env-cargo
 
-# Configure the DB ARG as late as possible to not invalidate the cached layers above
-# Enable MiMalloc to improve performance on Alpine builds
-ARG DB=sqlite,mysql,postgresql,enable_mimalloc
-
 RUN source /env-cargo && \
     rustup target add "${CARGO_TARGET}"
 
-ARG CARGO_PROFILE=release
-ARG VW_VERSION
-
 # Copies over *only* your manifests and build files
-COPY ./Cargo.* ./
-COPY ./rust-toolchain.toml ./rust-toolchain.toml
-COPY ./build.rs ./build.rs
+COPY ./Cargo.* ./rust-toolchain.toml ./build.rs ./
+
+ARG CARGO_PROFILE=release
+
+# Configure the DB ARG as late as possible to not invalidate the cached layers above
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder
@@ -97,6 +94,8 @@ RUN source /env-cargo && \
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
+
+ARG VW_VERSION
 
 # Builds again, this time it will be the actual source files being build
 RUN source /env-cargo && \
@@ -151,8 +150,7 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 
-COPY docker/healthcheck.sh /healthcheck.sh
-COPY docker/start.sh /start.sh
+COPY docker/healthcheck.sh docker/start.sh /
 
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -64,10 +64,7 @@ RUN apt-get update && \
         "libc6-$(xx-info debian-arch)-cross" \
         "libc6-dev-$(xx-info debian-arch)-cross" \
         "linux-libc-dev-$(xx-info debian-arch)-cross" && \
-    # Run xx-cargo early, since it sometimes seems to break when run at a later stage
-    echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
-
-RUN xx-apt-get install -y \
+    xx-apt-get install -y \
         --no-install-recommends \
         gcc \
         libmariadb3 \
@@ -78,11 +75,13 @@ RUN xx-apt-get install -y \
     # Force install arch dependend mariadb dev packages
     # Installing them the normal way breaks several other packages (again)
     apt-get download "libmariadb-dev-compat:$(xx-info debian-arch)" "libmariadb-dev:$(xx-info debian-arch)" && \
-    dpkg --force-all -i ./libmariadb-dev*.deb
+    dpkg --force-all -i ./libmariadb-dev*.deb && \
+    # Run xx-cargo early, since it sometimes seems to break when run at a later stage
+    echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
 
 # Create CARGO_HOME folder and don't download rust docs
-RUN mkdir -pv "${CARGO_HOME}" \
-    && rustup set profile minimal
+RUN mkdir -pv "${CARGO_HOME}" && \
+    rustup set profile minimal
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -111,19 +110,16 @@ RUN source /env-cargo && \
     # Output the current contents of the file
     cat /env-cargo
 
-# Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
-
 RUN source /env-cargo && \
     rustup target add "${CARGO_TARGET}"
 
-ARG CARGO_PROFILE=release
-ARG VW_VERSION
-
 # Copies over *only* your manifests and build files
-COPY ./Cargo.* ./
-COPY ./rust-toolchain.toml ./rust-toolchain.toml
-COPY ./build.rs ./build.rs
+COPY ./Cargo.* ./rust-toolchain.toml ./build.rs ./
+
+ARG CARGO_PROFILE=release
+
+# Configure the DB ARG as late as possible to not invalidate the cached layers above
+ARG DB=sqlite,mysql,postgresql
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder
@@ -135,6 +131,8 @@ RUN source /env-cargo && \
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
+
+ARG VW_VERSION
 
 # Builds again, this time it will be the actual source files being build
 RUN source /env-cargo && \
@@ -193,8 +191,7 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 
-COPY docker/healthcheck.sh /healthcheck.sh
-COPY docker/start.sh /start.sh
+COPY docker/healthcheck.sh docker/start.sh /
 
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -82,10 +82,7 @@ RUN apt-get update && \
         "libc6-$(xx-info debian-arch)-cross" \
         "libc6-dev-$(xx-info debian-arch)-cross" \
         "linux-libc-dev-$(xx-info debian-arch)-cross" && \
-    # Run xx-cargo early, since it sometimes seems to break when run at a later stage
-    echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
-
-RUN xx-apt-get install -y \
+    xx-apt-get install -y \
         --no-install-recommends \
         gcc \
         libmariadb3 \
@@ -96,12 +93,14 @@ RUN xx-apt-get install -y \
     # Force install arch dependend mariadb dev packages
     # Installing them the normal way breaks several other packages (again)
     apt-get download "libmariadb-dev-compat:$(xx-info debian-arch)" "libmariadb-dev:$(xx-info debian-arch)" && \
-    dpkg --force-all -i ./libmariadb-dev*.deb
+    dpkg --force-all -i ./libmariadb-dev*.deb && \
+    # Run xx-cargo early, since it sometimes seems to break when run at a later stage
+    echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
 {% endif %}
 
 # Create CARGO_HOME folder and don't download rust docs
-RUN mkdir -pv "${CARGO_HOME}" \
-    && rustup set profile minimal
+RUN mkdir -pv "${CARGO_HOME}" && \
+    rustup set profile minimal
 
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
@@ -131,8 +130,6 @@ RUN source /env-cargo && \
     # Output the current contents of the file
     cat /env-cargo
 
-# Configure the DB ARG as late as possible to not invalidate the cached layers above
-ARG DB=sqlite,mysql,postgresql
 {% elif base == "alpine" %}
 # Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
@@ -141,21 +138,22 @@ RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
     # Output the current contents of the file
     cat /env-cargo
 
-# Configure the DB ARG as late as possible to not invalidate the cached layers above
-# Enable MiMalloc to improve performance on Alpine builds
-ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 {% endif %}
-
 RUN source /env-cargo && \
     rustup target add "${CARGO_TARGET}"
 
-ARG CARGO_PROFILE=release
-ARG VW_VERSION
-
 # Copies over *only* your manifests and build files
-COPY ./Cargo.* ./
-COPY ./rust-toolchain.toml ./rust-toolchain.toml
-COPY ./build.rs ./build.rs
+COPY ./Cargo.* ./rust-toolchain.toml ./build.rs ./
+
+ARG CARGO_PROFILE=release
+
+# Configure the DB ARG as late as possible to not invalidate the cached layers above
+{% if base == "debian" %}
+ARG DB=sqlite,mysql,postgresql
+{% elif base == "alpine" %}
+# Enable MiMalloc to improve performance on Alpine builds
+ARG DB=sqlite,mysql,postgresql,enable_mimalloc
+{% endif %}
 
 # Builds your dependencies and removes the
 # dummy project, except the target folder
@@ -167,6 +165,8 @@ RUN source /env-cargo && \
 # Copies the complete project
 # To avoid copying unneeded files, use .dockerignore
 COPY . .
+
+ARG VW_VERSION
 
 # Builds again, this time it will be the actual source files being build
 RUN source /env-cargo && \
@@ -237,8 +237,7 @@ EXPOSE 3012
 # and the binary from the "build" stage to the current stage
 WORKDIR /
 
-COPY docker/healthcheck.sh /healthcheck.sh
-COPY docker/start.sh /start.sh
+COPY docker/healthcheck.sh docker/start.sh /
 
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .


### PR DESCRIPTION
Move some ARGs closer to the build stage (potentially improving caching):
Example: I usually set VW_VERSION to be the latest commit hash, without this change I'd have to also rebuild the dependencies even if they didn't change since the previous layers would get invalidated.

Remove redundant COPY commands:
They can be combined, no point in using extra layers if it can be avoided.

Remove redundant RUN command:
apt-get and xx-apt-get commands can be moved into the same RUN command, thus saving another layer.

Move CARGO_HOME's "&&" operator to the first line (improves consistency)