### PR TITLE
Fix bug where secureNotes is empty

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -189,9 +189,11 @@ impl Cipher {
             }
         }
 
-        // Fix secure note issues when data is `{}`
+        // Fix secure note issues when data is invalid
         // This breaks at least the native mobile clients
-        if self.atype == 2 && (self.data.eq("{}") || self.data.to_ascii_lowercase().eq("{\"type\":null}")) {
+        if self.atype == 2
+            && (self.data.is_empty() || self.data.eq("{}") || self.data.to_ascii_lowercase().eq("{\"type\":null}"))
+        {
             type_data_json = json!({"type": 0});
         }
 


### PR DESCRIPTION
Fixes #4719 
Fixes bug where the value of my notes is an empty string, and thus doesn't pass the check for an empty array.
This adds empty strings to the if condition.  Tested with the mobile app and this fixes my issue