### PR TITLE
Allow to increase the note size to 100_000

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -414,6 +414,12 @@
 ## KNOW WHAT YOU ARE DOING!
 # ORG_GROUPS_ENABLED=false
 
+## Increase secure note size limit (Know the risks!)
+## Sets the secure note size limit to 100_000 instead of the default 10_000.
+## WARNING: This could cause issues with clients. Also exports will not work on Bitwarden servers!
+## KNOW WHAT YOU ARE DOING!
+# INCREASE_NOTE_SIZE_LIMIT=false
+
 ########################
 ### MFA/2FA settings ###
 ########################

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -377,8 +377,9 @@ pub async fn update_cipher_from_data(
     }
 
     if let Some(note) = &data.notes {
-        if note.len() > 10_000 {
-            err!("The field Notes exceeds the maximum encrypted value length of 10000 characters.")
+        let max_note_size = CONFIG._max_note_size();
+        if note.len() > max_note_size {
+            err!(format!("The field Notes exceeds the maximum encrypted value length of {max_note_size} characters."))
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -618,7 +618,13 @@ make_config! {
         admin_session_lifetime:        i64, true,  def, 20;
 
         /// Enable groups (BETA!) (Know the risks!) |> Enables groups support for organizations (Currently contains known issues!).
-        org_groups_enabled:     bool,   false,  def,    false;
+        org_groups_enabled:            bool, false, def, false;
+
+        /// Increase note size limit (Know the risks!) |> Sets the secure note size limit to 100_000 instead of the default 10_000.
+        /// WARNING: This could cause issues with clients. Also exports will not work on Bitwarden servers!
+        increase_note_size_limit:      bool,  true,  def, false;
+        /// Generated max_note_size value to prevent if..else matching during every check
+        _max_note_size:                usize, false, gen, |c| if c.increase_note_size_limit {100_000} else {10_000};
     },
 
     /// Yubikey settings
@@ -1000,6 +1006,11 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
             }
             _ => {}
         }
+    }
+
+    if cfg.increase_note_size_limit {
+        println!("[WARNING] Secure Note size limit is increased to 100_000!");
+        println!("[WARNING] This could cause issues with clients. Also exports will not work on Bitwarden servers!.");
     }
     Ok(())
 }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -81,16 +81,14 @@ impl Cipher {
 
     pub fn validate_notes(cipher_data: &[CipherData]) -> EmptyResult {
         let mut validation_errors = serde_json::Map::new();
+        let max_note_size = CONFIG._max_note_size();
+        let max_note_size_msg =
+            format!("The field Notes exceeds the maximum encrypted value length of {} characters.", &max_note_size);
         for (index, cipher) in cipher_data.iter().enumerate() {
             if let Some(note) = &cipher.notes {
-                if note.len() > 10_000 {
-                    validation_errors.insert(
-                        format!("Ciphers[{index}].Notes"),
-                        serde_json::to_value([
-                            "The field Notes exceeds the maximum encrypted value length of 10000 characters.",
-                        ])
-                        .unwrap(),
-                    );
+                if note.len() > max_note_size {
+                    validation_errors
+                        .insert(format!("Ciphers[{index}].Notes"), serde_json::to_value([&max_note_size_msg]).unwrap());
                 }
             }
         }


### PR DESCRIPTION
This PR adds a config option to allow the note size to increase to 100_000, instead of the default 10_000. Since this might cause issues with the clients (in the future), and will cause issues with importing into a Bitwarden server, i added warnings regarding this.

Closes #3168