### PR TITLE
Fix Pw History null dates

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -190,10 +190,19 @@ impl Cipher {
             .map(|d| {
                 // Check every password history item if they are valid and return it.
                 // If a password field has the type `null` skip it, it breaks newer Bitwarden clients
+                // A second check is done to verify the lastUsedDate exists and is a string, if not the epoch start time will be used
                 d.into_iter()
                     .filter_map(|d| match d.data.get("password") {
                         Some(p) if p.is_string() => Some(d.data),
                         _ => None,
+                    })
+                    .map(|d| match d.get("lastUsedDate") {
+                        Some(l) if l.is_string() => d,
+                        _ => {
+                            let mut d = d;
+                            d["lastUsedDate"] = json!("1970-01-01T00:00:00.000Z");
+                            d
+                        }
                     })
                     .collect()
             })


### PR DESCRIPTION
It seemed to have been possible to have `null` date values. This PR fixes this by setting the epoch start date if either the date does not exists or is not a string.

This should solve sync issues with the new native mobile clients.

Fixes https://github.com/dani-garcia/vaultwarden/pull/4932#issuecomment-2357581292