### PR TITLE
chore: Dockerfile to Remove port 3012

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -142,7 +142,6 @@ RUN mkdir /data && \
 
 VOLUME /data
 EXPOSE 80
-EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -185,7 +185,6 @@ RUN mkdir /data && \
 
 VOLUME /data
 EXPOSE 80
-EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -229,7 +229,6 @@ RUN mkdir /data && \
 
 VOLUME /data
 EXPOSE 80
-EXPOSE 3012
 
 # Copies the files from the context (Rocket.toml file and web-vault)
 # and the binary from the "build" stage to the current stage


### PR DESCRIPTION
as of [v1.31.0](https://github.com/dani-garcia/vaultwarden/releases/tag/1.31.0), this is no longer needed