### PR TITLE
Reduce healthcheck internal while keep performance

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -153,6 +153,6 @@ COPY docker/healthcheck.sh docker/start.sh /
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .
 
-HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=3s --timeout=2s CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -196,6 +196,6 @@ COPY docker/healthcheck.sh docker/start.sh /
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .
 
-HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=3s --timeout=2s CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -240,6 +240,6 @@ COPY docker/healthcheck.sh docker/start.sh /
 COPY --from=vault /web-vault ./web-vault
 COPY --from=build /app/target/final/vaultwarden .
 
-HEALTHCHECK --interval=60s --timeout=10s CMD ["/healthcheck.sh"]
+HEALTHCHECK --interval=3s --timeout=2s CMD ["/healthcheck.sh"]
 
 CMD ["/start.sh"]

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
 
+LAST_HEALTHY_FILE="/tmp/healthy"
+
+last_check="$(cat "$LAST_HEALTHY_FILE" 2>/dev/null || echo "0")"
+current_time="$(date +%s)"
+if [ $((current_time - last_check)) -le 60 ]; then
+    exit 0
+fi
+
 # Use the value of the corresponding env var (if present),
 # or a default value otherwise.
 : "${DATA_FOLDER:="/data"}"
@@ -62,4 +70,4 @@ if [ -n "${ROCKET_TLS}" ]; then
     s='s'
 fi
 curl --insecure --fail --silent --show-error \
-     "http${s}://${addr}:${ROCKET_PORT}${base_path}/alive" || exit 1
+     "http${s}://${addr}:${ROCKET_PORT}${base_path}/alive" && echo "$current_time" > "$LAST_HEALTHY_FILE" || exit 1


### PR DESCRIPTION
Currently, it takes 60 seconds for `vaultwarden/server` to become healthy:

```ymal
version: "3"

services:
  vaultwarden:
    image: vaultwarden/server:1.30.5-alpine
    # image: vaultwarden/server:1.30.5
    restart: no
    environment:
      I_REALLY_WANT_VOLATILE_STORAGE: true

  nginx:
    image: nginx
    restart: no
    depends_on:
      vaultwarden:
        condition: service_healthy
```

By implementing a cache mechanism, we can reduce this interval.
