### PR TITLE
Switch to Whitelisting in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,40 +1,15 @@
-# Local build artifacts
-target
+// Ignore everything
+*
 
-# Data folder
-data
-
-# Misc
-.env
-.env.template
-.gitattributes
-.gitignore
-rustfmt.toml
-
-# IDE files
-.vscode
-.idea
-.editorconfig
-*.iml
-
-# Documentation
-.github
-*.md
-*.txt
-*.yml
-*.yaml
-
-# Docker
-hooks
-tools
-Dockerfile
-.dockerignore
-docker/**
+// Allow what is needed
+!.git
 !docker/healthcheck.sh
 !docker/start.sh
+!migrations
+!src
 
-# Web vault
-web-vault
-
-# Vaultwarden Resources
-resources
+!build.rs
+!Cargo.lock
+!Cargo.toml
+!rustfmt.toml
+!rust-toolchain.toml


### PR DESCRIPTION
Hey,

Recently mistakenly added `.git` to the `.dockerignore` in another PR because I thought it might be responsible for unnecessary rebuild (it was not anyway).

But with so many blacklisted element I think switching to a whitelist style is simpler.