### PR TITLE
fix 2fa policy check on registration

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -112,7 +112,7 @@ async fn is_email_2fa_required(org_user_uuid: Option<String>, conn: &mut DbConn)
         return true;
     }
     if org_user_uuid.is_some() {
-        return OrgPolicy::is_enabled_by_org(&org_user_uuid.unwrap(), OrgPolicyType::TwoFactorAuthentication, conn)
+        return OrgPolicy::is_enabled_for_member(&org_user_uuid.unwrap(), OrgPolicyType::TwoFactorAuthentication, conn)
             .await;
     }
     false

--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -342,9 +342,11 @@ impl OrgPolicy {
         false
     }
 
-    pub async fn is_enabled_by_org(org_uuid: &str, policy_type: OrgPolicyType, conn: &mut DbConn) -> bool {
-        if let Some(policy) = OrgPolicy::find_by_org_and_type(org_uuid, policy_type, conn).await {
-            return policy.enabled;
+    pub async fn is_enabled_for_member(org_user_uuid: &str, policy_type: OrgPolicyType, conn: &mut DbConn) -> bool {
+        if let Some(membership) = UserOrganization::find_by_uuid(org_user_uuid, conn).await {
+            if let Some(policy) = OrgPolicy::find_by_org_and_type(&membership.org_uuid, policy_type, conn).await {
+                return policy.enabled;
+            }
         }
         false
     }


### PR DESCRIPTION
Email as 2FA provider has not automatically been setup by default for new invitations when the 2FA required policy was enabled because I did not check the correct uuid.