### PR TITLE
Update rust and remove unused header values

### DIFF
--- a/docker/DockerSettings.yaml
+++ b/docker/DockerSettings.yaml
@@ -4,7 +4,7 @@ vault_image_digest: "sha256:784838b15c775c81b29e8979aaac36dc5ef44ea18ff0adb7fc56
 # Cross Compile Docker Helper Scripts v1.4.0
 # We use the linux/amd64 platform shell scripts since there is no difference between the different platform scripts
 xx_image_digest: "sha256:0cd3f05c72d6c9b038eb135f91376ee1169ef3a330d34e418e65e2a5c2e9c0d4"
-rust_version: 1.78.0 # Rust version to be used
+rust_version: 1.79.0 # Rust version to be used
 debian_version: bookworm # Debian release name to be used
 alpine_version: "3.20" # Alpine version to be used
 # For which platforms/architectures will we try to build images

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -31,10 +31,10 @@ FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:784838b15c775
 ########################## ALPINE BUILD IMAGES ##########################
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64
 ## And for Alpine we define all build images here, they will only be loaded when actually used
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.78.0 as build_amd64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.78.0 as build_arm64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.78.0 as build_armv7
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.78.0 as build_armv6
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.79.0 as build_amd64
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.79.0 as build_arm64
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.79.0 as build_armv7
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.79.0 as build_armv6
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -35,7 +35,7 @@ FROM --platform=linux/amd64 docker.io/tonistiigi/xx@sha256:0cd3f05c72d6c9b038eb1
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:1.78.0-slim-bookworm as build
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:1.79.0-slim-bookworm as build
 COPY --from=xx / /
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -405,7 +405,6 @@ impl<'r> FromRequest<'r> for Host {
 }
 
 pub struct ClientHeaders {
-    pub host: String,
     pub device_type: i32,
     pub ip: ClientIp,
 }
@@ -425,7 +424,6 @@ impl<'r> FromRequest<'r> for ClientHeaders {
             request.headers().get_one("device-type").map(|d| d.parse().unwrap_or(14)).unwrap_or_else(|| 14);
 
         Outcome::Success(ClientHeaders {
-            host,
             device_type,
             ip,
         })
@@ -531,7 +529,6 @@ pub struct OrgHeaders {
     pub user: User,
     pub org_user_type: UserOrgType,
     pub org_user: UserOrganization,
-    pub org_id: String,
     pub ip: ClientIp,
 }
 
@@ -594,7 +591,6 @@ impl<'r> FromRequest<'r> for OrgHeaders {
                         }
                     },
                     org_user,
-                    org_id: String::from(org_id),
                     ip: headers.ip,
                 })
             }
@@ -671,7 +667,6 @@ pub struct ManagerHeaders {
     pub host: String,
     pub device: Device,
     pub user: User,
-    pub org_user_type: UserOrgType,
     pub ip: ClientIp,
 }
 
@@ -700,7 +695,6 @@ impl<'r> FromRequest<'r> for ManagerHeaders {
                 host: headers.host,
                 device: headers.device,
                 user: headers.user,
-                org_user_type: headers.org_user_type,
                 ip: headers.ip,
             })
         } else {
@@ -727,7 +721,6 @@ pub struct ManagerHeadersLoose {
     pub device: Device,
     pub user: User,
     pub org_user: UserOrganization,
-    pub org_user_type: UserOrgType,
     pub ip: ClientIp,
 }
 
@@ -743,7 +736,6 @@ impl<'r> FromRequest<'r> for ManagerHeadersLoose {
                 device: headers.device,
                 user: headers.user,
                 org_user: headers.org_user,
-                org_user_type: headers.org_user_type,
                 ip: headers.ip,
             })
         } else {
@@ -782,14 +774,12 @@ impl ManagerHeaders {
             host: h.host,
             device: h.device,
             user: h.user,
-            org_user_type: h.org_user_type,
             ip: h.ip,
         })
     }
 }
 
 pub struct OwnerHeaders {
-    pub host: String,
     pub device: Device,
     pub user: User,
     pub ip: ClientIp,
@@ -803,7 +793,6 @@ impl<'r> FromRequest<'r> for OwnerHeaders {
         let headers = try_outcome!(OrgHeaders::from_request(request).await);
         if headers.org_user_type == UserOrgType::Owner {
             Outcome::Success(Self {
-                host: headers.host,
                 device: headers.device,
                 user: headers.user,
                 ip: headers.ip,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -414,7 +414,6 @@ impl<'r> FromRequest<'r> for ClientHeaders {
     type Error = &'static str;
 
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        let host = try_outcome!(Host::from_request(request).await).host;
         let ip = match ClientIp::from_request(request).await {
             Outcome::Success(ip) => ip,
             _ => err_handler!("Error getting Client IP"),


### PR DESCRIPTION
Updated rust to 1.79, and removed some unused values in the Header guards that Clippy was complaining about not being used anywhere.