### PR TITLE
Fix collections and native app issue

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -189,6 +189,12 @@ impl Cipher {
             }
         }
 
+        // Fix secure note issues when data is `{}`
+        // This breaks at least the native mobile clients
+        if self.atype == 2 && (self.data.eq("{}") || self.data.to_ascii_lowercase().eq("{\"type\":null}")) {
+            type_data_json = json!({"type": 0});
+        }
+
         // Clone the type_data and add some default value.
         let mut data_json = type_data_json.clone();
 

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -406,7 +406,7 @@ impl UserOrganization {
             "accessSecretsManager": false,
             "limitCollectionCreationDeletion": true,
             "allowAdminAccessToAllCollectionItems": true,
-            "flexibleCollections": true,
+            "flexibleCollections": false,
 
             "permissions": permissions,
 


### PR DESCRIPTION
Collections were not visible in the organization view.
This was because the `flexibleCollections` was set to `true`

Found an issue with loading some old created Secure Notes which had `{}` or `{"type":null}` as there `data` value.
This isn't allowed. When detected, replace it with `{"type":0}`

Fixes #4682
Fixes #4590
