### PR TITLE
Remove lowercase conversion for featureStates

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -730,8 +730,7 @@ pub fn convert_json_key_lcase_first(src_json: Value) -> Value {
 
 /// Parses the experimental client feature flags string into a HashMap.
 pub fn parse_experimental_client_feature_flags(experimental_client_feature_flags: &str) -> HashMap<String, bool> {
-    let feature_states =
-        experimental_client_feature_flags.to_lowercase().split(',').map(|f| (f.trim().to_owned(), true)).collect();
+    let feature_states = experimental_client_feature_flags.split(',').map(|f| (f.trim().to_owned(), true)).collect();
 
     feature_states
 }


### PR DESCRIPTION
- needed to match Bitwarden, some of the feature flags might have uppercase characters (for example: ```PM-4154-bulk-encryption-service```)