### PR TITLE
Fix manager in web-vault v2024.6.2 for collections

### DIFF
--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -1,3 +1,7 @@
+use super::{User, UserOrgType, UserOrganization};
+use crate::api::EmptyResult;
+use crate::db::DbConn;
+use crate::error::MapResult;
 use chrono::{NaiveDateTime, Utc};
 use serde_json::Value;
 
@@ -69,7 +73,7 @@ impl Group {
         })
     }
 
-    pub async fn to_json_details(&self, conn: &mut DbConn) -> Value {
+    pub async fn to_json_details(&self, user_org_type: &i32, conn: &mut DbConn) -> Value {
         let collections_groups: Vec<Value> = CollectionGroup::find_by_group(&self.uuid, conn)
             .await
             .iter()
@@ -77,7 +81,8 @@ impl Group {
                 json!({
                     "id": entry.collections_uuid,
                     "readOnly": entry.read_only,
-                    "hidePasswords": entry.hide_passwords
+                    "hidePasswords": entry.hide_passwords,
+                    "manage": *user_org_type == UserOrgType::Manager && !entry.read_only && !entry.hide_passwords
                 })
             })
             .collect();
@@ -121,13 +126,6 @@ impl GroupUser {
         }
     }
 }
-
-use crate::db::DbConn;
-
-use crate::api::EmptyResult;
-use crate::error::MapResult;
-
-use super::{User, UserOrganization};
 
 /// Database methods
 impl Group {

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -1,9 +1,13 @@
 use chrono::{NaiveDateTime, Utc};
 use num_traits::FromPrimitive;
 use serde_json::Value;
-use std::cmp::Ordering;
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+};
 
 use super::{CollectionUser, Group, GroupUser, OrgPolicy, OrgPolicyType, TwoFactor, User};
+use crate::db::models::{Collection, CollectionGroup};
 use crate::CONFIG;
 
 db_object! {
@@ -453,15 +457,47 @@ impl UserOrganization {
         };
 
         let collections: Vec<Value> = if include_collections {
-            CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn)
+            // Get all collections for the user here already to prevent more queries
+            let cu: HashMap<String, CollectionUser> =
+                CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn)
+                    .await
+                    .into_iter()
+                    .map(|cu| (cu.collection_uuid.clone(), cu))
+                    .collect();
+
+            // Get all collection groups for this user to prevent there inclusion
+            let cg: HashSet<String> = CollectionGroup::find_by_user(&self.user_uuid, conn)
                 .await
-                .iter()
-                .map(|cu| {
-                    json!({
-                        "id": cu.collection_uuid,
-                        "readOnly": cu.read_only,
-                        "hidePasswords": cu.hide_passwords,
-                    })
+                .into_iter()
+                .map(|cg| cg.collections_uuid)
+                .collect();
+
+            Collection::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn)
+                .await
+                .into_iter()
+                .filter_map(|c| {
+                    let (read_only, hide_passwords, can_manage) = if self.has_full_access() {
+                        (false, false, self.atype == UserOrgType::Manager)
+                    } else if let Some(cu) = cu.get(&c.uuid) {
+                        (
+                            cu.read_only,
+                            cu.hide_passwords,
+                            self.atype == UserOrgType::Manager && !cu.read_only && !cu.hide_passwords,
+                        )
+                    // If previous checks failed it might be that this user has access via a group, but we should not return those elements here
+                    // Those are returned via a special group endpoint
+                    } else if cg.contains(&c.uuid) {
+                        return None;
+                    } else {
+                        (true, true, false)
+                    };
+
+                    Some(json!({
+                        "id": c.uuid,
+                        "readOnly": read_only,
+                        "hidePasswords": hide_passwords,
+                        "manage": can_manage,
+                    }))
                 })
                 .collect()
         } else {
@@ -474,6 +510,7 @@ impl UserOrganization {
             "name": user.name,
             "email": user.email,
             "externalId": self.external_id,
+            "avatarColor": user.avatar_color,
             "groups": groups,
             "collections": collections,
 


### PR DESCRIPTION
The web-vault v2024.6.2 we use needs some extra information to allow managers to actually be able to manage collections.

The v2024.6.2 web-vault has somewhat of a mixture of the newer roles and older manager roles. To at least fix this for the web-vault we bundle these changes will make the manager able to manage.

For future web-vaults we would need a lot more changes to be done to fix this in a better way though.

Fixes #4844