### PR TITLE
add group support for Cipher::get_collections()

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -702,7 +702,7 @@ async fn put_collections_update(
     headers: Headers,
     conn: DbConn,
     nt: Notify<'_>,
-) -> EmptyResult {
+) -> JsonResult {
     post_collections_update(uuid, data, headers, conn, nt).await
 }
 
@@ -713,7 +713,7 @@ async fn post_collections_update(
     headers: Headers,
     mut conn: DbConn,
     nt: Notify<'_>,
-) -> EmptyResult {
+) -> JsonResult {
     let data: CollectionsAdminData = data.into_inner();
 
     let cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
@@ -761,7 +761,7 @@ async fn post_collections_update(
     log_event(
         EventType::CipherUpdatedCollections as i32,
         &cipher.uuid,
-        &cipher.organization_uuid.unwrap(),
+        &cipher.organization_uuid.clone().unwrap(),
         &headers.user.uuid,
         headers.device.atype,
         &headers.ip.ip,
@@ -769,7 +769,7 @@ async fn post_collections_update(
     )
     .await;
 
-    Ok(())
+    Ok(Json(cipher.to_json(&headers.host, &headers.user.uuid, None, CipherSyncType::User, &mut conn).await))
 }
 
 #[put("/ciphers/<uuid>/collections-admin", data = "<data>")]

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -79,6 +79,8 @@ pub fn routes() -> Vec<Route> {
         delete_all,
         move_cipher_selected,
         move_cipher_selected_put,
+        put_collections2_update,
+        post_collections2_update,
         put_collections_update,
         post_collections_update,
         post_collections_admin,
@@ -693,6 +695,33 @@ async fn put_cipher_partial(
 #[serde(rename_all = "camelCase")]
 struct CollectionsAdminData {
     collection_ids: Vec<String>,
+}
+
+#[put("/ciphers/<uuid>/collections_v2", data = "<data>")]
+async fn put_collections2_update(
+    uuid: &str,
+    data: Json<CollectionsAdminData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    post_collections2_update(uuid, data, headers, conn, nt).await
+}
+
+#[post("/ciphers/<uuid>/collections_v2", data = "<data>")]
+async fn post_collections2_update(
+    uuid: &str,
+    data: Json<CollectionsAdminData>,
+    headers: Headers,
+    conn: DbConn,
+    nt: Notify<'_>,
+) -> JsonResult {
+    let cipher_details = post_collections_update(uuid, data, headers, conn, nt).await?;
+    Ok(Json(json!({ // AttachmentUploadDataResponseModel
+        "object": "optionalCipherDetails",
+        "unavailable": false,
+        "cipher": *cipher_details
+    })))
 }
 
 #[put("/ciphers/<uuid>/collections", data = "<data>")]

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -747,9 +747,9 @@ async fn post_collections_admin(
         err!("Cipher is not write accessible")
     }
 
-    let posted_collections: HashSet<String> = data.collection_ids.iter().cloned().collect();
-    let current_collections: HashSet<String> =
-        cipher.get_collections(headers.user.uuid.clone(), &mut conn).await.iter().cloned().collect();
+    let posted_collections = HashSet::<String>::from_iter(data.collection_ids);
+    let current_collections =
+        HashSet::<String>::from_iter(cipher.get_collections(headers.user.uuid.clone(), &mut conn).await);
 
     for collection in posted_collections.symmetric_difference(&current_collections) {
         match Collection::find_by_uuid(collection, &mut conn).await {

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -206,7 +206,7 @@ impl Cipher {
                 Cow::from(Vec::with_capacity(0))
             }
         } else {
-            Cow::from(self.get_collections(user_uuid.to_string(), conn).await)
+            Cow::from(self.get_admin_collections(user_uuid.to_string(), conn).await)
         };
 
         // There are three types of cipher response models in upstream
@@ -776,6 +776,7 @@ impl Cipher {
         if CONFIG.org_groups_enabled() {
             db_run! {conn: {
                 ciphers_collections::table
+                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
                     .inner_join(collections::table.on(
                         collections::uuid.eq(ciphers_collections::collection_uuid)
                     ))
@@ -795,11 +796,12 @@ impl Cipher {
                         collections_groups::collections_uuid.eq(ciphers_collections::collection_uuid)
                         .and(collections_groups::groups_uuid.eq(groups::uuid))
                     ))
-                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
                     .filter(users_organizations::access_all.eq(true) // User has access all
-                        .or(users_collections::user_uuid.eq(user_id)) // User has access to collection
+                        .or(users_collections::user_uuid.eq(user_id) // User has access to collection
+                            .and(users_collections::read_only.eq(false)))
                         .or(groups::access_all.eq(true)) // Access via groups
-                        .or(collections_groups::collections_uuid.is_not_null()) // Access via groups
+                        .or(collections_groups::collections_uuid.is_not_null() // Access via groups
+                            .and(collections_groups::read_only.eq(false)))
                     )
                     .select(ciphers_collections::collection_uuid)
                     .load::<String>(conn).unwrap_or_default()
@@ -807,23 +809,85 @@ impl Cipher {
         } else {
             db_run! {conn: {
                 ciphers_collections::table
-                .inner_join(collections::table.on(
-                    collections::uuid.eq(ciphers_collections::collection_uuid)
-                ))
-                .inner_join(users_organizations::table.on(
-                    users_organizations::org_uuid.eq(collections::org_uuid)
-                    .and(users_organizations::user_uuid.eq(user_id.clone()))
-                ))
-                .left_join(users_collections::table.on(
-                    users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
-                    .and(users_collections::user_uuid.eq(user_id.clone()))
-                ))
-                .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
-                .filter(users_organizations::access_all.eq(true) // User has access all
-                    .or(users_collections::user_uuid.eq(user_id)) // User has access to collection
-                )
-                .select(ciphers_collections::collection_uuid)
-                .load::<String>(conn).unwrap_or_default()
+                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
+                    .inner_join(collections::table.on(
+                        collections::uuid.eq(ciphers_collections::collection_uuid)
+                    ))
+                    .inner_join(users_organizations::table.on(
+                        users_organizations::org_uuid.eq(collections::org_uuid)
+                        .and(users_organizations::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(users_collections::table.on(
+                        users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(users_collections::user_uuid.eq(user_id.clone()))
+                    ))
+                    .filter(users_organizations::access_all.eq(true) // User has access all
+                        .or(users_collections::user_uuid.eq(user_id) // User has access to collection
+                            .and(users_collections::read_only.eq(false)))
+                    )
+                    .select(ciphers_collections::collection_uuid)
+                    .load::<String>(conn).unwrap_or_default()
+            }}
+        }
+    }
+
+    pub async fn get_admin_collections(&self, user_id: String, conn: &mut DbConn) -> Vec<String> {
+        if CONFIG.org_groups_enabled() {
+            db_run! {conn: {
+                ciphers_collections::table
+                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
+                    .inner_join(collections::table.on(
+                        collections::uuid.eq(ciphers_collections::collection_uuid)
+                    ))
+                    .left_join(users_organizations::table.on(
+                        users_organizations::org_uuid.eq(collections::org_uuid)
+                        .and(users_organizations::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(users_collections::table.on(
+                        users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(users_collections::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(groups_users::table.on(
+                        groups_users::users_organizations_uuid.eq(users_organizations::uuid)
+                    ))
+                    .left_join(groups::table.on(groups::uuid.eq(groups_users::groups_uuid)))
+                    .left_join(collections_groups::table.on(
+                        collections_groups::collections_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(collections_groups::groups_uuid.eq(groups::uuid))
+                    ))
+                    .filter(users_organizations::access_all.eq(true) // User has access all
+                        .or(users_collections::user_uuid.eq(user_id) // User has access to collection
+                            .and(users_collections::read_only.eq(false)))
+                        .or(groups::access_all.eq(true)) // Access via groups
+                        .or(collections_groups::collections_uuid.is_not_null() // Access via groups
+                            .and(collections_groups::read_only.eq(false)))
+                        .or(users_organizations::atype.le(UserOrgType::Admin as i32)) // User is admin or owner
+                    )
+                    .select(ciphers_collections::collection_uuid)
+                    .load::<String>(conn).unwrap_or_default()
+            }}
+        } else {
+            db_run! {conn: {
+                ciphers_collections::table
+                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
+                    .inner_join(collections::table.on(
+                        collections::uuid.eq(ciphers_collections::collection_uuid)
+                    ))
+                    .inner_join(users_organizations::table.on(
+                        users_organizations::org_uuid.eq(collections::org_uuid)
+                        .and(users_organizations::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(users_collections::table.on(
+                        users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(users_collections::user_uuid.eq(user_id.clone()))
+                    ))
+                    .filter(users_organizations::access_all.eq(true) // User has access all
+                        .or(users_collections::user_uuid.eq(user_id) // User has access to collection
+                            .and(users_collections::read_only.eq(false)))
+                        .or(users_organizations::atype.le(UserOrgType::Admin as i32)) // User is admin or owner
+                    )
+                    .select(ciphers_collections::collection_uuid)
+                    .load::<String>(conn).unwrap_or_default()
             }}
         }
     }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -773,30 +773,59 @@ impl Cipher {
     }
 
     pub async fn get_collections(&self, user_id: String, conn: &mut DbConn) -> Vec<String> {
-        db_run! {conn: {
-            ciphers_collections::table
-            .inner_join(collections::table.on(
-                collections::uuid.eq(ciphers_collections::collection_uuid)
-            ))
-            .inner_join(users_organizations::table.on(
-                users_organizations::org_uuid.eq(collections::org_uuid).and(
-                    users_organizations::user_uuid.eq(user_id.clone())
+        if CONFIG.org_groups_enabled() {
+            db_run! {conn: {
+                ciphers_collections::table
+                    .inner_join(collections::table.on(
+                        collections::uuid.eq(ciphers_collections::collection_uuid)
+                    ))
+                    .left_join(users_organizations::table.on(
+                        users_organizations::org_uuid.eq(collections::org_uuid)
+                        .and(users_organizations::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(users_collections::table.on(
+                        users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(users_collections::user_uuid.eq(user_id.clone()))
+                    ))
+                    .left_join(groups_users::table.on(
+                        groups_users::users_organizations_uuid.eq(users_organizations::uuid)
+                    ))
+                    .left_join(groups::table.on(groups::uuid.eq(groups_users::groups_uuid)))
+                    .left_join(collections_groups::table.on(
+                        collections_groups::collections_uuid.eq(ciphers_collections::collection_uuid)
+                        .and(collections_groups::groups_uuid.eq(groups::uuid))
+                    ))
+                    .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
+                    .filter(users_organizations::access_all.eq(true) // User has access all
+                        .or(users_collections::user_uuid.eq(user_id)) // User has access to collection
+                        .or(groups::access_all.eq(true)) // Access via groups
+                        .or(collections_groups::collections_uuid.is_not_null()) // Access via groups
+                    )
+                    .select(ciphers_collections::collection_uuid)
+                    .load::<String>(conn).unwrap_or_default()
+            }}
+        } else {
+            db_run! {conn: {
+                ciphers_collections::table
+                .inner_join(collections::table.on(
+                    collections::uuid.eq(ciphers_collections::collection_uuid)
+                ))
+                .inner_join(users_organizations::table.on(
+                    users_organizations::org_uuid.eq(collections::org_uuid)
+                    .and(users_organizations::user_uuid.eq(user_id.clone()))
+                ))
+                .left_join(users_collections::table.on(
+                    users_collections::collection_uuid.eq(ciphers_collections::collection_uuid)
+                    .and(users_collections::user_uuid.eq(user_id.clone()))
+                ))
+                .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
+                .filter(users_organizations::access_all.eq(true) // User has access all
+                    .or(users_collections::user_uuid.eq(user_id)) // User has access to collection
                 )
-            ))
-            .left_join(users_collections::table.on(
-                users_collections::collection_uuid.eq(ciphers_collections::collection_uuid).and(
-                    users_collections::user_uuid.eq(user_id.clone())
-                )
-            ))
-            .filter(ciphers_collections::cipher_uuid.eq(&self.uuid))
-            .filter(users_collections::user_uuid.eq(user_id).or( // User has access to collection
-                users_organizations::access_all.eq(true).or( // User has access all
-                    users_organizations::atype.le(UserOrgType::Admin as i32) // User is admin or owner
-                )
-            ))
-            .select(ciphers_collections::collection_uuid)
-            .load::<String>(conn).unwrap_or_default()
-        }}
+                .select(ciphers_collections::collection_uuid)
+                .load::<String>(conn).unwrap_or_default()
+            }}
+        }
     }
 
     /// Return a Vec with (cipher_uuid, collection_uuid)


### PR DESCRIPTION
join group infos assigned to a collection to check whether user has been given access to all collections via any group or they have access to a specific collection via any group membership

fixes #4588