### PR TITLE
Fix Email 2FA login on native app

### DIFF
--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -24,7 +24,10 @@ pub fn routes() -> Vec<Route> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SendEmailLoginData {
+    // DeviceIdentifier: String, // Currently not used
+    #[serde(alias = "Email")]
     email: String,
+    #[serde(alias = "MasterPasswordHash")]
     master_password_hash: String,
 }
 


### PR DESCRIPTION
The new native android app still seems to send PascalCase entries for Email 2FA. Added aliasses for these keys.

Tested all other 2FA's (Except Duo, which might be fixable via #4637) and they all work fine using the Native Android Beta v2024.7.0 version.

Fixes #4713