### PR TITLE
Fix Vaultwarden Admin page error messages

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -750,12 +750,18 @@ fn get_diagnostics_config(_token: AdminToken) -> Json<Value> {
 #[post("/config", data = "<data>")]
 fn post_config(data: Json<ConfigBuilder>, _token: AdminToken) -> EmptyResult {
     let data: ConfigBuilder = data.into_inner();
-    CONFIG.update_config(data)
+    if let Err(e) = CONFIG.update_config(data) {
+        err!(format!("Unable to save config: {e:?}"))
+    }
+    Ok(())
 }
 
 #[post("/config/delete")]
 fn delete_config(_token: AdminToken) -> EmptyResult {
-    CONFIG.delete_user_config()
+    if let Err(e) = CONFIG.delete_user_config() {
+        err!(format!("Unable to delete config: {e:?}"))
+    }
+    Ok(())
 }
 
 #[post("/config/backup_db")]

--- a/src/static/scripts/admin.js
+++ b/src/static/scripts/admin.js
@@ -49,8 +49,8 @@ function _post(url, successMsg, errMsg, body, reload_page = true) {
     }).then(respText => {
         try {
             const respJson = JSON.parse(respText);
-            if (respJson.ErrorModel && respJson.ErrorModel.Message) {
-                return respJson.ErrorModel.Message;
+            if (respJson.errorModel && respJson.errorModel.message) {
+                return respJson.errorModel.message;
             } else {
                 return Promise.reject({ body: `${respStatus} - ${respStatusText}\n\nUnknown error`, error: true });
             }


### PR DESCRIPTION
Since the change to camelCase variables the error messages in the Vaultwarden Admin were not shown correctly anymore.

This PR fixes this by changing the case of the json key's. Also updated the save and delete of the config to provide a more descriptive error instead of only `Io` or which ever other error might occure.

Fixes #4834