### PR TITLE
Fix data disclosure on organization endpoints

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -737,6 +737,19 @@ impl UserOrganization {
         }}
     }
 
+    pub async fn find_confirmed_by_user_and_org(user_uuid: &str, org_uuid: &str, conn: &mut DbConn) -> Option<Self> {
+        db_run! { conn: {
+            users_organizations::table
+                .filter(users_organizations::user_uuid.eq(user_uuid))
+                .filter(users_organizations::org_uuid.eq(org_uuid))
+                .filter(
+                    users_organizations::status.eq(UserOrgStatus::Confirmed as i32)
+                )
+                .first::<UserOrganizationDb>(conn)
+                .ok().from_db()
+        }}
+    }
+
     pub async fn find_by_user(user_uuid: &str, conn: &mut DbConn) -> Vec<Self> {
         db_run! { conn: {
             users_organizations::table


### PR DESCRIPTION
- All users were able to request organizational details from any org, even if they were not a member (anymore). Now it will check if that user is a member of the org or not.
- The `/organization/<uuid>/keys` endpoint returned also the private keys. This should not be the case. Also, according to the upstream server code the endpoint changed, but the clients do not seem to use it. I added it anyway just in case they will in the future.
- Also require a valid login before being able to retreve those org keys. Upstream does not do this, but i see no reason why not.

Fixes: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-39925