### PR TITLE
remove backtics from postgresql migrations

### DIFF
--- a/migrations/postgresql/2024-09-04-091351_use_device_type_for_mails/down.sql
+++ b/migrations/postgresql/2024-09-04-091351_use_device_type_for_mails/down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `twofactor_incomplete` DROP COLUMN `device_type`;
+ALTER TABLE twofactor_incomplete DROP COLUMN device_type;

--- a/migrations/postgresql/2024-09-04-091351_use_device_type_for_mails/up.sql
+++ b/migrations/postgresql/2024-09-04-091351_use_device_type_for_mails/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `twofactor_incomplete` ADD COLUMN `device_type` INTEGER NOT NULL;
+ALTER TABLE twofactor_incomplete ADD COLUMN device_type INTEGER NOT NULL;


### PR DESCRIPTION
postgres does [not support backtics for escaping keywords](https://wiki.postgresql.org/wiki/Things_to_find_out_about_when_moving_from_MySQL_to_PostgreSQL) so we shouldn't use them in postgres migrations. 
should fix the issue reported here: https://github.com/dani-garcia/vaultwarden/pull/4916#issuecomment-2361033931