### PR TITLE
Duo: use the formatted db email

### DIFF
--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -423,8 +423,6 @@ pub async fn validate_duo_login(
     device_identifier: &str,
     conn: &mut DbConn,
 ) -> EmptyResult {
-    let email = &email.to_lowercase();
-
     // Result supplied to us by clients in the form "<authz code>|<state>"
     let split: Vec<&str> = two_factor_token.split('|').collect();
     if split.len() != 2 {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -524,12 +524,12 @@ async fn twofactor_auth(
             match CONFIG.duo_use_iframe() {
                 true => {
                     // Legacy iframe prompt flow
-                    duo::validate_duo_login(data.username.as_ref().unwrap().trim(), twofactor_code, conn).await?
+                    duo::validate_duo_login(&user.email, twofactor_code, conn).await?
                 }
                 false => {
                     // OIDC based flow
                     duo_oidc::validate_duo_login(
-                        data.username.as_ref().unwrap().trim(),
+                        &user.email,
                         twofactor_code,
                         data.client_id.as_ref().unwrap(),
                         data.device_identifier.as_ref().unwrap(),


### PR DESCRIPTION
Was rebasing and had a conflict with the latest addition of `validate_duo_login`.
Had made the fix for the OpenID PR and never back-ported it (Don't exactly remember the issue and it's buried in the comments, but it was linked to using the non lowercased email).

I think in general it makes more sense if available to use the reference email from the user instead of the non formatted value from the form.
I don't have a Duo account anymore so can't really test it :(.
