### PR TITLE
Some fixes for emergency access

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -515,15 +515,12 @@ async fn post_rotatekey(data: Json<KeyData>, headers: Headers, mut conn: DbConn,
 
     // Update emergency access data
     for emergency_access_data in data.emergency_access_keys {
-        let mut saved_emergency_access = match EmergencyAccess::find_by_uuid(&emergency_access_data.id, &mut conn).await
-        {
-            Some(emergency_access) => emergency_access,
-            None => err!("Emergency access doesn't exist"),
-        };
-
-        if &saved_emergency_access.grantor_uuid != user_uuid {
-            err!("The emergency access is not owned by the user")
-        }
+        let mut saved_emergency_access =
+            match EmergencyAccess::find_by_uuid_and_grantor_uuid(&emergency_access_data.id, user_uuid, &mut conn).await
+            {
+                Some(emergency_access) => emergency_access,
+                None => err!("Emergency access doesn't exist or is not owned by the user"),
+            };
 
         saved_emergency_access.key_encrypted = Some(emergency_access_data.key_encrypted);
         saved_emergency_access.save(&mut conn).await?

--- a/src/db/models/emergency_access.rs
+++ b/src/db/models/emergency_access.rs
@@ -238,15 +238,6 @@ impl EmergencyAccess {
         }}
     }
 
-    pub async fn find_by_uuid(uuid: &str, conn: &mut DbConn) -> Option<Self> {
-        db_run! { conn: {
-            emergency_access::table
-                .filter(emergency_access::uuid.eq(uuid))
-                .first::<EmergencyAccessDb>(conn)
-                .ok().from_db()
-        }}
-    }
-
     pub async fn find_by_grantor_uuid_and_grantee_uuid_or_email(
         grantor_uuid: &str,
         grantee_uuid: &str,
@@ -276,6 +267,26 @@ impl EmergencyAccess {
             emergency_access::table
                 .filter(emergency_access::uuid.eq(uuid))
                 .filter(emergency_access::grantor_uuid.eq(grantor_uuid))
+                .first::<EmergencyAccessDb>(conn)
+                .ok().from_db()
+        }}
+    }
+
+    pub async fn find_by_uuid_and_grantee_uuid(uuid: &str, grantee_uuid: &str, conn: &mut DbConn) -> Option<Self> {
+        db_run! { conn: {
+            emergency_access::table
+                .filter(emergency_access::uuid.eq(uuid))
+                .filter(emergency_access::grantee_uuid.eq(grantee_uuid))
+                .first::<EmergencyAccessDb>(conn)
+                .ok().from_db()
+        }}
+    }
+
+    pub async fn find_by_uuid_and_grantee_email(uuid: &str, grantee_email: &str, conn: &mut DbConn) -> Option<Self> {
+        db_run! { conn: {
+            emergency_access::table
+                .filter(emergency_access::uuid.eq(uuid))
+                .filter(emergency_access::email.eq(grantee_email))
                 .first::<EmergencyAccessDb>(conn)
                 .ok().from_db()
         }}


### PR DESCRIPTION
 - Add missing `Headers` parameter for some functions This allowed any request from allowing these endpoints by not validating the user correctly.
 - Changed the functions to retreive the emergency access record by using the user uuid which calls the endpoint, instead of validating afterwards. This is more secure and prevents the need of an if check.