### PR TITLE
Fix Dockerfile linter warnings

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# check=skip=FromPlatformFlagConstDisallowed,RedundantTargetPlatform
 
 # This file was generated using a Jinja2 template.
 # Please make your changes in `DockerSettings.yaml` or `Dockerfile.j2` and then `make`
@@ -26,19 +27,19 @@
 #     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375
 #     [docker.io/vaultwarden/web-vault:v2024.5.1b]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375 AS vault
 
 ########################## ALPINE BUILD IMAGES ##########################
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64
 ## And for Alpine we define all build images here, they will only be loaded when actually used
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.79.0 as build_amd64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.79.0 as build_arm64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.79.0 as build_armv7
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.79.0 as build_armv6
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.79.0 AS build_amd64
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.79.0 AS build_arm64
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.79.0 AS build_armv7
+FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.79.0 AS build_armv6
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform=linux/amd64 build_${TARGETARCH}${TARGETVARIANT} as build
+FROM --platform=linux/amd64 build_${TARGETARCH}${TARGETVARIANT} AS build
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG TARGETPLATFORM

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# check=skip=FromPlatformFlagConstDisallowed,RedundantTargetPlatform
 
 # This file was generated using a Jinja2 template.
 # Please make your changes in `DockerSettings.yaml` or `Dockerfile.j2` and then `make`
@@ -26,7 +27,7 @@
 #     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375
 #     [docker.io/vaultwarden/web-vault:v2024.5.1b]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375 as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:1a867b4b175e85fc8602314bd83bc263c76c49787031704f16a2915567725375 AS vault
 
 ########################## Cross Compile Docker Helper Scripts ##########################
 ## We use the linux/amd64 no matter which Build Platform, since these are all bash scripts
@@ -35,7 +36,7 @@ FROM --platform=linux/amd64 docker.io/tonistiigi/xx@sha256:0cd3f05c72d6c9b038eb1
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform=$BUILDPLATFORM docker.io/library/rust:1.79.0-slim-bookworm as build
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:1.79.0-slim-bookworm AS build
 COPY --from=xx / /
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# check=skip=FromPlatformFlagConstDisallowed,RedundantTargetPlatform
 
 # This file was generated using a Jinja2 template.
 # Please make your changes in `DockerSettings.yaml` or `Dockerfile.j2` and then `make`
@@ -26,7 +27,7 @@
 #     $ docker image inspect --format "{{ '{{' }}.RepoTags}}" docker.io/vaultwarden/web-vault@{{ vault_image_digest }}
 #     [docker.io/vaultwarden/web-vault:{{ vault_version }}]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_digest }} as vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_digest }} AS vault
 
 {% if base == "debian" %}
 ########################## Cross Compile Docker Helper Scripts ##########################
@@ -38,13 +39,13 @@ FROM --platform=linux/amd64 docker.io/tonistiigi/xx@{{ xx_image_digest }} AS xx
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64
 ## And for Alpine we define all build images here, they will only be loaded when actually used
 {% for arch in build_stage_image[base].arch_image %}
-FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].arch_image[arch] }} as build_{{ arch }}
+FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].arch_image[arch] }} AS build_{{ arch }}
 {% endfor %}
 {% endif %}
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].image }} as build
+FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].image }} AS build
 {% if base == "debian" %}
 COPY --from=xx / /
 {% endif %}


### PR DESCRIPTION
- they seem to have started appearing with buildx v0.16.0

Alpine warnings:
```
13 warnings found (use --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 37)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 38)
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 133)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 35)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 36)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 42)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 29)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 36)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 42)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 34)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 37)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 38)
```
Debian warnings:
```
5 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 38)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 29)
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 34)
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 171)
```

For ```FromPlatformFlagConstDisallowed``` I decided to use the 3rd variant from here:
https://github.com/moby/buildkit/blob/master/frontend/dockerfile/linter/docs/FromPlatformFlagConstDisallowed.md#description