### PR TITLE
Add support for MFA with Duo's Universal Prompt

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -422,15 +422,21 @@
 # YUBICO_SERVER=http://yourdomain.com/wsapi/2.0/verify
 
 ## Duo Settings
-## You need to configure all options to enable global Duo support, otherwise users would need to configure it themselves
+## You need to configure the DUO_IKEY, DUO_SKEY, and DUO_HOST options to enable global Duo support.
+## Otherwise users will need to configure it themselves.
 ## Create an account and protect an application as mentioned in this link (only the first step, not the rest):
 ## https://help.bitwarden.com/article/setup-two-step-login-duo/#create-a-duo-security-account
 ## Then set the following options, based on the values obtained from the last step:
-# DUO_IKEY=<Integration Key>
-# DUO_SKEY=<Secret Key>
+# DUO_IKEY=<Client ID>
+# DUO_SKEY=<Client Secret>
 # DUO_HOST=<API Hostname>
 ## After that, you should be able to follow the rest of the guide linked above,
 ## ignoring the fields that ask for the values that you already configured beforehand.
+##
+## If you want to attempt to use Duo's 'Traditional Prompt' (deprecated, iframe based) set DUO_USE_IFRAME to 'true'.
+## Duo no longer supports this, but it still works for some integrations.
+## If you aren't sure, leave this alone.
+# DUO_USE_IFRAME=false
 
 ## Email 2FA settings
 ## Email token size

--- a/.env.template
+++ b/.env.template
@@ -152,6 +152,10 @@
 ## Cron schedule of the job that cleans old auth requests from the auth request.
 ## Defaults to every minute. Set blank to disable this job.
 # AUTH_REQUEST_PURGE_SCHEDULE="30 * * * * *"
+##
+## Cron schedule of the job that cleans expired Duo contexts from the database. Does nothing if Duo MFA is disabled or set to use the legacy iframe prompt.
+## Defaults to every minute. Set blank to disable this job.
+# DUO_CONTEXT_PURGE_SCHEDULE="30 * * * * *"
 
 ########################
 ### General settings ###

--- a/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/down.sql
+++ b/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE twofactor_duo_ctx;

--- a/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,11 +1,8 @@
 CREATE TABLE twofactor_duo_ctx (
-    -- For mysql, the character set on state is overridden to ascii because the utf8mb4 database charset recommended in
-    -- the Vaultwarden docs causes 1 character to consume 4 bytes, exceeding innodb's 3072 max key size if we want to
-    -- accommodate the largest supported state size. This isn't a problem for nonce since it's not a key for the table.
-    state      VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
-    user_email VARCHAR(255)  NOT NULL,
-    nonce      VARCHAR(1024) NOT NULL,
-    exp        BIGINT        NOT NULL,
+    state      VARCHAR(64)  NOT NULL,
+    user_email VARCHAR(255) NOT NULL,
+    nonce      VARCHAR(64)  NOT NULL,
+    exp        BIGINT       NOT NULL,
 
     PRIMARY KEY (state)
 );

--- a/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE twofactor_duo_ctx (
+    state      VARCHAR(1024) NOT NULL,
+    user_email VARCHAR(255)  NOT NULL,
+    nonce      VARCHAR(1024) NOT NULL,
+    exp        BIGINT        NOT NULL,
+
+    PRIMARY KEY (state)
+);

