### PR TITLE
Fix duplicate folder creations during import

### DIFF
--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -41,6 +41,7 @@ async fn get_folder(uuid: &str, headers: Headers, mut conn: DbConn) -> JsonResul
 #[serde(rename_all = "camelCase")]
 pub struct FolderData {
     pub name: String,
+    pub id: Option<String>,
 }
 
 #[post("/folders", data = "<data>")]


### PR DESCRIPTION
During import you are able to select an existing folder, or with Bitwarden exports it can contain existing folders already. In either case it didn't matter, we always created new folders.

Bitwarden uses the same UUID of the selected or existing folders if they are already there.

This PR fixes this by using the same behaviour.

Fixes #4700