### PR TITLE
Fix collection update from native client

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -703,6 +703,7 @@ async fn put_cipher_partial(
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CollectionsAdminData {
+    #[serde(alias = "CollectionIds")]
     collection_ids: Vec<String>,
 }
 


### PR DESCRIPTION
For some strange reason the native clients send `CollectionIds` instead of `collectionIds` for updating the collection. Added an alias to allow this.

Fixes an issue reported via Matrix.