### PR TITLE
Fix field type to actually be hidden

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -186,7 +186,7 @@ impl Cipher {
                         match f.data.get("type") {
                             Some(t) if t.is_number() => {}
                             Some(t) if t.is_string() => {
-                                let type_num = &t.as_str().unwrap_or("0").parse::<u8>().unwrap_or(1);
+                                let type_num = &t.as_str().unwrap_or("1").parse::<u8>().unwrap_or(1);
                                 f.data["type"] = json!(type_num);
                             }
                             _ => {


### PR DESCRIPTION
In an oversight i forgot to set the type to a hidden type if converting the int was not possible. This fixes that.