### PR TITLE
Add Read-Only Mode

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -14,6 +14,7 @@ use crate::util::NumberOrString;
 use crate::{
     api::{self, core::log_event, EmptyResult, JsonResult, Notify, PasswordOrOtpData, UpdateType},
     auth::Headers,
+    config::not_readonly,
     crypto,
     db::{models::*, DbConn, DbPool},
     CONFIG,
@@ -266,6 +267,8 @@ pub struct Attachments2Data {
 /// Called when an org admin clones an org cipher.
 #[post("/ciphers/admin", data = "<data>")]
 async fn post_ciphers_admin(data: Json<ShareCipherData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     post_ciphers_create(data, headers, conn, nt).await
 }
 
@@ -279,6 +282,8 @@ async fn post_ciphers_create(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let mut data: ShareCipherData = data.into_inner();
 
     // Check if there are one more more collections selected when this cipher is part of an organization.
@@ -310,6 +315,8 @@ async fn post_ciphers_create(
 /// Called when creating a new user-owned cipher.
 #[post("/ciphers", data = "<data>")]
 async fn post_ciphers(data: Json<CipherData>, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     let mut data: CipherData = data.into_inner();
 
     // The web/browser clients set this field to null as expected, but the
@@ -554,6 +561,8 @@ async fn post_ciphers_import(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     enforce_personal_ownership_policy(None, &headers, &mut conn).await?;
 
     let data: ImportData = data.into_inner();
@@ -612,6 +621,8 @@ async fn put_cipher_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     put_cipher(uuid, data, headers, conn, nt).await
 }
 
@@ -623,11 +634,15 @@ async fn post_cipher_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     post_cipher(uuid, data, headers, conn, nt).await
 }
 
 #[post("/ciphers/<uuid>", data = "<data>")]
 async fn post_cipher(uuid: &str, data: Json<CipherData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     put_cipher(uuid, data, headers, conn, nt).await
 }
 
@@ -639,6 +654,8 @@ async fn put_cipher(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: CipherData = data.into_inner();
 
     let mut cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
@@ -662,6 +679,8 @@ async fn put_cipher(
 
 #[post("/ciphers/<uuid>/partial", data = "<data>")]
 async fn post_cipher_partial(uuid: &str, data: Json<PartialCipherData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     put_cipher_partial(uuid, data, headers, conn).await
 }
 
@@ -673,6 +692,8 @@ async fn put_cipher_partial(
     headers: Headers,
     mut conn: DbConn,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: PartialCipherData = data.into_inner();
 
     let cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
@@ -713,6 +734,8 @@ async fn put_collections2_update(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     post_collections2_update(uuid, data, headers, conn, nt).await
 }
 
@@ -724,6 +747,8 @@ async fn post_collections2_update(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let cipher_details = post_collections_update(uuid, data, headers, conn, nt).await?;
     Ok(Json(json!({ // AttachmentUploadDataResponseModel
         "object": "optionalCipherDetails",
@@ -740,6 +765,8 @@ async fn put_collections_update(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     post_collections_update(uuid, data, headers, conn, nt).await
 }
 
@@ -751,6 +778,8 @@ async fn post_collections_update(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: CollectionsAdminData = data.into_inner();
 
     let cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
@@ -817,6 +846,8 @@ async fn put_collections_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     post_collections_admin(uuid, data, headers, conn, nt).await
 }
 
@@ -828,6 +859,8 @@ async fn post_collections_admin(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     let data: CollectionsAdminData = data.into_inner();
 
     let cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
@@ -903,6 +936,8 @@ async fn post_cipher_share(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: ShareCipherData = data.into_inner();
 
     share_cipher_by_uuid(uuid, data, &headers, &mut conn, &nt).await
@@ -916,6 +951,8 @@ async fn put_cipher_share(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: ShareCipherData = data.into_inner();
 
     share_cipher_by_uuid(uuid, data, &headers, &mut conn, &nt).await
@@ -935,6 +972,8 @@ async fn put_cipher_share_selected(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     let mut data: ShareSelectedCipherData = data.into_inner();
 
     if data.ciphers.is_empty() {
@@ -973,6 +1012,8 @@ async fn share_cipher_by_uuid(
     conn: &mut DbConn,
     nt: &Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let mut cipher = match Cipher::find_by_uuid(uuid, conn).await {
         Some(cipher) => {
             if cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
@@ -1063,6 +1104,8 @@ async fn post_attachment_v2(
     headers: Headers,
     mut conn: DbConn,
 ) -> JsonResult {
+    not_readonly()?;
+
     let cipher = match Cipher::find_by_uuid(uuid, &mut conn).await {
         Some(cipher) => cipher,
         None => err!("Cipher doesn't exist"),
@@ -1120,6 +1163,8 @@ async fn save_attachment(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> Result<(Cipher, DbConn), crate::error::Error> {
+    not_readonly()?;
+
     let mut data = data.into_inner();
 
     let Some(size) = data.data.len().to_i64() else {
@@ -1295,6 +1340,8 @@ async fn post_attachment_v2_data(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     let attachment = match Attachment::find_by_id(attachment_id, &mut conn).await {
         Some(attachment) if uuid == attachment.cipher_uuid => Some(attachment),
         Some(_) => err!("Attachment doesn't belong to cipher"),
@@ -1315,6 +1362,8 @@ async fn post_attachment(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     // Setting this as None signifies to save_attachment() that it should create
     // the attachment database record as well as saving the data to disk.
     let attachment = None;
@@ -1332,6 +1381,8 @@ async fn post_attachment_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     post_attachment(uuid, data, headers, conn, nt).await
 }
 
@@ -1344,6 +1395,8 @@ async fn post_attachment_share(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     _delete_cipher_attachment_by_id(uuid, attachment_id, &headers, &mut conn, &nt).await?;
     post_attachment(uuid, data, headers, conn, nt).await
 }
@@ -1356,6 +1409,8 @@ async fn delete_attachment_post_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     delete_attachment(uuid, attachment_id, headers, conn, nt).await
 }
 
@@ -1367,6 +1422,8 @@ async fn delete_attachment_post(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     delete_attachment(uuid, attachment_id, headers, conn, nt).await
 }
 
@@ -1378,6 +1435,8 @@ async fn delete_attachment(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_attachment_by_id(uuid, attachment_id, &headers, &mut conn, &nt).await
 }
 
@@ -1389,40 +1448,54 @@ async fn delete_attachment_admin(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_attachment_by_id(uuid, attachment_id, &headers, &mut conn, &nt).await
 }
 
 #[post("/ciphers/<uuid>/delete")]
 async fn delete_cipher_post(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, false, &nt).await
     // permanent delete
 }
 
 #[post("/ciphers/<uuid>/delete-admin")]
 async fn delete_cipher_post_admin(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, false, &nt).await
     // permanent delete
 }
 
 #[put("/ciphers/<uuid>/delete")]
 async fn delete_cipher_put(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, true, &nt).await
     // soft delete
 }
 
 #[put("/ciphers/<uuid>/delete-admin")]
 async fn delete_cipher_put_admin(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, true, &nt).await
 }
 
 #[delete("/ciphers/<uuid>")]
 async fn delete_cipher(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, false, &nt).await
     // permanent delete
 }
 
 #[delete("/ciphers/<uuid>/admin")]
 async fn delete_cipher_admin(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     _delete_cipher_by_uuid(uuid, &headers, &mut conn, false, &nt).await
     // permanent delete
 }
@@ -1434,6 +1507,8 @@ async fn delete_cipher_selected(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, false, nt).await // permanent delete
 }
 
@@ -1444,6 +1519,8 @@ async fn delete_cipher_selected_post(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, false, nt).await // permanent delete
 }
 
@@ -1454,6 +1531,8 @@ async fn delete_cipher_selected_put(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, true, nt).await // soft delete
 }
 
@@ -1464,6 +1543,8 @@ async fn delete_cipher_selected_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, false, nt).await // permanent delete
 }
 
@@ -1474,6 +1555,8 @@ async fn delete_cipher_selected_post_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, false, nt).await // permanent delete
 }
 
@@ -1484,16 +1567,22 @@ async fn delete_cipher_selected_put_admin(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     _delete_multiple_ciphers(data, headers, conn, true, nt).await // soft delete
 }
 
 #[put("/ciphers/<uuid>/restore")]
 async fn restore_cipher_put(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     _restore_cipher_by_uuid(uuid, &headers, &mut conn, &nt).await
 }
 
 #[put("/ciphers/<uuid>/restore-admin")]
 async fn restore_cipher_put_admin(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     _restore_cipher_by_uuid(uuid, &headers, &mut conn, &nt).await
 }
 
@@ -1504,6 +1593,8 @@ async fn restore_cipher_selected(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     _restore_multiple_ciphers(data, &headers, &mut conn, &nt).await
 }
 
@@ -1521,6 +1612,8 @@ async fn move_cipher_selected(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     let data = data.into_inner();
     let user_uuid = headers.user.uuid;
 
@@ -1569,6 +1662,8 @@ async fn move_cipher_selected_put(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     move_cipher_selected(data, headers, conn, nt).await
 }
 
@@ -1586,6 +1681,8 @@ async fn delete_all(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     let data: PasswordOrOtpData = data.into_inner();
     let mut user = headers.user;
 

--- a/src/api/core/emergency_access.rs
+++ b/src/api/core/emergency_access.rs
@@ -8,6 +8,7 @@ use crate::{
         EmptyResult, JsonResult,
     },
     auth::{decode_emergency_access_invite, Headers},
+    config::not_readonly,
     db::{models::*, DbConn, DbPool},
     mail,
     util::NumberOrString,
@@ -123,6 +124,8 @@ async fn put_emergency_access(
     headers: Headers,
     conn: DbConn,
 ) -> JsonResult {
+    not_readonly()?;
+
     post_emergency_access(emer_id, data, headers, conn).await
 }
 
@@ -133,6 +136,8 @@ async fn post_emergency_access(
     headers: Headers,
     mut conn: DbConn,
 ) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let data: EmergencyAccessUpdateData = data.into_inner();
@@ -164,6 +169,8 @@ async fn post_emergency_access(
 
 #[delete("/emergency-access/<emer_id>")]
 async fn delete_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let emergency_access = match (
@@ -187,6 +194,8 @@ async fn delete_emergency_access(emer_id: &str, headers: Headers, mut conn: DbCo
 
 #[post("/emergency-access/<emer_id>/delete")]
 async fn post_delete_emergency_access(emer_id: &str, headers: Headers, conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     delete_emergency_access(emer_id, headers, conn).await
 }
 
@@ -204,6 +213,8 @@ struct EmergencyAccessInviteData {
 
 #[post("/emergency-access/invite", data = "<data>")]
 async fn send_invite(data: Json<EmergencyAccessInviteData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let data: EmergencyAccessInviteData = data.into_inner();
@@ -282,6 +293,8 @@ async fn send_invite(data: Json<EmergencyAccessInviteData>, headers: Headers, mu
 
 #[post("/emergency-access/<emer_id>/reinvite")]
 async fn resend_invite(emer_id: &str, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let mut emergency_access =
@@ -334,6 +347,8 @@ struct AcceptData {
 
 #[post("/emergency-access/<emer_id>/accept", data = "<data>")]
 async fn accept_invite(emer_id: &str, data: Json<AcceptData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let data: AcceptData = data.into_inner();
@@ -397,6 +412,8 @@ async fn confirm_emergency_access(
     headers: Headers,
     mut conn: DbConn,
 ) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let confirming_user = headers.user;
@@ -447,6 +464,8 @@ async fn confirm_emergency_access(
 
 #[post("/emergency-access/<emer_id>/initiate")]
 async fn initiate_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let initiating_user = headers.user;
@@ -486,6 +505,8 @@ async fn initiate_emergency_access(emer_id: &str, headers: Headers, mut conn: Db
 
 #[post("/emergency-access/<emer_id>/approve")]
 async fn approve_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let mut emergency_access =
@@ -523,6 +544,8 @@ async fn approve_emergency_access(emer_id: &str, headers: Headers, mut conn: DbC
 
 #[post("/emergency-access/<emer_id>/reject")]
 async fn reject_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let mut emergency_access =
@@ -561,6 +584,8 @@ async fn reject_emergency_access(emer_id: &str, headers: Headers, mut conn: DbCo
 
 #[post("/emergency-access/<emer_id>/view")]
 async fn view_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let emergency_access =
@@ -599,6 +624,8 @@ async fn view_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn
 
 #[post("/emergency-access/<emer_id>/takeover")]
 async fn takeover_emergency_access(emer_id: &str, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let requesting_user = headers.user;
@@ -643,6 +670,8 @@ async fn password_emergency_access(
     headers: Headers,
     mut conn: DbConn,
 ) -> EmptyResult {
+    not_readonly()?;
+
     check_emergency_access_enabled()?;
 
     let data: EmergencyAccessPasswordData = data.into_inner();

--- a/src/api/core/folders.rs
+++ b/src/api/core/folders.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use crate::{
     api::{EmptyResult, JsonResult, Notify, UpdateType},
     auth::Headers,
+    config::not_readonly,
     db::{models::*, DbConn},
 };
 
@@ -46,6 +47,8 @@ pub struct FolderData {
 
 #[post("/folders", data = "<data>")]
 async fn post_folders(data: Json<FolderData>, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     let data: FolderData = data.into_inner();
 
     let mut folder = Folder::new(headers.user.uuid, data.name);
@@ -58,6 +61,8 @@ async fn post_folders(data: Json<FolderData>, headers: Headers, mut conn: DbConn
 
 #[post("/folders/<uuid>", data = "<data>")]
 async fn post_folder(uuid: &str, data: Json<FolderData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     put_folder(uuid, data, headers, conn, nt).await
 }
 
@@ -69,6 +74,8 @@ async fn put_folder(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: FolderData = data.into_inner();
 
     let mut folder = match Folder::find_by_uuid(uuid, &mut conn).await {
@@ -90,11 +97,15 @@ async fn put_folder(
 
 #[post("/folders/<uuid>/delete")]
 async fn delete_folder_post(uuid: &str, headers: Headers, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     delete_folder(uuid, headers, conn, nt).await
 }
 
 #[delete("/folders/<uuid>")]
 async fn delete_folder(uuid: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     let folder = match Folder::find_by_uuid(uuid, &mut conn).await {
         Some(folder) => folder,
         _ => err!("Invalid folder"),

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -15,6 +15,8 @@ pub use events::{event_cleanup_job, log_event, log_user_event};
 use reqwest::Method;
 pub use sends::purge_sends;
 
+use crate::config::not_readonly;
+
 pub fn routes() -> Vec<Route> {
     let mut eq_domains_routes = routes![get_eq_domains, post_eq_domains, put_eq_domains];
     let mut hibp_routes = routes![hibp_breach];
@@ -111,6 +113,8 @@ async fn post_eq_domains(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let data: EquivDomainData = data.into_inner();
 
     let excluded_globals = data.excluded_global_equivalent_domains.unwrap_or_default();
@@ -131,6 +135,8 @@ async fn post_eq_domains(
 
 #[put("/settings/domains", data = "<data>")]
 async fn put_eq_domains(data: Json<EquivDomainData>, headers: Headers, conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     post_eq_domains(data, headers, conn, nt).await
 }
 

--- a/src/api/core/public.rs
+++ b/src/api/core/public.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use crate::{
     api::EmptyResult,
     auth,
+    config::not_readonly,
     db::{models::*, DbConn},
     mail, CONFIG,
 };
@@ -45,6 +46,8 @@ struct OrgImportData {
 
 #[post("/public/organization/import", data = "<data>")]
 async fn ldap_import(data: Json<OrgImportData>, token: PublicToken, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     // Most of the logic for this function can be found here
     // https://github.com/bitwarden/server/blob/fd892b2ff4547648a276734fb2b14a8abae2c6f5/src/Core/Services/Implementations/OrganizationService.cs#L1797
 

--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use crate::{
     api::{ApiResult, EmptyResult, JsonResult, Notify, UpdateType},
     auth::{ClientIp, Headers, Host},
+    config::not_readonly,
     db::{models::*, DbConn, DbPool},
     util::{NumberOrString, SafeString},
     CONFIG,
@@ -173,6 +174,8 @@ async fn get_send(uuid: &str, headers: Headers, mut conn: DbConn) -> JsonResult 
 
 #[post("/sends", data = "<data>")]
 async fn post_send(data: Json<SendData>, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let data: SendData = data.into_inner();
@@ -212,6 +215,8 @@ struct UploadDataV2<'f> {
 // Upstream: https://github.com/bitwarden/server/blob/d0c793c95181dfb1b447eb450f85ba0bfd7ef643/src/Api/Controllers/SendsController.cs#L164-L167
 #[post("/sends/file", format = "multipart/form-data", data = "<data>")]
 async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let UploadData {
@@ -289,6 +294,8 @@ async fn post_send_file(data: Form<UploadData<'_>>, headers: Headers, mut conn: 
 // Upstream: https://github.com/bitwarden/server/blob/d0c793c95181dfb1b447eb450f85ba0bfd7ef643/src/Api/Controllers/SendsController.cs#L190
 #[post("/sends/file/v2", data = "<data>")]
 async fn post_send_file_v2(data: Json<SendData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let data = data.into_inner();
@@ -359,6 +366,8 @@ async fn post_send_file_v2_data(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> EmptyResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let mut data = data.into_inner();
@@ -408,6 +417,8 @@ async fn post_access(
     ip: ClientIp,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let mut send = match Send::find_by_access_id(access_id, &mut conn).await {
         Some(s) => s,
         None => err_code!(SEND_INACCESSIBLE_MSG, 404),
@@ -469,6 +480,8 @@ async fn post_access_file(
     mut conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    not_readonly()?;
+
     let mut send = match Send::find_by_uuid(send_id, &mut conn).await {
         Some(s) => s,
         None => err_code!(SEND_INACCESSIBLE_MSG, 404),
@@ -536,6 +549,8 @@ async fn download_send(send_id: SafeString, file_id: SafeString, t: &str) -> Opt
 
 #[put("/sends/<id>", data = "<data>")]
 async fn put_send(id: &str, data: Json<SendData>, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let data: SendData = data.into_inner();
@@ -611,6 +626,8 @@ pub async fn update_send_from_data(
 
 #[delete("/sends/<id>")]
 async fn delete_send(id: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> EmptyResult {
+    not_readonly()?;
+
     let send = match Send::find_by_uuid(id, &mut conn).await {
         Some(s) => s,
         None => err!("Send not found"),
@@ -635,6 +652,8 @@ async fn delete_send(id: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_
 
 #[put("/sends/<id>/remove-password")]
 async fn put_remove_password(id: &str, headers: Headers, mut conn: DbConn, nt: Notify<'_>) -> JsonResult {
+    not_readonly()?;
+
     enforce_disable_send_policy(&headers, &mut conn).await?;
 
     let mut send = match Send::find_by_uuid(id, &mut conn).await {

--- a/src/api/core/two_factor/authenticator.rs
+++ b/src/api/core/two_factor/authenticator.rs
@@ -5,6 +5,7 @@ use rocket::Route;
 use crate::{
     api::{core::log_user_event, core::two_factor::_generate_recover_code, EmptyResult, JsonResult, PasswordOrOtpData},
     auth::{ClientIp, Headers},
+    config::not_readonly,
     crypto,
     db::{
         models::{EventType, TwoFactor, TwoFactorType},
@@ -52,6 +53,8 @@ struct EnableAuthenticatorData {
 
 #[post("/two-factor/authenticator", data = "<data>")]
 async fn activate_authenticator(data: Json<EnableAuthenticatorData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: EnableAuthenticatorData = data.into_inner();
     let key = data.key;
     let token = data.token.into_string();
@@ -91,6 +94,8 @@ async fn activate_authenticator(data: Json<EnableAuthenticatorData>, headers: He
 
 #[put("/two-factor/authenticator", data = "<data>")]
 async fn activate_authenticator_put(data: Json<EnableAuthenticatorData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     activate_authenticator(data, headers, conn).await
 }
 

--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -9,6 +9,7 @@ use crate::{
         PasswordOrOtpData,
     },
     auth::Headers,
+    config::not_readonly,
     crypto,
     db::{
         models::{EventType, TwoFactor, TwoFactorType, User},
@@ -156,6 +157,8 @@ fn check_duo_fields_custom(data: &EnableDuoData) -> bool {
 
 #[post("/two-factor/duo", data = "<data>")]
 async fn activate_duo(data: Json<EnableDuoData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: EnableDuoData = data.into_inner();
     let mut user = headers.user;
 
@@ -194,6 +197,8 @@ async fn activate_duo(data: Json<EnableDuoData>, headers: Headers, mut conn: DbC
 
 #[put("/two-factor/duo", data = "<data>")]
 async fn activate_duo_put(data: Json<EnableDuoData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     activate_duo(data, headers, conn).await
 }
 

--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -8,6 +8,7 @@ use crate::{
         EmptyResult, JsonResult, PasswordOrOtpData,
     },
     auth::Headers,
+    config::not_readonly,
     crypto,
     db::{
         models::{EventType, TwoFactor, TwoFactorType, User},
@@ -113,6 +114,8 @@ struct SendEmailData {
 /// Send a verification email to the specified email address to check whether it exists/belongs to user.
 #[post("/two-factor/send-email", data = "<data>")]
 async fn send_email(data: Json<SendEmailData>, headers: Headers, mut conn: DbConn) -> EmptyResult {
+    not_readonly()?;
+
     let data: SendEmailData = data.into_inner();
     let user = headers.user;
 
@@ -157,6 +160,8 @@ struct EmailData {
 /// Verify email belongs to user and can be used for 2FA email codes.
 #[put("/two-factor/email", data = "<data>")]
 async fn email(data: Json<EmailData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: EmailData = data.into_inner();
     let mut user = headers.user;
 

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         EmptyResult, JsonResult, PasswordOrOtpData,
     },
     auth::{ClientHeaders, Headers},
+    config::not_readonly,
     crypto,
     db::{models::*, DbConn, DbPool},
     mail,
@@ -80,6 +81,8 @@ struct RecoverTwoFactor {
 
 #[post("/two-factor/recover", data = "<data>")]
 async fn recover(data: Json<RecoverTwoFactor>, client_headers: ClientHeaders, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: RecoverTwoFactor = data.into_inner();
 
     use crate::db::models::User;
@@ -137,6 +140,8 @@ struct DisableTwoFactorData {
 
 #[post("/two-factor/disable", data = "<data>")]
 async fn disable_twofactor(data: Json<DisableTwoFactorData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: DisableTwoFactorData = data.into_inner();
     let user = headers.user;
 
@@ -169,6 +174,8 @@ async fn disable_twofactor(data: Json<DisableTwoFactorData>, headers: Headers, m
 
 #[put("/two-factor/disable", data = "<data>")]
 async fn disable_twofactor_put(data: Json<DisableTwoFactorData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     disable_twofactor(data, headers, conn).await
 }
 

--- a/src/api/core/two_factor/webauthn.rs
+++ b/src/api/core/two_factor/webauthn.rs
@@ -10,6 +10,7 @@ use crate::{
         EmptyResult, JsonResult, PasswordOrOtpData,
     },
     auth::Headers,
+    config::not_readonly,
     db::{
         models::{EventType, TwoFactor, TwoFactorType},
         DbConn,
@@ -126,6 +127,8 @@ async fn get_webauthn(data: Json<PasswordOrOtpData>, headers: Headers, mut conn:
 
 #[post("/two-factor/get-webauthn-challenge", data = "<data>")]
 async fn generate_webauthn_challenge(data: Json<PasswordOrOtpData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: PasswordOrOtpData = data.into_inner();
     let user = headers.user;
 
@@ -239,6 +242,8 @@ impl From<PublicKeyCredentialCopy> for PublicKeyCredential {
 
 #[post("/two-factor/webauthn", data = "<data>")]
 async fn activate_webauthn(data: Json<EnableWebauthnData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: EnableWebauthnData = data.into_inner();
     let mut user = headers.user;
 
@@ -292,6 +297,8 @@ async fn activate_webauthn(data: Json<EnableWebauthnData>, headers: Headers, mut
 
 #[put("/two-factor/webauthn", data = "<data>")]
 async fn activate_webauthn_put(data: Json<EnableWebauthnData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     activate_webauthn(data, headers, conn).await
 }
 
@@ -304,6 +311,8 @@ struct DeleteU2FData {
 
 #[delete("/two-factor/webauthn", data = "<data>")]
 async fn delete_webauthn(data: Json<DeleteU2FData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let id = data.id.into_i32()?;
     if !headers.user.check_valid_password(&data.master_password_hash) {
         err!("Invalid password");

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -9,6 +9,7 @@ use crate::{
         EmptyResult, JsonResult, PasswordOrOtpData,
     },
     auth::Headers,
+    config::not_readonly,
     db::{
         models::{EventType, TwoFactor, TwoFactorType},
         DbConn,
@@ -117,6 +118,8 @@ async fn generate_yubikey(data: Json<PasswordOrOtpData>, headers: Headers, mut c
 
 #[post("/two-factor/yubikey", data = "<data>")]
 async fn activate_yubikey(data: Json<EnableYubikeyData>, headers: Headers, mut conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     let data: EnableYubikeyData = data.into_inner();
     let mut user = headers.user;
 
@@ -178,6 +181,8 @@ async fn activate_yubikey(data: Json<EnableYubikeyData>, headers: Headers, mut c
 
 #[put("/two-factor/yubikey", data = "<data>")]
 async fn activate_yubikey_put(data: Json<EnableYubikeyData>, headers: Headers, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     activate_yubikey(data, headers, conn).await
 }
 

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -18,6 +18,7 @@ use crate::{
         ApiResult, EmptyResult, JsonResult,
     },
     auth::{generate_organization_api_key_login_claims, ClientHeaders, ClientIp},
+    config::not_readonly,
     db::{models::*, DbConn},
     error::MapResult,
     mail, util, CONFIG,
@@ -681,6 +682,8 @@ async fn prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
 
 #[post("/accounts/register", data = "<data>")]
 async fn identity_register(data: Json<RegisterData>, conn: DbConn) -> JsonResult {
+    not_readonly()?;
+
     _register(data, conn).await
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,6 +507,9 @@ make_config! {
 
         /// Events days retain |> Number of days to retain events stored in the database. If unset, events are kept indefinitely.
         events_days_retain:     i64,    false,   option;
+
+        /// Read-Only Mode |> Prevent writing of data but logins are still allowed.
+        readonly:     bool,    false,   def,  false;
     },
 
     /// Advanced settings
@@ -1008,6 +1011,10 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         }
     }
 
+    if cfg.readonly {
+        println!("[NOTICE] Read-Only Mode is enabled");
+    }
+
     if cfg.increase_note_size_limit {
         println!("[WARNING] Secure Note size limit is increased to 100_000!");
         println!("[WARNING] This could cause issues with clients. Also exports will not work on Bitwarden servers!.");
@@ -1275,6 +1282,16 @@ impl Config {
             if let Some(handle) = c.rocket_shutdown_handle.take() {
                 handle.notify();
             }
+        }
+    }
+}
+
+pub fn not_readonly() -> Result<(), Error> {
+    match CONFIG.readonly() {
+        false => Ok(()),
+        true => {
+            let msg = "The server is in read-only mode";
+            Err(Error::new(msg, msg))
         }
     }
 }

--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -1,4 +1,9 @@
 <main class="container-xl">
+    {{#if page_data.readonly}}
+    <div id="readonly_mode" class="alert alert-info fade show">
+        Read-Only Mode is enabled. This means no password changes, new accounts, or other modifications can be made.
+    </div>
+    {{/if}}
     <div id="diagnostics-block" class="my-3 p-3 rounded shadow">
         <h6 class="border-bottom pb-2 mb-2">Diagnostics</h6>
 

--- a/src/static/templates/admin/organizations.hbs
+++ b/src/static/templates/admin/organizations.hbs
@@ -1,4 +1,9 @@
 <main class="container-xl">
+    {{#if page_data.readonly}}
+    <div id="readonly_mode" class="alert alert-info fade show">
+        Read-Only Mode is enabled. This means no password changes, new accounts, or other modifications can be made.
+    </div>
+    {{/if}}
     <div id="organizations-block" class="my-3 p-3 rounded shadow">
         <h6 class="border-bottom pb-2 mb-3">Organizations</h6>
         <div class="table-responsive-xl small">
@@ -14,7 +19,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each page_data}}
+                    {{#each page_data.organizations}}
                     <tr>
                         <td>
                             <svg width="48" height="48" class="float-start me-2 rounded" data-jdenticon-value="{{id}}">

--- a/src/static/templates/admin/settings.hbs
+++ b/src/static/templates/admin/settings.hbs
@@ -5,6 +5,11 @@
         Please generate a secure Argon2 PHC string by using `vaultwarden hash` or `argon2`.<br>
         See: <a href="https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page#secure-the-admin_token" target="_blank" rel="noopener noreferrer">Enabling admin page - Secure the `ADMIN_TOKEN`</a>
     </div>
+    {{#if page_data.readonly}}
+    <div id="readonly_mode" class="alert alert-info fade show">
+        Read-Only Mode is enabled. This means no password changes, new accounts, or other modifications can be made.
+    </div>
+    {{/if}}
     <div id="config-block" class="align-items-center p-3 mb-3 bg-secondary rounded shadow">
         <div>
             <h6 class="text-white mb-3">Configuration</h6>

--- a/src/static/templates/admin/users.hbs
+++ b/src/static/templates/admin/users.hbs
@@ -1,4 +1,9 @@
 <main class="container-xl">
+    {{#if page_data.readonly}}
+    <div id="readonly_mode" class="alert alert-info fade show">
+        Read-Only Mode is enabled. This means no password changes, new accounts, or other modifications can be made.
+    </div>
+    {{/if}}
     <div id="users-block" class="my-3 p-3 rounded shadow">
         <h6 class="border-bottom pb-2 mb-3">Registered Users</h6>
         <div class="table-responsive-xl small">
@@ -15,7 +20,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each page_data}}
+                    {{#each page_data.users}}
                     <tr>
                         <td>
                             <svg width="48" height="48" class="float-start me-2 rounded" data-jdenticon-value="{{email}}">


### PR DESCRIPTION
Implementation of https://github.com/dani-garcia/vaultwarden/discussions/4780

This allows to set ENV variable `READONLY=1` which forbids `POST` `PUT` `DELETE` requests with exceptions for stuff that's required to login.

First i wanted to create a middleware but rocket only has fairings which cannot respond on their own so i instead put a guard in all `POST` `PUT` `DELETE` requests.

I tested it with authenticator and email 2fa which still work the others i'm only 80% sure (for webauthn only 50%).

`post("/accounts/api-key")` is only forbidden if `api_key.is_none()` since that would cause a write.

In organisations some responses returned `Json<Value>` which i changed to `JsonResult`

Using a recovery token to login is not allowed since that would permanently disable 2fa which is a write. The rationale for disallowing 2fa changes is that it may cause people to think "ok i don't need that 2nd factor anymore" and then delete it only to come back and find the 2fa is still enabled since the data on that instance was overwritten from the primary one which still hat 2fa enabled.

On the admin interface there is an info popup announcing the Read-Only Mode but config changes are still allowed.

I don't know how to get a popup for the Vault especially one that's visible on arbitrary clients.
