### PR TITLE
Fix some nightly build errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,13 @@ fn main() {
         "You need to enable one DB backend. To build with previous defaults do: cargo build --features sqlite"
     );
 
+    // Use check-cfg to let cargo know which cfg's we define,
+    // and avoid warnings when they are used in the code.
+    println!("cargo::rustc-check-cfg=cfg(sqlite)");
+    println!("cargo::rustc-check-cfg=cfg(mysql)");
+    println!("cargo::rustc-check-cfg=cfg(postgresql)");
+    println!("cargo::rustc-check-cfg=cfg(query_logger)");
+
     // Rerun when these paths are changed.
     // Someone could have checked-out a tag or specific commit, but no other files changed.
     println!("cargo:rerun-if-changed=.git");

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -95,7 +95,7 @@ impl Attachment {
 
     pub async fn delete(&self, conn: &mut DbConn) -> EmptyResult {
         db_run! { conn: {
-            crate::util::retry(
+            let _: () = crate::util::retry(
                 || diesel::delete(attachments::table.filter(attachments::id.eq(&self.id))).execute(conn),
                 10,
             )

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -632,7 +632,7 @@ impl CollectionUser {
 
         db_run! { conn: {
             for user in collectionusers {
-                diesel::delete(users_collections::table.filter(
+                let _: () = diesel::delete(users_collections::table.filter(
                     users_collections::user_uuid.eq(user_uuid)
                     .and(users_collections::collection_uuid.eq(user.collection_uuid))
                 ))


### PR DESCRIPTION
I was building vaultwarden with the latest rust nightly and was met with a couple of build errors/warnings.
- Some `unknown cfg` warnings about the cfg's that we define based on features, which I disabled in the build.rs file
- Some type inference errors, where a couple of functions were inferring the `!` type instead of `()`. I'm not sure if this is a transient error or will become a hard error in a future stable release, but it was easy enough to solve.

This was using nightly `2024-06-18`