### PR TITLE
Add a CLI feature to backup the SQLite DB

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -384,9 +384,11 @@ pub async fn backup_database(conn: &mut DbConn) -> Result<String, Error> {
 pub fn backup_sqlite_database(conn: &mut diesel::sqlite::SqliteConnection) -> Result<String, Error> {
     use diesel::RunQueryDsl;
     let db_url = CONFIG.database_url();
-    let db_path = std::path::Path::new(&db_url).parent().unwrap().to_string_lossy();
-    let file_date = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
-    let backup_file = format!("{db_path}/db_{file_date}.sqlite3");
+    let db_path = std::path::Path::new(&db_url).parent().unwrap();
+    let backup_file = db_path
+        .join(format!("db_{}.sqlite3", chrono::Utc::now().format("%Y%m%d_%H%M%S")))
+        .to_string_lossy()
+        .into_owned();
     diesel::sql_query(format!("VACUUM INTO '{backup_file}'")).execute(conn)?;
     Ok(backup_file)
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -368,21 +368,27 @@ pub mod models;
 
 /// Creates a back-up of the sqlite database
 /// MySQL/MariaDB and PostgreSQL are not supported.
-pub async fn backup_database(conn: &mut DbConn) -> Result<(), Error> {
+pub async fn backup_database(conn: &mut DbConn) -> Result<String, Error> {
     db_run! {@raw conn:
         postgresql, mysql {
             let _ = conn;
             err!("PostgreSQL and MySQL/MariaDB do not support this backup feature");
         }
         sqlite {
-            use std::path::Path;
-            let db_url = CONFIG.database_url();
-            let db_path = Path::new(&db_url).parent().unwrap().to_string_lossy();
-            let file_date = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
-            diesel::sql_query(format!("VACUUM INTO '{db_path}/db_{file_date}.sqlite3'")).execute(conn)?;
-            Ok(())
+            backup_sqlite_database(conn)
         }
     }
+}
+
+#[cfg(sqlite)]
+pub fn backup_sqlite_database(conn: &mut diesel::sqlite::SqliteConnection) -> Result<String, Error> {
+    use diesel::RunQueryDsl;
+    let db_url = CONFIG.database_url();
+    let db_path = std::path::Path::new(&db_url).parent().unwrap().to_string_lossy();
+    let file_date = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
+    let backup_file = format!("{db_path}/db_{file_date}.sqlite3");
+    diesel::sql_query(format!("VACUUM INTO '{backup_file}'")).execute(conn)?;
+    Ok(backup_file)
 }
 
 /// Get the SQL Server version

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use std::{
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},
+    signal::unix::SignalKind,
 };
 
 #[macro_use]
@@ -97,10 +98,12 @@ USAGE:
 
 FLAGS:
     -h, --help       Prints help information
-    -v, --version    Prints the app version
+    -v, --version    Prints the app and web-vault version
 
 COMMAND:
     hash [--preset {bitwarden|owasp}]  Generate an Argon2id PHC ADMIN_TOKEN
+    backup                             Create a backup of the SQLite database
+                                       You can also send the USR1 signal to trigger a backup
 
 PRESETS:                  m=         t=          p=
     bitwarden (default) 64MiB, 3 Iterations, 4 Threads
@@ -115,11 +118,13 @@ fn parse_args() {
     let version = VERSION.unwrap_or("(Version info from Git not present)");
 
     if pargs.contains(["-h", "--help"]) {
-        println!("vaultwarden {version}");
+        println!("Vaultwarden {version}");
         print!("{HELP}");
         exit(0);
     } else if pargs.contains(["-v", "--version"]) {
-        println!("vaultwarden {version}");
+        let web_vault_version = util::get_web_vault_version();
+        println!("Vaultwarden {version}");
+        println!("Web-Vault {web_vault_version}");
         exit(0);
     }
 
@@ -174,13 +179,47 @@ fn parse_args() {
                     argon2_timer.elapsed()
                 );
             } else {
-                error!("Unable to generate Argon2id PHC hash.");
+                println!("Unable to generate Argon2id PHC hash.");
                 exit(1);
+            }
+        } else if command == "backup" {
+            match backup_sqlite() {
+                Ok(f) => {
+                    println!("Backup to '{f}' was successful");
+                    exit(0);
+                }
+                Err(e) => {
+                    println!("Backup failed. {e:?}");
+                    exit(1);
+                }
             }
         }
         exit(0);
     }
 }
