### PR TITLE
differentiate external groups by organization id

### DIFF
--- a/src/api/core/public.rs
+++ b/src/api/core/public.rs
@@ -137,7 +137,8 @@ async fn ldap_import(data: JsonUpcase<OrgImportData>, token: PublicToken, mut co
 
     if CONFIG.org_groups_enabled() {
         for group_data in &data.Groups {
-            let group_uuid = match Group::find_by_external_id(&group_data.ExternalId, &mut conn).await {
+            let group_uuid = match Group::find_by_external_id_and_org(&group_data.ExternalId, &org_id, &mut conn).await
+            {
                 Some(group) => group.uuid,
                 None => {
                     let mut group =

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -203,10 +203,11 @@ impl Group {
         }}
     }
 
-    pub async fn find_by_external_id(id: &str, conn: &mut DbConn) -> Option<Self> {
+    pub async fn find_by_external_id_and_org(external_id: &str, org_uuid: &str, conn: &mut DbConn) -> Option<Self> {
         db_run! { conn: {
             groups::table
-                .filter(groups::external_id.eq(id))
+                .filter(groups::external_id.eq(external_id))
+                .filter(groups::organizations_uuid.eq(org_uuid))
                 .first::<GroupDb>(conn)
                 .ok()
                 .from_db()


### PR DESCRIPTION
should fix [Group support and directory connector within multiple organisations](https://vaultwarden.discourse.group/t/group-support-and-directory-connector-within-multiple-organisations/3659?u=stefan0xc)