### PR TITLE
make access_all optional

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1297,7 +1297,7 @@ struct EditUserData {
     r#type: NumberOrString,
     collections: Option<Vec<CollectionData>>,
     groups: Option<Vec<String>>,
-    access_all: bool,
+    access_all: Option<bool>,
 }
 
 #[put("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
@@ -1370,7 +1370,7 @@ async fn edit_user(
         }
     }
 
-    user_to_edit.access_all = data.access_all;
+    user_to_edit.access_all = data.access_all.unwrap_or(false);
     user_to_edit.atype = new_type as i32;
 
     // Delete all the odd collections
@@ -1379,7 +1379,7 @@ async fn edit_user(
     }
 
     // If no accessAll, add the collections received
-    if !data.access_all {
+    if !data.access_all.unwrap_or(false) {
         for col in data.collections.iter().flatten() {
             match Collection::find_by_uuid_and_org(&col.id, org_id, &mut conn).await {
                 None => err!("Collection not found in Organization"),

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -844,7 +844,8 @@ struct InviteData {
     groups: Vec<String>,
     r#type: NumberOrString,
     collections: Option<Vec<CollectionData>>,
-    access_all: Option<bool>,
+    #[serde(default)]
+    access_all: bool,
 }
 
 #[post("/organizations/<org_id>/users/invite", data = "<data>")]
@@ -896,7 +897,7 @@ async fn send_invite(org_id: &str, data: Json<InviteData>, headers: AdminHeaders
         };
 
         let mut new_user = UserOrganization::new(user.uuid.clone(), String::from(org_id));
-        let access_all = data.access_all.unwrap_or(false);
+        let access_all = data.access_all;
         new_user.access_all = access_all;
         new_user.atype = new_type;
         new_user.status = user_org_status;
@@ -1297,7 +1298,8 @@ struct EditUserData {
     r#type: NumberOrString,
     collections: Option<Vec<CollectionData>>,
     groups: Option<Vec<String>>,
-    access_all: Option<bool>,
+    #[serde(default)]
+    access_all: bool,
 }
 
 #[put("/organizations/<org_id>/users/<org_user_id>", data = "<data>", rank = 1)]
@@ -1370,7 +1372,7 @@ async fn edit_user(
         }
     }
 
-    user_to_edit.access_all = data.access_all.unwrap_or(false);
+    user_to_edit.access_all = data.access_all;
     user_to_edit.atype = new_type as i32;
 
     // Delete all the odd collections
@@ -1379,7 +1381,7 @@ async fn edit_user(
     }
 
     // If no accessAll, add the collections received
-    if !data.access_all.unwrap_or(false) {
+    if !data.access_all {
         for col in data.collections.iter().flatten() {
             match Collection::find_by_uuid_and_org(&col.id, org_id, &mut conn).await {
                 None => err!("Collection not found in Organization"),
@@ -2223,7 +2225,8 @@ async fn get_groups(org_id: &str, _headers: ManagerHeadersLoose, mut conn: DbCon
 #[serde(rename_all = "camelCase")]
 struct GroupRequest {
     name: String,
-    access_all: Option<bool>,
+    #[serde(default)]
+    access_all: bool,
     external_id: Option<String>,
     collections: Vec<SelectionReadOnly>,
     users: Vec<String>,
@@ -2231,17 +2234,12 @@ struct GroupRequest {
 
 impl GroupRequest {
     pub fn to_group(&self, organizations_uuid: &str) -> Group {
-        Group::new(
-            String::from(organizations_uuid),
-            self.name.clone(),
-            self.access_all.unwrap_or(false),
-            self.external_id.clone(),
-        )
+        Group::new(String::from(organizations_uuid), self.name.clone(), self.access_all, self.external_id.clone())
     }
 
     pub fn update_group(&self, mut group: Group) -> Group {
         group.name.clone_from(&self.name);
-        group.access_all = self.access_all.unwrap_or(false);
+        group.access_all = self.access_all;
         // Group Updates do not support changing the external_id
         // These input fields are in a disabled state, and can only be updated/added via ldap_import
 


### PR DESCRIPTION
As noted here https://github.com/dani-garcia/vaultwarden/issues/4775#issuecomment-2251024214 the `access_all` flag has been removed in the newer web-vaults resulting in an error when editing a user:
```
[2024-08-01 13:29:25.313][vaultwarden::api::core::organizations::_][WARN] Data guard `Json < EditUserData >` failed: Parse("{\"collections\":[{\"id\":\"64256828-6251-4bef-8dee-2128b63f520a\",\"readOnly\":true,\"hidePasswords\":false,\"manage\":false}],\"groups\":[],\"permissions\":{\"response\":null},\"type\":0}", Error("missing field `accessAll`", line: 1, column: 169)).
```

Note: Since newer web-vaults don't have the `access_all` flag anymore, it will be removed if you update a user with that permission. Due to the new view admins/owners will also not see all items in the password manager anymore, but only to items in collections they have explicit view access to (either directly or via a group).

This is purely a fix to make it compatible with newer versions of the web-vault (`web-v2024.6.3` and later). [Bitwarden stated that](https://bitwarden.com/help/user-types-access-control/#member-roles) they will deprecate "the **Access all existing and future collections** permission" and change "all users that had this permission the **Can manage** permission for all existing collections" when migrating existing users to the new collection management system. This does not (currently) apply to Vaultwarden as we have not implemented this yet. They also removed the Manager role, so I'm not sure if that's the appropriate course of action, giving all users with access_all the ability to manage who has access to collections... :grimacing: