### PR TITLE
Fix Duo Redirect not using path

### DIFF
--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -357,7 +357,7 @@ pub async fn purge_duo_contexts(pool: DbPool) {
 // Construct the url that Duo should redirect users to.
 fn make_callback_url(client_name: &str) -> Result<String, Error> {
     // Get the location of this application as defined in the config.
-    let base = match Url::parse(CONFIG.domain().as_str()) {
+    let base = match Url::parse(&format!("{}/", CONFIG.domain())) {
         Ok(url) => url,
         Err(e) => err!(format!("Error parsing configured domain URL (check your domain configuration): {e:?}")),
     };


### PR DESCRIPTION
The URL crate treats `https://domain.tld/path` differently then `https://domain.tld/path/` the latter will make sure a `.join()` will append the given path instead of using the base as a relative path.

Fixes #4858