### PR TITLE
Disable Login with device if push is not enabled

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -50,7 +50,6 @@ pub fn routes() -> Vec<rocket::Route> {
         api_key,
         rotate_api_key,
         get_known_device,
-        get_known_device_from_path,
         put_avatar,
         put_device_token,
         put_clear_device_token,
@@ -979,20 +978,17 @@ async fn rotate_api_key(data: JsonUpcase<PasswordOrOtpData>, headers: Headers, c
     _api_key(data, true, headers, conn).await
 }
 
-// This variant is deprecated: https://github.com/bitwarden/server/pull/2682
-#[get("/devices/knowndevice/<email>/<uuid>")]
-async fn get_known_device_from_path(email: &str, uuid: &str, mut conn: DbConn) -> JsonResult {
-    // This endpoint doesn't have auth header
+// ATM only used to toggle Login with device
+// Without push it's not working so always return false
+#[get("/devices/knowndevice")]
+async fn get_known_device(device: KnownDevice, mut conn: DbConn) -> JsonResult {
     let mut result = false;
-    if let Some(user) = User::find_by_mail(email, &mut conn).await {
-        result = Device::find_by_uuid_and_user(uuid, &user.uuid, &mut conn).await.is_some();
+    if CONFIG.push_enabled() {
+        if let Some(user) = User::find_by_mail(&device.email, &mut conn).await {
+            result = Device::find_by_uuid_and_user(&device.uuid, &user.uuid, &mut conn).await.is_some();
+        }
     }
     Ok(Json(json!(result)))
-}
-
-#[get("/devices/knowndevice")]
-async fn get_known_device(device: KnownDevice, conn: DbConn) -> JsonResult {
-    get_known_device_from_path(&device.email, &device.uuid, conn).await
 }
 
 struct KnownDevice {


### PR DESCRIPTION
I believe the `knowndevice` endpoint is only used to toggle the `Login with device` feature (Could not find any other reference in Bitwarden clients).

And unless I'm mistaken the `Login with device` only work if push is enabled.

Additionally, I removed the compatibility method since the migration to the endpoint was merged on March 7 2023 in the clients (github.com/bitwarden/clients/pull/4710).