### PR TITLE
Fix org invite url being html encoded

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -872,20 +872,19 @@ async fn send_invite(org_id: &str, data: Json<InviteData>, headers: AdminHeaders
     }
 
     for email in data.emails.iter() {
-        let email = email.to_lowercase();
         let mut user_org_status = UserOrgStatus::Invited as i32;
-        let user = match User::find_by_mail(&email, &mut conn).await {
+        let user = match User::find_by_mail(email, &mut conn).await {
             None => {
                 if !CONFIG.invitations_allowed() {
                     err!(format!("User does not exist: {email}"))
                 }
 
-                if !CONFIG.is_email_domain_allowed(&email) {
+                if !CONFIG.is_email_domain_allowed(email) {
                     err!("Email domain not eligible for invitations")
                 }
 
                 if !CONFIG.mail_enabled() {
-                    let invitation = Invitation::new(&email);
+                    let invitation = Invitation::new(email);
                     invitation.save(&mut conn).await?;
                 }
 

--- a/src/static/templates/email/send_org_invite.hbs
+++ b/src/static/templates/email/send_org_invite.hbs
@@ -3,7 +3,7 @@ Join {{{org_name}}}
 You have been invited to join the *{{org_name}}* organization.
 
 
-Click here to join: {{url}}
+Click here to join: {{{url}}}
 
 
 If you do not wish to join this organization, you can safely ignore this email.

--- a/src/static/templates/email/send_org_invite.html.hbs
+++ b/src/static/templates/email/send_org_invite.html.hbs
@@ -9,7 +9,7 @@ Join {{{org_name}}}
    </tr>
    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
       <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
-         <a href="{{url}}"
+         <a href="{{{url}}}"
             clicktracking=off target="_blank" style="color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #3c8dbc; border-color: #3c8dbc; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
          Join Organization Now
          </a>


### PR DESCRIPTION
Ever since we changed to pass the full url as a template value handlebars now html-encodes this. This causes issues with the plain/text mails, but it also could potentially cause issues with the text/html templates.

This PR encloses the template values inside triple braces `{{{ }}}` which prevents html-encoding. Since the URL is generated via the `url` crate the values are percent-encoded anyway.

Fixes #5097