### PR TITLE
Switch registry cache compression algorithm to zstd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           # Check if there is a GitHub Container Registry Login and use it for caching
           if [[ -n "${HAVE_GHCR_LOGIN}" ]]; then
             echo "BAKE_CACHE_FROM=type=registry,ref=${{ vars.GHCR_REPO }}-buildcache:${{ matrix.base_image }}" | tee -a "${GITHUB_ENV}"
-            echo "BAKE_CACHE_TO=type=registry,ref=${{ vars.GHCR_REPO }}-buildcache:${{ matrix.base_image }},mode=max" | tee -a "${GITHUB_ENV}"
+            echo "BAKE_CACHE_TO=type=registry,ref=${{ vars.GHCR_REPO }}-buildcache:${{ matrix.base_image }},compression=zstd,mode=max" | tee -a "${GITHUB_ENV}"
           else
             echo "BAKE_CACHE_FROM="
             echo "BAKE_CACHE_TO="


### PR DESCRIPTION
- faster builds than with gzip (the default)

Quick comparison I did (vaultwarden built for 3 platforms: linux/amd64, linux/amd64/v3 and linux/arm64):
gzip
• No cache: 22m 7s
• Cached: 11m 20s

zstd:
• No cache: 19m 36s
• Cached: 10m 48s