### PR TITLE
fix issue with adding ciphers to organizations on native ios app

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -208,6 +208,7 @@ pub struct CipherData {
     // Folder id is not included in import
     folder_id: Option<String>,
     // TODO: Some of these might appear all the time, no need for Option
+    #[serde(alias = "organizationID")]
     pub organization_id: Option<String>,
 
     key: Option<String>,

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -287,6 +287,10 @@ async fn post_ciphers_create(
     if data.cipher.organization_id.is_some() && data.collection_ids.is_empty() {
         err!("You must select at least one collection.");
     }
+    // reverse sanity check to prevent corruptions
+    if !data.collection_ids.is_empty() && data.cipher.organization_id.is_none() {
+        err!("The client has not provided an organization id!");
+    }
 
     // This check is usually only needed in update_cipher_from_data(), but we
     // need it here as well to avoid creating an empty cipher in the call to


### PR DESCRIPTION
This should fix the issues reported in #4767 where an entry added via the native iOS app cannot be decrypted:
![Screenshot 2024-07-30 at 08-46-28 353277473-652ee101-fd1e-4a6d-af6a-510dd90f4994 mp4](https://github.com/user-attachments/assets/73be06a8-ca61-4a8c-9355-7ab210c4286e)

The problem seems to be that the iOS app sends an [organizationID](https://github.com/bitwarden/ios/blob/3ec242eb73735608fbed32837303b22ceb531abb/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift#L47) which serde fails to deseralize and because it's an optional argument adding the cipher will not fail but it will be added incorrectly to your personal vault, unless you have disabled personal ownerships. So to prevent such corruptions from occurring again I've added a reverse sanity check, just in case some other clients send the organization_id in an unrecognizable format.