### PR TITLE
Add x.com/twitter.com alias

### DIFF
--- a/src/static/global_domains.json
+++ b/src/static/global_domains.json
@@ -971,5 +971,13 @@
       "pinterest.se"
     ],
     "excluded": false
+  },
+  {
+    "type": 91,
+    "domains": [
+      "twitter.com",
+      "x.com"
+    ],
+    "excluded": false
   }
 ]


### PR DESCRIPTION
Since twitter.com now redirects to x.com, accounts created on the old domain aren't detected automatically.

I just incremented the "type" number since that's what the rest of the file seemed to be doing, but if that's not correct then happy to change.