### PR TITLE
Fix sync with new native clients

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -490,7 +490,7 @@ async fn post_rotatekey(data: Json<KeyData>, headers: Headers, mut conn: DbConn,
     // Bitwarden does not process the import if there is one item invalid.
     // Since we check for the size of the encrypted note length, we need to do that here to pre-validate it.
     // TODO: See if we can optimize the whole cipher adding/importing and prevent duplicate code and checks.
-    Cipher::validate_notes(&data.ciphers)?;
+    Cipher::validate_cipher_data(&data.ciphers)?;
 
     let user_uuid = &headers.user.uuid;
 

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -233,7 +233,7 @@ pub struct CipherData {
     favorite: Option<bool>,
     reprompt: Option<i32>,
 
-    password_history: Option<Value>,
+    pub password_history: Option<Value>,
 
     // These are used during key rotation
     // 'Attachments' is unused, contains map of {id: filename}
@@ -563,7 +563,7 @@ async fn post_ciphers_import(
     // Bitwarden does not process the import if there is one item invalid.
     // Since we check for the size of the encrypted note length, we need to do that here to pre-validate it.
     // TODO: See if we can optimize the whole cipher adding/importing and prevent duplicate code and checks.
-    Cipher::validate_notes(&data.ciphers)?;
+    Cipher::validate_cipher_data(&data.ciphers)?;
 
     // Read and create the folders
     let existing_folders: Vec<String> =

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1596,7 +1596,7 @@ async fn post_org_import(
     // Bitwarden does not process the import if there is one item invalid.
     // Since we check for the size of the encrypted note length, we need to do that here to pre-validate it.
     // TODO: See if we can optimize the whole cipher adding/importing and prevent duplicate code and checks.
-    Cipher::validate_notes(&data.ciphers)?;
+    Cipher::validate_cipher_data(&data.ciphers)?;
 
     let mut collections = Vec::new();
     for coll in data.collections {


### PR DESCRIPTION
This should fix syncing with the new native clients.

- Filter out password history items which have `null`
- Redesigned the Secure Note Type check to be more robust
- Check for `null` passwords in history during import (or key rotation)
  This should not be an issue during the key rotation, since we do not return the invalid password history items anymore.

Fixes #4870
Fixes #4921
