### PR TITLE
Remove unecessary email normalization

### DIFF
--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -281,10 +281,6 @@ fn sign_duo_values(key: &str, email: &str, ikey: &str, prefix: &str, expire: i64
 }
 
 pub async fn validate_duo_login(email: &str, response: &str, conn: &mut DbConn) -> EmptyResult {
-    // email is as entered by the user, so it needs to be normalized before
-    // comparison with auth_user below.
-    let email = &email.to_lowercase();
-
     let split: Vec<&str> = response.split(':').collect();
     if split.len() != 2 {
         err!(


### PR DESCRIPTION
Hey,

Was checking the OIDC pr change and realized that this change was still present.
I forgot to include it in the recent https://github.com/dani-garcia/vaultwarden/pull/4779.

Note that for stronger guaranty that the email is correctly formatted (would apply to `duo_oidc.validate_duo_login` too):
 - Could change the parameter to `User`.
 - Could define a custom type for a formatted email and wrap it.