### PR TITLE
Allow custom umask setting

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -n "${UMASK}" ]; then
+    umask "${UMASK}"
+fi
+
 if [ -r /etc/vaultwarden.sh ]; then
     . /etc/vaultwarden.sh
 elif [ -r /etc/bitwarden_rs.sh ]; then


### PR DESCRIPTION
To provide a way to add more security regarding file/folder permissions this PR adds a way to allow setting a custom `UMASK` variable.

This allows people to set a more secure default like only allowing the owner the the process/container to read/write files and folders.

Examples:
 - `UMASK=022` File: 644 | Folder: 755 (Default of the containers)
    This means Owner read/write and group/world read-only
    
 - `UMASK=027` File: 640 | Folder: 750
    This means Owner read/write, group read-only, world no access
    
 - `UMASK=077` File: 600 | Folder: 700
    This means Owner read/write and group/world no access

resolves #4571