### PR TITLE
Fix cipher creation on new android app

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -797,7 +797,9 @@ async fn post_collections_admin(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ShareCipherData {
+    #[serde(alias = "Cipher")]
     cipher: CipherData,
+    #[serde(alias = "CollectionIds")]
     collection_ids: Vec<String>,
 }
 


### PR DESCRIPTION
The new android app is sending PascalCase for these two values. Ideally this will be updated in the app but it's an easy fix from our side for now. Using `serde(alias)` it will check both the camel case and pascal case versions.