### PR TITLE
Update GitHub Action Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   build:
+    # We use Ubuntu 22.04 here because this matches the library versions used within the Debian docker containers
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     # Make warnings errors, this is to prevent warnings slipping through.
@@ -74,7 +75,7 @@ jobs:
 
       # Only install the clippy and rustfmt components on the default rust-toolchain
       - name: "Install rust-toolchain version"
-        uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17 # master @ Jun 13, 2024, 6:20 PM GMT+2
+        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master @ Aug 8, 2024, 7:36 PM GMT+2
         if: ${{ matrix.channel == 'rust-toolchain' }}
         with:
           toolchain: "${{steps.toolchain.outputs.RUST_TOOLCHAIN}}"
@@ -84,7 +85,7 @@ jobs:
 
       # Install the any other channel to be used for which we do not execute clippy and rustfmt
       - name: "Install MSRV version"
-        uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17 # master @ Jun 13, 2024, 6:20 PM GMT+2
+        uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master @ Aug 8, 2024, 7:36 PM GMT+2
         if: ${{ matrix.channel != 'rust-toolchain' }}
         with:
           toolchain: "${{steps.toolchain.outputs.RUST_TOOLCHAIN}}"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -8,13 +8,25 @@ on: [
 jobs:
   hadolint:
     name: Validate Dockerfile syntax
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       # Checkout the repo
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       # End Checkout the repo
+
+      # Start Docker Buildx
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+        # https://github.com/moby/buildkit/issues/3969
+        # Also set max parallelism to 2, the default of 4 breaks GitHub Actions and causes OOMKills
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+              max-parallelism = 2
+          driver-opts: |
+            network=host
 
       # Download hadolint - https://github.com/hadolint/hadolint/releases
       - name: Download hadolint
@@ -26,8 +38,18 @@ jobs:
           HADOLINT_VERSION: 2.12.0
       # End Download hadolint
 
-      # Test Dockerfiles
+      # Test Dockerfiles with hadolint
       - name: Run hadolint
         shell: bash
         run: hadolint docker/Dockerfile.{debian,alpine}
-      # End Test Dockerfiles
+      # End Test Dockerfiles with hadolint
+
+      # Test Dockerfiles with docker build checks
+      - name: Run docker build check
+        shell: bash
+        run: |
+          echo "Checking docker/Dockerfile.debian"
+          docker build --check . -f docker/Dockerfile.debian
+          echo "Checking docker/Dockerfile.alpine"
+          docker build --check . -f docker/Dockerfile.alpine
+      # End Test Dockerfiles with docker build checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   # Some checks to determine if we need to continue with building a new docker.
   # We will skip this check if we are creating a tag, because that has the same hash as a previous run already.
   skip_check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -27,7 +27,7 @@ jobs:
         if: ${{ github.ref_type == 'branch' }}
 
   docker-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     needs: skip_check
     if: ${{ needs.skip_check.outputs.should_skip != 'true' && github.repository == 'dani-garcia/vaultwarden' }}
@@ -69,13 +69,13 @@ jobs:
 
       # Start Docker Buildx
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@aa33708b10e362ff993539393ff100fa93ed6a27 # v3.5.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         # https://github.com/moby/buildkit/issues/3969
-        # Also set max parallelism to 3, the default of 4 breaks GitHub Actions and causes OOMKills
+        # Also set max parallelism to 2, the default of 4 breaks GitHub Actions and causes OOMKills
         with:
           buildkitd-config-inline: |
             [worker.oci]
-              max-parallelism = 3
+              max-parallelism = 2
           driver-opts: |
             network=host
 
@@ -165,7 +165,7 @@ jobs:
           echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}localhost:5000/vaultwarden/server" | tee -a "${GITHUB_ENV}"
 
       - name: Bake ${{ matrix.base_image }} containers
-        uses: docker/bake-action@a4d7f0b5b91c14a296d792d4ec53a9db17f02e67 # v5.5.0
+        uses: docker/bake-action@8cea75c238fa977d2ac1fa69d09604b3b740f809 # v5.6.1
         env:
           BASE_TAGS: "${{ env.BASE_TAGS }}"
           SOURCE_COMMIT: "${{ env.SOURCE_COMMIT }}"
@@ -223,28 +223,28 @@ jobs:
 
       # Upload artifacts to Github Actions
       - name: "Upload amd64 artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-amd64
           path: vaultwarden-amd64
 
       - name: "Upload arm64 artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-arm64
           path: vaultwarden-arm64
 
       - name: "Upload armv7 artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv7
           path: vaultwarden-armv7
 
       - name: "Upload armv6 artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         if: ${{ matrix.base_image == 'alpine' }}
         with:
           name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv6

--- a/.github/workflows/releasecache-cleanup.yml
+++ b/.github/workflows/releasecache-cleanup.yml
@@ -13,7 +13,7 @@ name: Cleanup
 jobs:
   releasecache-cleanup:
     name: Releasecache Cleanup
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 30
     steps:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   trivy-scan:
     name: Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
- Set the buildx parallel back to 2 again, 3 still produces issues
- Updated several workflows to use Ubuntu 24.04 Omitted the `build` workflow to keep the libraries the same as the Debian container images.
- Updated all actions
- Added `docker build --check` to the hadolint workflow