### PR TITLE
remove overzealous sanity check

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -287,10 +287,6 @@ async fn post_ciphers_create(
     if data.cipher.organization_id.is_some() && data.collection_ids.is_empty() {
         err!("You must select at least one collection.");
     }
-    // reverse sanity check to prevent corruptions
-    if !data.collection_ids.is_empty() && data.cipher.organization_id.is_none() {
-        err!("The client has not provided an organization id!");
-    }
 
     // This check is usually only needed in update_cipher_from_data(), but we
     // need it here as well to avoid creating an empty cipher in the call to


### PR DESCRIPTION
when cloning an item from an organization to the personal vault the client sends the collection id of the cloned item

cf. https://vaultwarden.discourse.group/t/moving-logins-between-organisations-clone-or-move-doesnt-work/3909