--- a/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/mysql/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,5 +1,8 @@
 CREATE TABLE twofactor_duo_ctx (
-    state      VARCHAR(1024) NOT NULL,
+    -- For mysql, the character set on state is overridden to ascii because the utf8mb4 database charset recommended in
+    -- the Vaultwarden docs causes 1 character to consume 4 bytes, exceeding innodb's 3072 max key size if we want to
+    -- accommodate the largest supported state size. This isn't a problem for nonce since it's not a key for the table.
+    state      VARCHAR(1024) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     user_email VARCHAR(255)  NOT NULL,
     nonce      VARCHAR(1024) NOT NULL,
     exp        BIGINT        NOT NULL,

--- a/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/down.sql
+++ b/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE twofactor_duo_ctx;

--- a/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE twofactor_duo_ctx (
+    state      VARCHAR(1024) NOT NULL,
+    user_email VARCHAR(255)  NOT NULL,
+    nonce      VARCHAR(1024) NOT NULL,
+    exp        BIGINT        NOT NULL,
+
+    PRIMARY KEY (state)
+);

--- a/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/postgresql/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE twofactor_duo_ctx (
-    state      VARCHAR(1024) NOT NULL,
+    state      VARCHAR(64) NOT NULL,
     user_email VARCHAR(255)  NOT NULL,
-    nonce      VARCHAR(1024) NOT NULL,
+    nonce      VARCHAR(64) NOT NULL,
     exp        BIGINT        NOT NULL,
 
     PRIMARY KEY (state)

--- a/migrations/sqlite/2024-06-05-131359_add_2fa_duo_store/down.sql
+++ b/migrations/sqlite/2024-06-05-131359_add_2fa_duo_store/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE twofactor_duo_ctx;

--- a/migrations/sqlite/2024-06-05-131359_add_2fa_duo_store/up.sql
+++ b/migrations/sqlite/2024-06-05-131359_add_2fa_duo_store/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE twofactor_duo_ctx (
+    state      TEXT    NOT NULL,
+    user_email TEXT    NOT NULL,
+    nonce      TEXT    NOT NULL,
+    exp        INTEGER NOT NULL,
+
+    PRIMARY KEY (state)
+);

--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -252,7 +252,7 @@ async fn get_user_duo_data(uuid: &str, conn: &mut DbConn) -> DuoStatus {
 }
 
 // let (ik, sk, ak, host) = get_duo_keys();
-async fn get_duo_keys_email(email: &str, conn: &mut DbConn) -> ApiResult<(String, String, String, String)> {
+pub(crate) async fn get_duo_keys_email(email: &str, conn: &mut DbConn) -> ApiResult<(String, String, String, String)> {
     let data = match User::find_by_mail(email, conn).await {
         Some(u) => get_user_duo_data(&u.uuid, conn).await.data(),
         _ => DuoData::global(),

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -51,7 +51,7 @@ macro_rules! TOKEN_ENDPOINT {
     };
 }
 
-// Default JWT validity time
+// Number of seconds that a JWT we generate for Duo should be valid for
 const JWT_VALIDITY_SECS: i64 = 300;
 
 // Stored Duo context validity duration
@@ -125,7 +125,6 @@ struct DuoClient {
     client_secret: String, // Duo Client Secret (DuoData.sk)
     api_host: String,      // Duo API hostname (DuoData.host)
     redirect_uri: String,  // URL in this application clients should call for MFA verification
-    jwt_exp_seconds: i64,  // Number of seconds that JWTs we create should be valid for
 }
 
 impl DuoClient {
@@ -137,8 +136,7 @@ impl DuoClient {
             client_secret,
             api_host,
             redirect_uri,
-            jwt_exp_seconds: JWT_VALIDITY_SECS,
-        };
+        }
     }
 
     // Generate a client assertion for health checks and authorization code exchange.
@@ -150,7 +148,7 @@ impl DuoClient {
             iss: self.client_id.clone(),
             sub: self.client_id.clone(),
             aud: url.clone(),
-            exp: now + self.jwt_exp_seconds,
+            exp: now + JWT_VALIDITY_SECS,
             jti: jwt_id,
             iat: now,
         }
@@ -227,7 +225,7 @@ impl DuoClient {
         let jwt_payload = AuthorizationRequest {
             response_type: String::from("code"),
             scope: String::from("openid"),
-            exp: now + self.jwt_exp_seconds,
+            exp: now + JWT_VALIDITY_SECS,
             client_id: self.client_id.clone(),
             redirect_uri: self.redirect_uri.clone(),
             state,

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -1,0 +1,473 @@
+use chrono::{TimeDelta, Utc};
+use jsonwebtoken::{decode_header, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+use reqwest::{header, StatusCode};
+use serde::Serialize;
+use std::collections::HashMap;
+use url::Url;
+use crate::{
+    api::{core::two_factor::duo::get_duo_keys_email, EmptyResult},
+    auth::ClientType,
+    crypto,
+    db::{models::EventType, DbConn},
+    error::Error,
+    util::get_reqwest_client,
+    CONFIG,
+};
+
+// Pool of characters for state and nonce generation
+// 0-9 -> 0x30-0x39
+// A-Z -> 0x41-0x5A
+// a-z -> 0x61-0x7A
+const STATE_CHAR_POOL: [u8; 62] = [
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
+    0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x61, 0x62,
+    0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75,
+    0x76, 0x77, 0x78, 0x79, 0x7A,
+];
+
+const MIN_STATE_SIZE: usize = 16;
+const MAX_STATE_SIZE: usize = 1024;
+const STATE_LENGTH: usize = 36; // Default size of state for generate_state_default()
+
+// Client URL constants. Defined as macros, so they can be passed into format!()
+#[allow(non_snake_case)]
+macro_rules! HEALTH_ENDPOINT {
+    () => {
+        "https://{}/oauth/v1/health_check"
+    };
+}
+#[allow(non_snake_case)]
+macro_rules! AUTHZ_ENDPOINT {
+    () => {
+        "https://{}/oauth/v1/authorize"
+    };
+}
+#[allow(non_snake_case)]
+macro_rules! API_HOST_FMT {
+    () => {
+        "https://{}"
+    };
+}
+#[allow(non_snake_case)]
+macro_rules! TOKEN_ENDPOINT {
+    () => {
+        "https://{}/oauth/v1/token"
+    };
+}
+
+// Default JWT validity time
+const JWT_VALIDITY_SECS: i64 = 300;
+
+// Generate a new Duo WebSDKv4 state string with a given size.
+// This can also be used to generate the optional OpenID Connect nonce.
+// Size must be between 16 and 1024 (inclusive).
+pub fn generate_state_len(size: usize) -> String {
+    if (size < MIN_STATE_SIZE) || (MAX_STATE_SIZE < size) {
+        panic!("Illegal Duo state size: {size}. Size must be 15 < size < 1025")
+    }
+
+    return crypto::get_random_string(&STATE_CHAR_POOL, size);
+}
+
+pub fn generate_state_default() -> String {
+    return generate_state_len(STATE_LENGTH);
+}
+
+// Structs for serializing calls to Duo
+#[derive(Debug, Serialize, Deserialize)]
+struct ClientAssertionJwt {
+    pub iss: String,
+    pub sub: String,
+    pub aud: String,
+    pub exp: i64,
+    pub jti: String,
+    pub iat: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AuthUrlJwt {
+    pub response_type: String,
+    pub scope: String,
+    pub exp: i64,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub state: String,
+    pub duo_uname: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iss: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aud: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_duo_code_attribute: Option<bool>,
+}
+
+/*
+Structs for deserializing responses from Duo's API
+*/
+#[derive(Debug, Serialize, Deserialize)]
+struct HealthOKTS {
+    timestamp: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum HealthCheckResponse {
+    HealthOK {
+        stat: String,
+        response: HealthOKTS,
+    },
+    HealthFail {
+        stat: String,
+        code: i32,
+        timestamp: i64,
+        message: String,
+        message_detail: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IdTokenResponse {
+    id_token: String,
+    access_token: String,
+    expires_in: i64,
+    token_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IdTokenClaims {
+    aud: String,
+    iss: String,
+    preferred_username: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+}
+
+// Duo WebSDK 4 Client
+struct DuoClient {
+    client_id: String,     // Duo Client ID (DuoData.ik)
+    client_secret: String, // Duo Client Secret (DuoData.sk)
+    api_host: String,      // Duo API hostname (DuoData.host)
+    redirect_uri: String,  // URL in this application clients should call for MFA verification
+    jwt_exp_seconds: i64,  // Number of seconds that JWTs we create should be valid for
+}
+// TODO: Cert pinning for calls to Duo?
+
+// See https://duo.com/docs/oauthapi
+impl DuoClient {
+    fn new(client_id: String, client_secret: String, api_host: String, redirect_uri: String) -> DuoClient {
+        return DuoClient {
+            client_id,
+            client_secret,
+            api_host,
+            redirect_uri,
+            jwt_exp_seconds: JWT_VALIDITY_SECS,
+        };
+    }
+
+    // Given a serde-serializable struct, attempt to encode it as a JWT
+    fn encode_duo_jwt<T: Serialize>(&self, jwt_payload: T) -> Result<String, Error> {
+        match jsonwebtoken::encode(
+            &Header::new(Algorithm::HS512),
+            &jwt_payload,
+            &EncodingKey::from_secret(&self.client_secret.as_bytes()),
+        ) {
+            Ok(token) => Ok(token),
+            Err(e) => err!(format!("{}", e)),
+        }
+    }
+
+    // "required" health check to verify the integration is configured and Duo's services
+    // are up.
+    // https://duo.com/docs/oauthapi#health-check
+    async fn health_check(&self) -> Result<(), Error> {
+        let health_check_url: String = format!(HEALTH_ENDPOINT!(), self.api_host);
+
+        let now = Utc::now();
+        let jwt_id = generate_state_default();
+        let jwt_payload = ClientAssertionJwt {
+            iss: self.client_id.clone(),
+            sub: self.client_id.clone(),
+            aud: health_check_url.clone(),
+            exp: (now + TimeDelta::try_seconds(self.jwt_exp_seconds).unwrap()).timestamp(),
+            jti: jwt_id,
+            iat: now.timestamp(),
+        };
+
+        let token = match self.encode_duo_jwt(jwt_payload) {
+            Ok(token) => token,
+            Err(e) => err!(format!("{}", e)),
+        };
+
+        let mut post_body = HashMap::new();
+        post_body.insert("client_assertion", token);
+        post_body.insert("client_id", self.client_id.clone());
+
+        let res = match get_reqwest_client()
+            .post(health_check_url)
+            .header(header::USER_AGENT, "vaultwarden:Duo/2.0 (Rust)")
+            .form(&post_body)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => err!(format!("Error requesting Duo health check: {}", e)),
+        };
+
+        let response: HealthCheckResponse = match res.json::<HealthCheckResponse>().await {
+            Ok(r) => r,
+            Err(e) => err!(format!("Duo health check response decode error: {}", e)),
+        };
+
+        let health_stat: String = match response {
+            HealthCheckResponse::HealthOK {
+                stat,
+                response: _,
+            } => stat,
+            HealthCheckResponse::HealthFail {
+                stat: _,
+                code: _,
+                timestamp: _,
+                message,
+                message_detail,
+            } => err!(format!("Duo health check FAIL response msg: {}, detail: {}", message, message_detail)),
+        };
+
+        if health_stat != "OK" {
+            err!("Duo health check returned OK-like body but did not contain an OK stat.");
+        }
+
+        Ok(())
+    }
+
+    // Constructs the URL for the authorization request endpoint on Duo's service.
+    // Clients are sent here to continue authentication.
+    // https://duo.com/docs/oauthapi#authorization-request
+    fn make_authz_req_url(&self, duo_username: &str, state: String, nonce: Option<String>) -> Result<String, Error> {
+        let now = Utc::now();
+
+        let jwt_payload = AuthUrlJwt {
+            response_type: String::from("code"),
+            scope: String::from("openid"),
+            exp: (now + TimeDelta::try_seconds(self.jwt_exp_seconds).unwrap()).timestamp(),
+            client_id: self.client_id.clone(),
+            redirect_uri: self.redirect_uri.clone(),
+            state,
+            duo_uname: String::from(duo_username),
+            iss: Some(self.client_id.clone()),
+            aud: Some(format!(API_HOST_FMT!(), self.api_host)),
+            nonce,
+            use_duo_code_attribute: Some(false),
+        };
+
+        let token = match self.encode_duo_jwt(jwt_payload) {
+            Ok(token) => token,
+            Err(e) => err!(format!("{}", e)),
+        };
+
+        let authz_endpoint = format!(AUTHZ_ENDPOINT!(), self.api_host);
+        let mut auth_url = match Url::parse(authz_endpoint.as_str()) {
+            Ok(url) => url,
+            Err(e) => err!(format!("{}", e)),
+        };
+
+        {
+            let mut query_params = auth_url.query_pairs_mut();
+            query_params.append_pair("response_type", "code");
+            query_params.append_pair("client_id", self.client_id.as_str());
+            query_params.append_pair("request", token.as_str());
+        }
+
+        let final_auth_url = auth_url.to_string();
+        return Ok(final_auth_url);
+    }
+
+    async fn exchange_authz_code_for_result(
+        &self,
+        duo_code: &str,
+        duo_username: &str,
+        nonce: Option<&str>,
+    ) -> Result<(), Error> {
+        if duo_code == "" {
+            err!("Invalid Duo Code")
+        }
+
+        let now = Utc::now();
+
+        let token_url = format!(TOKEN_ENDPOINT!(), self.api_host);
+        let jwt_id = generate_state_default();
+
+        let jwt_payload = ClientAssertionJwt {
+            iss: self.client_id.clone(),
+            sub: self.client_id.clone(),
+            aud: token_url.clone(),
+            exp: (now + TimeDelta::try_seconds(self.jwt_exp_seconds).unwrap()).timestamp(),
+            jti: jwt_id,
+            iat: now.timestamp(),
+        };
+
+        let token = match self.encode_duo_jwt(jwt_payload) {
+            Ok(token) => token,
+            Err(e) => err!(format!("{}", e)),
+        };
+
+        let mut post_body = HashMap::new();
+        post_body.insert("grant_type", String::from("authorization_code"));
+        post_body.insert("code", String::from(duo_code));
+        post_body.insert("redirect_uri", self.redirect_uri.clone());
+        post_body
+            .insert("client_assertion_type", String::from("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"));
+        post_body.insert("client_assertion", token);
+
+        let res = match get_reqwest_client()
+            .post(token_url.clone())
+            .header(header::USER_AGENT, "vaultwarden:Duo/2.0 (Rust)")
+            .form(&post_body)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => err!(format!("Error exchanging Duo code: {}", e)),
+        };
+
+        let status_code = res.status();
+        if status_code != StatusCode::OK {
+            err!(format!("Failure response from Duo: {}", status_code))
+        }
+
+        let response: IdTokenResponse = match res.json::<IdTokenResponse>().await {
+            Ok(r) => r,
+            Err(e) => err!(format!("Error decoding ID token response: {}", e)),
+        };
+
+        let header = decode_header(&response.id_token).unwrap();
+
+        let mut validation = Validation::new(header.alg);
+        validation.set_required_spec_claims(&["exp", "aud", "iss"]);
+        validation.set_audience(&[&self.client_id]);
+        validation.set_issuer(&[token_url.as_str()]);
+
+        let token_data = match jsonwebtoken::decode::<IdTokenClaims>(
+            &response.id_token,
+            &DecodingKey::from_secret(self.client_secret.as_bytes()),
+            &validation,
+        ) {
+            Ok(c) => c,
+            Err(e) => err!(format!("Failed to decode Duo token {}", e)),
+        };
+
+        if !crypto::ct_eq(&duo_username, &token_data.claims.preferred_username) {
+            err!(format!(
+                "Error validating Duo user, expected {}, got {}",
+                duo_username, token_data.claims.preferred_username
+            ))
+        };
+
+        match nonce {
+            Some(nonce) => {
+                _ = nonce; // FIXME: Add Nonce support
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
+}
+
+// Construct the url that Duo should redirect users to.
+// The actual location is a bridge built in to the clients.
+// See: /clients/apps/web/src/connectors/duo-redirect.ts
+fn make_callback_url(client_name: &str) -> Result<String, Error> {
+    const DUO_REDIRECT_LOCATION: &str = "duo-redirect-connector.html";
+
+    // Get the location of this application as defined in the config.
+    let base = match Url::parse(CONFIG.domain().as_str()) {
+        Ok(url) => url,
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    // Add the client redirect bridge location
+    let mut callback = match base.join(DUO_REDIRECT_LOCATION) {
+        Ok(url) => url,
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    // Add the 'client' string. This is sent by clients in the 'Bitwarden-Client-Name'
+    // HTTP header of the request to /identity/connect/token
+    {
+        let mut query_params = callback.query_pairs_mut();
+        query_params.append_pair("client", client_name);
+    }
+    return Ok(callback.to_string());
+}
+
+// Initiates the first stage of the Duo WebSDKv4 authentication flow.
+// Returns the "AuthUrl" that should be passed to clients for MFA.
+pub async fn get_duo_auth_url(email: &str, client_type: &ClientType, conn: &mut DbConn) -> Result<String, Error> {
+    let (ik, sk, _, host) = get_duo_keys_email(email, conn).await?;
+
+    let callback_url = match make_callback_url(client_type.as_str()) {
+        Ok(url) => url,
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    let client = DuoClient::new(ik, sk, host, callback_url);
+
+    match client.health_check().await {
+        Ok(()) => {}
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    // Generate a random Duo state and OIDC Nonce
+    let state = generate_state_default();
+
+    return client.make_authz_req_url(email, state, None);
+}
+
+pub async fn validate_duo_login(
+    email: &str,
+    two_factor_token: &str,
+    client_type: &ClientType,
+    conn: &mut DbConn,
+) -> EmptyResult {
+    let email = &email.to_lowercase();
+
+    let split: Vec<&str> = two_factor_token.split('|').collect();
+    if split.len() != 2 {
+        err!(
+            "Invalid response length",
+            ErrorEvent {
+                event: EventType::UserFailedLogIn2fa
+            }
+        );
+    }
+
+    let code = split[0];
+    //let state = split[1];
+
+    let (ik, sk, _, host) = get_duo_keys_email(email, conn).await?;
+
+    let callback_url = match make_callback_url(client_type.as_str()) {
+        Ok(url) => url,
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    let client = DuoClient::new(ik, sk, host, callback_url);
+
+    match client.health_check().await {
+        Ok(()) => {}
+        Err(e) => err!(format!("{}", e)),
+    };
+
+    match client.exchange_authz_code_for_result(code, email, None).await {
+        Ok(_r) => Ok(()),
+        Err(_e) => {
+            err!(
+                "Error validating duo authentication",
+                ErrorEvent {
+                    event: EventType::UserFailedLogIn2fa
+                }
+            )
+        }
+    }
+}

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -25,21 +25,6 @@ use crate::{
 // State length must be at least 16 characters and at most 1024 characters.
 const STATE_LENGTH: usize = 64;
 
-// Pool of characters for state and nonce generation
-// 0-9 -> 0x30-0x39
-// A-Z -> 0x41-0x5A
-// a-z -> 0x61-0x7A
-const STATE_CHAR_POOL: [u8; 62] = [
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
-    0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x61, 0x62,
-    0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75,
-    0x76, 0x77, 0x78, 0x79, 0x7A,
-];
-// Generate a state/nonce string.
-pub fn generate_state() -> String {
-    return crypto::get_random_string(&STATE_CHAR_POOL, STATE_LENGTH);
-}
-
 // Client URL constants. Defined as macros, so they can be passed into format!()
 #[allow(non_snake_case)]
 macro_rules! HEALTH_ENDPOINT {
@@ -159,7 +144,7 @@ impl DuoClient {
     // Generate a client assertion for health checks and authorization code exchange.
     fn new_client_assertion(&self, url: &String) -> ClientAssertion {
         let now = Utc::now().timestamp();
-        let jwt_id = generate_state();
+        let jwt_id = crypto::get_random_string_alphanum(STATE_LENGTH);
 
         ClientAssertion {
             iss: self.client_id.clone(),
@@ -444,8 +429,8 @@ pub async fn get_duo_auth_url(email: &str,
     };
 
     // Generate random OAuth2 state and OIDC Nonce
-    let state: String = generate_state();
-    let nonce: String = generate_state();
+    let state: String = crypto::get_random_string_alphanum(STATE_LENGTH);
+    let nonce: String = crypto::get_random_string_alphanum(STATE_LENGTH);
 
     // Bind the nonce to the device that's currently authing by hashing the nonce and device id
     // and sending that as the OIDC nonce.

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeDelta, Utc};
+use chrono::Utc;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use reqwest::{header, StatusCode};
 use serde::Serialize;
@@ -235,12 +235,12 @@ impl DuoClient {
     // Clients are sent here to continue authentication.
     // https://duo.com/docs/oauthapi#authorization-request
     fn make_authz_req_url(&self, duo_username: &str, state: String, nonce: String) -> Result<String, Error> {
-        let now = Utc::now();
+        let now = Utc::now().timestamp();
 
         let jwt_payload = AuthorizationRequest {
             response_type: String::from("code"),
             scope: String::from("openid"),
-            exp: (now + TimeDelta::try_seconds(self.jwt_exp_seconds).unwrap()).timestamp(),
+            exp: now,
             client_id: self.client_id.clone(),
             redirect_uri: self.redirect_uri.clone(),
             state,

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 // State length must be at least 16 characters and at most 1024 characters.
-const STATE_LENGTH: usize = 36;
+const STATE_LENGTH: usize = 64;
 
 // Pool of characters for state and nonce generation
 // 0-9 -> 0x30-0x39

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -63,6 +63,8 @@ const DUO_RESP_SIGNATURE_ALG: Algorithm = Algorithm::HS512;
 const JWT_SIGNATURE_ALG: Algorithm = Algorithm::HS512;
 
 // Size of random strings for state and nonce. Must be at least 16 characters and at most 1024 characters.
+// If increasing this above 64, also increase the size of the twofactor_duo_ctx.state and
+// twofactor_duo_ctx.nonce database columns for postgres and mariadb.
 const STATE_LENGTH: usize = 64;
 
 // client_assertion payload for health checks and obtaining MFA results.

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -14,7 +14,7 @@ use crate::{
         DbConn, DbPool,
     },
     error::Error,
-    util::get_reqwest_client,
+    http_client::make_http_request,
     CONFIG,
 };
 use url::Url;
@@ -186,8 +186,7 @@ impl DuoClient {
         post_body.insert("client_assertion", token);
         post_body.insert("client_id", self.client_id.clone());
 
-        let res = match get_reqwest_client()
-            .post(health_check_url)
+        let res = match make_http_request(reqwest::Method::POST, &health_check_url)?
             .header(header::USER_AGENT, "vaultwarden:Duo/2.0 (Rust)")
             .form(&post_body)
             .send()
@@ -293,8 +292,7 @@ impl DuoClient {
             .insert("client_assertion_type", String::from("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"));
         post_body.insert("client_assertion", token);
 
-        let res = match get_reqwest_client()
-            .post(&token_url)
+        let res = match make_http_request(reqwest::Method::POST, &token_url)?
             .header(header::USER_AGENT, "vaultwarden:Duo/2.0 (Rust)")
             .form(&post_body)
             .send()

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -131,7 +131,8 @@ struct IdTokenClaims {
     nonce: String,
 }
 
-// Duo WebSDK 4 Client
+// Duo OIDC Authorization Client
+// See https://duo.com/docs/oauthapi
 struct DuoClient {
     client_id: String,     // Duo Client ID (DuoData.ik)
     client_secret: String, // Duo Client Secret (DuoData.sk)
@@ -140,7 +141,6 @@ struct DuoClient {
     jwt_exp_seconds: i64,  // Number of seconds that JWTs we create should be valid for
 }
 
-// See https://duo.com/docs/oauthapi
 impl DuoClient {
 
     // Construct a new DuoClient
@@ -240,7 +240,7 @@ impl DuoClient {
         let jwt_payload = AuthorizationRequest {
             response_type: String::from("code"),
             scope: String::from("openid"),
-            exp: now,
+            exp: now + self.jwt_exp_seconds,
             client_id: self.client_id.clone(),
             redirect_uri: self.redirect_uri.clone(),
             state,
@@ -303,7 +303,7 @@ impl DuoClient {
         post_body.insert("client_assertion", token);
 
         let res = match get_reqwest_client()
-            .post(token_url.clone())
+            .post(&token_url)
             .header(header::USER_AGENT, "vaultwarden:Duo/2.0 (Rust)")
             .form(&post_body)
             .send()

--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -19,32 +19,6 @@ use crate::{
 };
 use url::Url;
 
-// Duo OIDC Auth API URL constants. Defined as macros, so they can be passed into format!()
-#[allow(non_snake_case)]
-macro_rules! HEALTH_ENDPOINT {
-    () => {
-        "https://{}/oauth/v1/health_check"
-    };
-}
-#[allow(non_snake_case)]
-macro_rules! AUTHZ_ENDPOINT {
-    () => {
-        "https://{}/oauth/v1/authorize"
-    };
-}
-#[allow(non_snake_case)]
-macro_rules! API_HOST_FMT {
-    () => {
-        "https://{}"
-    };
-}
-#[allow(non_snake_case)]
-macro_rules! TOKEN_ENDPOINT {
-    () => {
-        "https://{}/oauth/v1/token"
-    };
-}
-
 // The location on this service that Duo should redirect users to. For us, this is a bridge
 // built in to the Bitwarden clients.
 // See: https://github.com/bitwarden/clients/blob/main/apps/web/src/connectors/duo-redirect.ts
@@ -173,7 +147,7 @@ impl DuoClient {
     // are up.
     // https://duo.com/docs/oauthapi#health-check
     async fn health_check(&self) -> Result<(), Error> {
-        let health_check_url: String = format!(HEALTH_ENDPOINT!(), self.api_host);
+        let health_check_url: String = format!("https://{}/oauth/v1/health_check", self.api_host);
 
         let jwt_payload = self.new_client_assertion(&health_check_url);
 
@@ -233,7 +207,7 @@ impl DuoClient {
             state,
             duo_uname: String::from(duo_username),
             iss: self.client_id.clone(),
-            aud: format!(API_HOST_FMT!(), self.api_host),
+            aud: format!("https://{}", self.api_host),
             nonce,
         };
 
@@ -242,7 +216,7 @@ impl DuoClient {
             Err(e) => return Err(e),
         };
 
-        let authz_endpoint = format!(AUTHZ_ENDPOINT!(), self.api_host);
+        let authz_endpoint = format!("https://{}/oauth/v1/authorize", self.api_host);
         let mut auth_url = match Url::parse(authz_endpoint.as_str()) {
             Ok(url) => url,
             Err(e) => err!(format!("Error parsing Duo authorization URL: {e:?}")),
@@ -272,7 +246,7 @@ impl DuoClient {
             err!("Empty Duo authorization code")
         }
 
-        let token_url = format!(TOKEN_ENDPOINT!(), self.api_host);
+        let token_url = format!("https://{}/oauth/v1/token", self.api_host);
 
         let jwt_payload = self.new_client_assertion(&token_url);
 

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -19,11 +19,11 @@ use crate::{
 
 pub mod authenticator;
 pub mod duo;
+pub mod duo_oidc;
 pub mod email;
 pub mod protected_actions;
 pub mod webauthn;
 pub mod yubikey;
-pub mod duo_oidc;
 
 pub fn routes() -> Vec<Route> {
     let mut routes = routes![

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -23,6 +23,7 @@ pub mod email;
 pub mod protected_actions;
 pub mod webauthn;
 pub mod yubikey;
+pub mod duo_oidc;
 
 pub fn routes() -> Vec<Route> {
     let mut routes = routes![

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -503,7 +503,7 @@ async fn twofactor_auth(
     let twofactor_code = match data.two_factor_token {
         Some(ref code) => code,
         None => {
-            err_json!(_json_err_twofactor(&twofactor_ids, &user.uuid, &data, conn).await?, "2FA token not provided")
+            err_json!(_json_err_twofactor(&twofactor_ids, &user.uuid, data, conn).await?, "2FA token not provided")
         }
     };
 
@@ -550,7 +550,7 @@ async fn twofactor_auth(
                 }
                 _ => {
                     err_json!(
-                        _json_err_twofactor(&twofactor_ids, &user.uuid, &data, conn).await?,
+                        _json_err_twofactor(&twofactor_ids, &user.uuid, data, conn).await?,
                         "2FA Remember token not provided"
                     )
                 }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -631,7 +631,7 @@ async fn _json_err_twofactor(
                         .await?;
 
                         result["TwoFactorProviders2"][provider.to_string()] = json!({
-                        "AuthUrl": auth_url,
+                            "AuthUrl": auth_url,
                         })
                     }
                 }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -520,7 +520,7 @@ async fn twofactor_auth(
         }
         Some(TwoFactorType::Webauthn) => webauthn::validate_webauthn_login(&user.uuid, twofactor_code, conn).await?,
         Some(TwoFactorType::YubiKey) => yubikey::validate_yubikey_login(twofactor_code, &selected_data?).await?,
-        Some(TwoFactorType::Duo | TwoFactorType::OrganizationDuo) => {
+        Some(TwoFactorType::Duo) => {
             match CONFIG.duo_use_iframe() {
                 true => {
                     // Legacy iframe prompt flow
@@ -605,7 +605,7 @@ async fn _json_err_twofactor(
                 result["TwoFactorProviders2"][provider.to_string()] = request.0;
             }
 
-            Some(TwoFactorType::Duo | TwoFactorType::OrganizationDuo) => {
+            Some(TwoFactorType::Duo) => {
                 let email = match User::find_by_uuid(user_uuid, conn).await {
                     Some(u) => u.email,
                     None => err!("User does not exist"),

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -416,47 +416,9 @@ impl<'r> FromRequest<'r> for Host {
     }
 }
 
-pub enum ClientType {
-    Unspecified = 0,
-    Web = 1,
-    Browser = 2,
-    Desktop = 3,
-    Mobile = 4,
-    Cli = 5,
-    DirectoryConnector = 6,
-}
-
-impl ClientType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ClientType::Unspecified => "",
-            ClientType::Web => "web",
-            ClientType::Browser => "browser",
-            ClientType::Desktop => "desktop",
-            ClientType::Mobile => "mobile",
-            ClientType::Cli => "cli",
-            ClientType::DirectoryConnector => "connector",
-        }
-    }
-
-    pub fn from_str(client_name: &str) -> ClientType {
-        match client_name {
-            "web" => ClientType::Web,
-            "browser" => ClientType::Browser,
-            "desktop" => ClientType::Desktop,
-            "mobile" => ClientType::Mobile,
-            "cli" => ClientType::Cli,
-            "connector" => ClientType::DirectoryConnector,
-            _ => ClientType::Unspecified,
-        }
-    }
-}
-
-
 pub struct ClientHeaders {
     pub device_type: i32,
     pub ip: ClientIp,
-    pub client_type: ClientType,
 }
 
 #[rocket::async_trait]
@@ -472,13 +434,9 @@ impl<'r> FromRequest<'r> for ClientHeaders {
         let device_type: i32 =
             request.headers().get_one("device-type").map(|d| d.parse().unwrap_or(14)).unwrap_or_else(|| 14);
 
-        let client_name = request.headers().get_one("Bitwarden-Client-Name").unwrap_or_else(|| "");
-        let client_type: ClientType = ClientType::from_str(client_name);
-
         Outcome::Success(ClientHeaders {
             device_type,
             ip,
-            client_type,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -415,7 +415,9 @@ make_config! {
         /// Auth Request cleanup schedule |> Cron schedule of the job that cleans old auth requests from the auth request.
         /// Defaults to every minute. Set blank to disable this job.
         auth_request_purge_schedule:   String, false,  def,    "30 * * * * *".to_string();
-
+        /// Duo Auth context cleanup schedule |> Cron schedule of the job that cleans expired Duo contexts from the database. Does nothing if Duo MFA is disabled or set to use the legacy iframe prompt.
+        /// Defaults to once every minute. Set blank to disable this job.
+        duo_context_purge_schedule:   String, false,  def,    "30 * * * * *".to_string();
     },
 
     /// General settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -634,6 +634,8 @@ make_config! {
     duo: _enable_duo {
         /// Enabled
         _enable_duo:            bool,   true,   def,     true;
+        /// Attempt to use deprecated iframe-based Traditional Prompt (Duo WebSDK 2)
+        duo_use_iframe:         bool,   false,  def,     false;
         /// Integration Key
         duo_ikey:               String, true,   option;
         /// Secret Key

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -12,8 +12,8 @@ mod org_policy;
 mod organization;
 mod send;
 mod two_factor;
-mod two_factor_incomplete;
 mod two_factor_duo_context;
+mod two_factor_incomplete;
 mod user;
 
 pub use self::attachment::Attachment;

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -13,6 +13,7 @@ mod organization;
 mod send;
 mod two_factor;
 mod two_factor_incomplete;
+mod two_factor_duo_context;
 mod user;
 
 pub use self::attachment::Attachment;
@@ -29,5 +30,6 @@ pub use self::org_policy::{OrgPolicy, OrgPolicyErr, OrgPolicyType};
 pub use self::organization::{Organization, OrganizationApiKey, UserOrgStatus, UserOrgType, UserOrganization};
 pub use self::send::{Send, SendType};
 pub use self::two_factor::{TwoFactor, TwoFactorType};
+pub use self::two_factor_duo_context::TwoFactorDuoContext;
 pub use self::two_factor_incomplete::TwoFactorIncomplete;
 pub use self::user::{Invitation, User, UserKdfType, UserStampException};

--- a/src/db/models/two_factor_duo_context.rs
+++ b/src/db/models/two_factor_duo_context.rs
@@ -1,0 +1,92 @@
+use chrono::Utc;
+
+use crate::{api::EmptyResult, db::DbConn, error::MapResult};
+
+db_object! {
+    #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
+    #[diesel(table_name = twofactor_duo_ctx)]
+    #[diesel(primary_key(state))]
+    pub struct TwoFactorDuoContext {
+        pub state: String,
+        pub user_email: String,
+        pub nonce: String,
+        pub exp: i64,
+    }
+}
+
+impl TwoFactorDuoContext {
+    pub async fn find_by_state(state: &str, conn: &mut DbConn) -> Option<Self> {
+        db_run! {
+            conn: {
+                twofactor_duo_ctx::table
+                    .filter(twofactor_duo_ctx::state.eq(state))
+                    .first::<TwoFactorDuoContextDb>(conn)
+                    .ok()
+                    .from_db()
+            }
+        }
+    }
+
+    pub async fn save(
+        state: &str,
+        user_email: &str,
+        nonce: &str,
+        ttl: i64,
+        conn: &mut DbConn,
+    ) -> EmptyResult {
+        // A saved context should never be changed, only created or deleted.
+        let exists = Self::find_by_state(state, conn).await;
+        if exists.is_some() {
+            return Ok(())
+        };
+
+        let exp = Utc::now().timestamp() + ttl;
+
+        db_run! {
+            conn: {
+                diesel::insert_into(twofactor_duo_ctx::table)
+                    .values((
+                        twofactor_duo_ctx::state.eq(state),
+                        twofactor_duo_ctx::user_email.eq(user_email),
+                        twofactor_duo_ctx::nonce.eq(nonce),
+                        twofactor_duo_ctx::exp.eq(exp)
+                ))
+                .execute(conn)
+                .map_res("Error saving context to twofactor_duo_ctx")
+            }
+        }
+    }
+
+    pub async fn find_expired(conn: &mut DbConn) -> Vec<Self> {
+        let now = Utc::now().timestamp();
+        db_run! {
+            conn: {
+                twofactor_duo_ctx::table
+                    .filter(twofactor_duo_ctx::exp.lt(now))
+                    .load::<TwoFactorDuoContextDb>(conn)
+                    .expect("Error finding expired contexts in twofactor_duo_ctx")
+                    .from_db()
+            }
+        }
+    }
+
+    pub async fn delete(&self, conn: &mut DbConn) -> EmptyResult {
+        db_run! {
+            conn: {
+                diesel::delete(
+                    twofactor_duo_ctx::table
+                    .filter(twofactor_duo_ctx::state.eq(&self.state)))
+                    .execute(conn)
+                    .map_res("Error deleting from twofactor_duo_ctx")
+            }
+        }
+    }
+
+    pub async fn purge_expired_duo_contexts(conn: &mut DbConn) {
+        for context in Self::find_expired(conn).await {
+            if context.exp < Utc::now().timestamp() {
+                context.delete(conn).await.ok();
+            }
+        }
+    }
+}

--- a/src/db/models/two_factor_duo_context.rs
+++ b/src/db/models/two_factor_duo_context.rs
@@ -78,9 +78,7 @@ impl TwoFactorDuoContext {
 
     pub async fn purge_expired_duo_contexts(conn: &mut DbConn) {
         for context in Self::find_expired(conn).await {
-            if context.exp < Utc::now().timestamp() {
-                context.delete(conn).await.ok();
-            }
+            context.delete(conn).await.ok();
         }
     }
 }

--- a/src/db/models/two_factor_duo_context.rs
+++ b/src/db/models/two_factor_duo_context.rs
@@ -27,17 +27,11 @@ impl TwoFactorDuoContext {
         }
     }
 
-    pub async fn save(
-        state: &str,
-        user_email: &str,
-        nonce: &str,
-        ttl: i64,
-        conn: &mut DbConn,
-    ) -> EmptyResult {
+    pub async fn save(state: &str, user_email: &str, nonce: &str, ttl: i64, conn: &mut DbConn) -> EmptyResult {
         // A saved context should never be changed, only created or deleted.
         let exists = Self::find_by_state(state, conn).await;
         if exists.is_some() {
-            return Ok(())
+            return Ok(());
         };
 
         let exp = Utc::now().timestamp() + ttl;

--- a/src/db/schemas/mysql/schema.rs
+++ b/src/db/schemas/mysql/schema.rs
@@ -175,6 +175,15 @@ table! {
 }
 
 table! {
+    twofactor_duo_ctx (state) {
+        state -> Text,
+        user_email -> Text,
+        nonce -> Text,
+        exp -> BigInt,
+    }
+}
+
+table! {
     users (uuid) {
         uuid -> Text,
         enabled -> Bool,

--- a/src/db/schemas/postgresql/schema.rs
+++ b/src/db/schemas/postgresql/schema.rs
@@ -175,6 +175,15 @@ table! {
 }
 
 table! {
+    twofactor_duo_ctx (state) {
+        state -> Text,
+        user_email -> Text,
+        nonce -> Text,
+        exp -> BigInt,
+    }
+}
+
+table! {
     users (uuid) {
         uuid -> Text,
         enabled -> Bool,

--- a/src/db/schemas/sqlite/schema.rs
+++ b/src/db/schemas/sqlite/schema.rs
@@ -175,6 +175,15 @@ table! {
 }
 
 table! {
+    twofactor_duo_ctx (state) {
+        state -> Text,
+        user_email -> Text,
+        nonce -> Text,
+        exp -> BigInt,
+    }
+}
+
+table! {
     users (uuid) {
         uuid -> Text,
         enabled -> Bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ mod mail;
 mod ratelimit;
 mod util;
 
+use crate::api::core::two_factor::duo_oidc::purge_duo_contexts;
 use crate::api::purge_auth_requests;
 use crate::api::{WS_ANONYMOUS_SUBSCRIPTIONS, WS_USERS};
 pub use config::CONFIG;
@@ -59,7 +60,6 @@ pub use error::{Error, MapResult};
 use rocket::data::{Limits, ToByteUnit};
 use std::sync::Arc;
 pub use util::is_running_in_container;
-use crate::api::core::two_factor::duo_oidc::purge_duo_contexts;
 
 #[rocket::main]
 async fn main() -> Result<(), Error> {
@@ -586,9 +586,7 @@ fn schedule_jobs(pool: db::DbPool) {
             }
 
             // Clean unused, expired Duo authentication contexts.
-            if !CONFIG.duo_context_purge_schedule().is_empty()
-                && CONFIG._enable_duo()
-                && !CONFIG.duo_use_iframe() {
+            if !CONFIG.duo_context_purge_schedule().is_empty() && CONFIG._enable_duo() && !CONFIG.duo_use_iframe() {
                 sched.add(Job::new(CONFIG.duo_context_purge_schedule().parse().unwrap(), || {
                     runtime.spawn(purge_duo_contexts(pool.clone()));
                 }));


### PR DESCRIPTION
### Overview

This adds support for MFA using Duo's "Universal Prompt".

On March 30th, 2024, the Duo MFA integration that Vaultwarden uses, the 'Traditional Prompt' was end-of-lifed. While Duo's API continues to allow the traditional prompt to be used in some cases, it is entirely unsupported, and it will eventually stop working. Some Vaultwarden users have already begun reporting that their Duo API keys are no longer functional in Vaultwarden. Bitwarden introduced Universal Prompt support in release 2024.2.3 on March 5th.

Duo's Universal Prompt uses the OIDC Authorization Code flow. This flow requires us to pack information about the authentication we want to be prompted for MFA into an authorization request (a JWT signed with a secret key provided by Duo) and send the user to their service, where MFA is performed. The user is then returned to our service with a code that we use to call Duo's API and obtain the result of the MFA. Once we validate the information passed back by the user's client and returned by Duo's service, we can log the user in.

Detailed documentation is located at [https://duo.com/docs/oauthapi](https://duo.com/docs/oauthapi)

The web vault handles receiving the redirection from Duo. It has a 'connector' page responsible for communicating the authorization code back to the user's true client so it can be provided in a call to Vaultwarden's API.

### Major additions/changes

- Added a crate, duo_oidc, which implements the Duo Universal Prompt MFA flow.
- Added a database table, twofactor_duo_ctx, migrations, and a model to represent it. This table stores information about in-progress Duo MFA attempts for validation while an authenticating user completes MFA on Duo's service.
- Added an internal task to clear the twofactor_duo_ctx table of incomplete Duo MFA attempts.
- Added a configuration option to globally force Vaultwarden to use the legacy Duo traditional prompt flow instead of the universal prompt. 

### Specific Review Items

Beyond what you'd normally check, I'd like to highlight a few decisions I made that you should probably consider in your review.

- The OIDC 'nonce' parameter is optional and intended to harden against replay attacks. The best practice is to bind the nonce to a specific authentication attempt using something like an HttpOnly cookie. Cookies don't seem to be an option without significant changes to Vaultwarden, let alone the Bitwarden clients. Instead of not leveraging it, I tried to win back some of the hardening the parameter is intended to provide. I ended up with a strategy where a random nonce is generated, combined with the `device_identifier` reported by the client, and hashed to produce the OIDC nonce sent to Duo in the authorization request. Then, the `device_identifier` reported by the user's client when providing the authorization code is hashed with the saved nonce, and the resulting hash is compared to the OIDC nonce Duo reports when we call their API for the MFA result.
- Duo's official client libraries for the Universal Prompt pin hard-coded CA certs from Digicert, SecureTrust, and Amazon. Duo's implementation documentation didn't make any recommendations around pinning certs, and it looks like some of them are root CA certs (the pinning of which is controversial), so I did not implement this. 
- Instead of copying or reimplementing the original duo crate's `get_duo_keys_email` function, which fetches the Duo keys from the database/config for a given user, I set its visibility to `pub(crate)` and re-used it. 

### Testing

Tested on the following clients; everything is working well:
- Vaultwarden-patched web vault
- Windows, macOS, and Linux (Flatpak) desktop clients
- Android app (as obtained from Google play) 
- iOS app (as obtained from the Apple app store)
- Chrome and Firefox browser extensions

The only major client issue I found was with the unpackaged AppImage Linux desktop client. When authenticating users on desktop clients, the connector in the web vault opens a `bitwarden://` link, which my system refused to use the AppImage to open. It looks like the AppImage client either doesn't or can't register itself as the `x-scheme-handler` for `bitwarden`, preventing the redirect connector from handing off to the client. It worked fine with the Flatpak packaged Bitwarden client, so I'm chalking it up to my not configuring the AppImage client correctly. 

There is also a known issue upstream in the web vault where the redirect connector shows 'successful authentication', does not automatically close, and the JS 'close' button does not work. See [https://github.com/bitwarden/clients/issues/8554](https://github.com/bitwarden/clients/issues/8554)

I also tested this while running PostgreSQL and MariaDB using the versions packaged in Debian 12; no issues.