### PR TITLE
Include sqlite3 binaries in Docker images

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -139,7 +139,8 @@ RUN mkdir /data && \
         ca-certificates \
         curl \
         openssl \
-        tzdata
+        tzdata \
+        sqlite
 
 VOLUME /data
 EXPOSE 80

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -180,7 +180,8 @@ RUN mkdir /data && \
         curl \
         libmariadb-dev-compat \
         libpq5 \
-        openssl && \
+        openssl \
+        sqlite3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -217,7 +217,8 @@ RUN mkdir /data && \
         curl \
         libmariadb-dev-compat \
         libpq5 \
-        openssl && \
+        openssl \
+        sqlite3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 {% elif base == "alpine" %}
@@ -225,7 +226,8 @@ RUN mkdir /data && \
         ca-certificates \
         curl \
         openssl \
-        tzdata
+        tzdata \
+        sqlite
 {% endif %}
 
 VOLUME /data


### PR DESCRIPTION
I understand that the runtime docker images are trimmed down for size. Regardless, I think that it makes sense to have the sqlite3 binaries as part of the images because it makes backups way easier without having to resort to other images/containers or having sqlite installed on the docker host.

A cron-driven backup on the Docker host would then just be similar to the following cronjob (assuming a running container named `vaultwarden`)
```
0 0 * * * root /usr/bin/docker exec vaultwarden sqlite3 /data/db.sqlite3 "VACUUM INTO '/backup/db-$(date '+%Y%m%d-%H%M').sqlite3'"
```

If size of the images is more important, I understand, please decline the PR.