+
+fn backup_sqlite() -> Result<String, Error> {
+    #[cfg(sqlite)]
+    {
+        use crate::db::{backup_sqlite_database, DbConnType};
+        if DbConnType::from_url(&CONFIG.database_url()).map(|t| t == DbConnType::sqlite).unwrap_or(false) {
+            use diesel::Connection;
+            let url = crate::CONFIG.database_url();
+
+            // Establish a connection to the sqlite database
+            let mut conn = diesel::sqlite::SqliteConnection::establish(&url)?;
+            let backup_file = backup_sqlite_database(&mut conn)?;
+            Ok(backup_file)
+        } else {
+            err_silent!("The database type is not SQLite. Backups only works for SQLite databases")
+        }
+    }
+    #[cfg(not(sqlite))]
+    {
+        err_silent!("The 'sqlite' feature is not enabled. Backups only works for SQLite databases")
+    }
+}
+
 fn launch_info() {
     println!(
         "\
@@ -346,7 +385,7 @@ fn init_logging() -> Result<log::LevelFilter, Error> {
         }
         #[cfg(not(windows))]
         {
-            const SIGHUP: i32 = tokio::signal::unix::SignalKind::hangup().as_raw_value();
+            const SIGHUP: i32 = SignalKind::hangup().as_raw_value();
             let path = Path::new(&log_file);
             logger = logger.chain(fern::log_reopen1(path, [SIGHUP])?);
         }
@@ -559,6 +598,22 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         info!("Exiting Vaultwarden!");
         CONFIG.shutdown();
     });
+
+    #[cfg(unix)]
+    {
+        tokio::spawn(async move {
+            let mut signal_user1 = tokio::signal::unix::signal(SignalKind::user_defined1()).unwrap();
+            loop {
+                // If we need more singles to act upon, we might want to use select! here.
+                // With only one item to listen for this is enough.
+                let _ = signal_user1.recv().await;
+                match backup_sqlite() {
+                    Ok(f) => info!("Backup to '{f}' was successful"),
+                    Err(e) => error!("Backup failed. {e:?}"),
+                }
+            }
+        });
+    }
 
     let _ = instance.launch().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,7 +604,7 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         tokio::spawn(async move {
             let mut signal_user1 = tokio::signal::unix::signal(SignalKind::user_defined1()).unwrap();
             loop {
-                // If we need more singles to act upon, we might want to use select! here.
+                // If we need more signals to act upon, we might want to use select! here.
                 // With only one item to listen for this is enough.
                 let _ = signal_user1.recv().await;
                 match backup_sqlite() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -513,6 +513,28 @@ pub fn container_base_image() -> &'static str {
     }
 }
 
+#[derive(Deserialize)]
+struct WebVaultVersion {
+    version: String,
+}
+
+pub fn get_web_vault_version() -> String {
+    let version_files = [
+        format!("{}/vw-version.json", CONFIG.web_vault_folder()),
+        format!("{}/version.json", CONFIG.web_vault_folder()),
+    ];
+
+    for version_file in version_files {
+        if let Ok(version_str) = std::fs::read_to_string(&version_file) {
+            if let Ok(version) = serde_json::from_str::<WebVaultVersion>(&version_str) {
+                return String::from(version.version.trim_start_matches('v'));
+            }
+        }
+    }
+
+    String::from("Version file missing")
+}
+
 //
 // Deserialization methods
 //


### PR DESCRIPTION
Many users request to add the sqlite3 binary to the container image. This isn't really ideal as that might bring in other dependencies and will only bloat the image. There main reason is to create a backup of the database.

While there already was a feature within the admin interface to do so (or by using the admin API call), this might not be easy.

This PR adds several ways to generate a backup.
1. By calling the Vaultwarden binary with the `backup` command like:
  - `/vaultwarden backup`
  - `docker exec -it vaultwarden /vaultwarden backup`
2. By sending the USR1 signal to the running process like:
  - `kill -s USR1 $(pidof vaultwarden)`
  - `killall -s USR1 vaultwarden`

This should help users to more easily create backups of there SQLite database.

Also added the Web-Vault version number when using `-v/--version` to the output.