### PR TITLE
use a custom plan of enterprise tier to fix limits

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -156,11 +156,12 @@ impl Organization {
             "id": self.uuid,
             "identifier": null, // not supported by us
             "name": self.name,
-            "seats": 10, // The value doesn't matter, we don't check server-side
-            // "maxAutoscaleSeats": null, // The value doesn't matter, we don't check server-side
-            "maxCollections": 10, // The value doesn't matter, we don't check server-side
+            "seats": null,
+            "maxAutoscaleSeats": null,
+            "maxCollections": null,
             "maxStorageGb": 10, // The value doesn't matter, we don't check server-side
             "use2fa": true,
+            "useCustomPermissions": false,
             "useDirectory": false, // Is supported, but this value isn't checked anywhere (yet)
             "useEvents": CONFIG.org_events_enabled(),
             "useGroups": CONFIG.org_groups_enabled(),
@@ -182,8 +183,7 @@ impl Organization {
             "businessTaxNumber": null,
 
             "billingEmail": self.billing_email,
-            "plan": "TeamsAnnually",
-            "planType": 5, // TeamsAnnually plan
+            "planType": 6, // Custom plan
             "usersGetPremium": true,
             "object": "organization",
         })
@@ -369,8 +369,9 @@ impl UserOrganization {
             "id": self.org_uuid,
             "identifier": null, // Not supported
             "name": org.name,
-            "seats": 10, // The value doesn't matter, we don't check server-side
-            "maxCollections": 10, // The value doesn't matter, we don't check server-side
+            "seats": null,
+            "maxAutoscaleSeats": null,
+            "maxCollections": null,
             "usersGetPremium": true,
             "use2fa": true,
             "useDirectory": false, // Is supported, but this value isn't checked anywhere (yet)
@@ -392,12 +393,14 @@ impl UserOrganization {
             "useCustomPermissions": false,
             "useActivateAutofillPolicy": false,
 
+            "organizationUserId": self.uuid,
             "providerId": null,
             "providerName": null,
             "providerType": null,
             "familySponsorshipFriendlyName": null,
             "familySponsorshipAvailable": false,
-            "planProductType": 0,
+            "planProductType": 3,
+            "productTierType": 3, // Enterprise tier
             "keyConnectorEnabled": false,
             "keyConnectorUrl": null,
             "familySponsorshipLastSyncDate": null,

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -159,7 +159,7 @@ impl Organization {
             "seats": null,
             "maxAutoscaleSeats": null,
             "maxCollections": null,
-            "maxStorageGb": 10, // The value doesn't matter, we don't check server-side
+            "maxStorageGb": i16::MAX, // The value doesn't matter, we don't check server-side
             "use2fa": true,
             "useCustomPermissions": false,
             "useDirectory": false, // Is supported, but this value isn't checked anywhere (yet)
@@ -413,7 +413,7 @@ impl UserOrganization {
 
             "permissions": permissions,
 
-            "maxStorageGb": 10, // The value doesn't matter, we don't check server-side
+            "maxStorageGb": i16::MAX, // The value doesn't matter, we don't check server-side
 
             // These are per user
             "userId": self.user_uuid,


### PR DESCRIPTION
this should fix #4707 and other related issues from using the free tier plan (like the totp display not working in the admin console).

Fixes #4707 