### PR TITLE
Fix for RSA Keys which are read only

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -36,14 +36,14 @@ static PRIVATE_RSA_KEY: OnceCell<EncodingKey> = OnceCell::new();
 static PUBLIC_RSA_KEY: OnceCell<DecodingKey> = OnceCell::new();
 
 pub fn initialize_keys() -> Result<(), crate::error::Error> {
-    fn read_key(creat_if_missing: bool) -> Result<(Rsa<openssl::pkey::Private>, Vec<u8>), crate::error::Error> {
+    fn read_key(create_if_missing: bool) -> Result<(Rsa<openssl::pkey::Private>, Vec<u8>), crate::error::Error> {
         let mut priv_key_buffer = Vec::with_capacity(2048);
 
         let mut priv_key_file = File::options()
-            .create(creat_if_missing)
+            .create(create_if_missing)
             .truncate(false)
             .read(true)
-            .write(creat_if_missing)
+            .write(create_if_missing)
             .open(CONFIG.private_rsa_key())?;
 
         #[allow(clippy::verbose_file_reads)]
@@ -51,7 +51,7 @@ pub fn initialize_keys() -> Result<(), crate::error::Error> {
 
         let rsa_key = if bytes_read > 0 {
             Rsa::private_key_from_pem(&priv_key_buffer[..bytes_read])?
-        } else if creat_if_missing {
+        } else if create_if_missing {
             // Only create the key if the file doesn't exist or is empty
             let rsa_key = openssl::rsa::Rsa::generate(2048)?;
             priv_key_buffer = rsa_key.private_key_to_pem()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Error> {
 
     check_data_folder().await;
     auth::initialize_keys().unwrap_or_else(|_| {
-        error!("Error creating keys, exiting...");
+        error!("Error creating private key '{}', exiting...", CONFIG.private_rsa_key());
         exit(1);
     });
     check_web_vault();

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,9 @@ async fn main() -> Result<(), Error> {
     });
     init_logging(level).ok();
 
-    let extra_debug = matches!(level, LF::Trace | LF::Debug);
-
     check_data_folder().await;
-    auth::initialize_keys().unwrap_or_else(|_| {
-        error!("Error creating private key '{}', exiting...", CONFIG.private_rsa_key());
+    auth::initialize_keys().unwrap_or_else(|e| {
+        error!("Error creating private key '{}'\n{e:?}\nExiting Vaultwarden!", CONFIG.private_rsa_key());
         exit(1);
     });
     check_web_vault();
@@ -91,6 +89,7 @@ async fn main() -> Result<(), Error> {
     schedule_jobs(pool.clone());
     crate::db::models::TwoFactor::migrate_u2f_to_webauthn(&mut pool.get().await.unwrap()).await.unwrap();
 
+    let extra_debug = matches!(level, LF::Trace | LF::Debug);
     launch_rocket(pool, extra_debug).await // Blocks until program termination.
 }
 
@@ -514,7 +513,7 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
 
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.expect("Error setting Ctrl-C handler");
-        info!("Exiting vaultwarden!");
+        info!("Exiting Vaultwarden!");
         CONFIG.shutdown();
     });
 


### PR DESCRIPTION
Sometimes an RSA Key file could be read only.
We currently failed because we also wanted to write. Added an extra check if the file exists already and is not 0 in size. If it does already exists and is larger then 0, then open in read only mode.

Fixes #4644