### PR TITLE
Remove mimalloc workaround

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -67,8 +67,6 @@ WORKDIR /app
 
 # Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
-    # To be able to build the armv6 image with mimalloc we need to tell the linker to also look for libatomic
-    if [[ "${TARGETARCH}${TARGETVARIANT}" == "armv6" ]] ; then echo "export RUSTFLAGS='-Clink-arg=-latomic'" >> /env-cargo ; fi && \
     # Output the current contents of the file
     cat /env-cargo
 

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -133,8 +133,6 @@ RUN source /env-cargo && \
 {% elif base == "alpine" %}
 # Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
-    # To be able to build the armv6 image with mimalloc we need to tell the linker to also look for libatomic
-    if [[ "${TARGETARCH}${TARGETVARIANT}" == "armv6" ]] ; then echo "export RUSTFLAGS='-Clink-arg=-latomic'" >> /env-cargo ; fi && \
     # Output the current contents of the file
     cat /env-cargo
 


### PR DESCRIPTION
- libatomic linking for armv6 has been fixed in mimalloc v0.1.42

For reference: https://github.com/purpleprotocol/mimalloc_rust/commit/446fc231151cfab485b0ac7d5178baf797799dda