### PR TITLE
Hide user name on invite status

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -232,6 +232,14 @@ impl UserOrganization {
         false
     }
 
+    /// Return the status of the user in an unrevoked state
+    pub fn get_unrevoked_status(&self) -> i32 {
+        if self.status <= UserOrgStatus::Revoked as i32 {
+            return self.status + ACTIVATE_REVOKE_DIFF;
+        }
+        self.status
+    }
+
     pub fn set_external_id(&mut self, external_id: Option<String>) -> bool {
         //Check if external id is empty. We don't want to have
         //empty strings in the database
@@ -524,7 +532,7 @@ impl UserOrganization {
         json!({
             "id": self.uuid,
             "userId": self.user_uuid,
-            "name": user.name,
+            "name": if self.get_unrevoked_status() >= UserOrgStatus::Accepted as i32 { Some(user.name) } else { None },
             "email": user.email,
             "externalId": self.external_id,
             "avatarColor": user.avatar_color,

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,10 +516,10 @@ async fn container_data_folder_is_persistent(data_folder: &str) -> bool {
             format!(" /{data_folder} ")
         };
         let mut lines = BufReader::new(mountinfo).lines();
+        let re = regex::Regex::new(r"/volumes/[a-z0-9]{64}/_data /").unwrap();
         while let Some(line) = lines.next_line().await.unwrap_or_default() {
             // Only execute a regex check if we find the base match
             if line.contains(&data_folder_match) {
-                let re = regex::Regex::new(r"/volumes/[a-z0-9]{64}/_data /").unwrap();
                 if re.is_match(&line) {
                     return false;
                 }


### PR DESCRIPTION
A possible user disclosure when you invite an user into an organization which already has an account on the same instance. This was because we always returned the user's name. To prevent this, this PR only returns the user's name if the status is accepted or higher, else we will return null. This is the same as Bitwarden does.

Resolves a reported issue.

Also resolved a new `nightly` reported clippy regarding a regex within a loop.