### PR TITLE
More authrequest fixes

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -165,22 +165,41 @@ async fn _password_login(
     // Set the user_uuid here to be passed back used for event logging.
     *user_uuid = Some(user.uuid.clone());
 
-    // Check password
-    let password = data.password.as_ref().unwrap();
-    if let Some(auth_request_uuid) = data.auth_request.clone() {
-        if let Some(auth_request) = AuthRequest::find_by_uuid(auth_request_uuid.as_str(), conn).await {
-            if !auth_request.check_access_code(password) {
-                err!(
-                    "Username or access code is incorrect. Try again",
-                    format!("IP: {}. Username: {}.", ip.ip, username),
-                    ErrorEvent {
-                        event: EventType::UserFailedLogIn,
-                    }
-                )
+    // Check if the user is disabled
+    if !user.enabled {
+        err!(
+            "This user has been disabled",
+            format!("IP: {}. Username: {}.", ip.ip, username),
+            ErrorEvent {
+                event: EventType::UserFailedLogIn
             }
-        } else {
+        )
+    }
+
+    let password = data.password.as_ref().unwrap();
+
+    // If we get an auth request, we don't check the user's password, but the access code of the auth request
+    if let Some(ref auth_request_uuid) = data.auth_request {
+        let Some(auth_request) = AuthRequest::find_by_uuid(auth_request_uuid.as_str(), conn).await else {
             err!(
                 "Auth request not found. Try again.",
+                format!("IP: {}. Username: {}.", ip.ip, username),
+                ErrorEvent {
+                    event: EventType::UserFailedLogIn,
+                }
+            )
+        };
+
+        // Delete the request after we used it
+        auth_request.delete(conn).await?;
+
+        if auth_request.user_uuid != user.uuid
+            || !auth_request.approved.unwrap_or(false)
+            || ip.ip.to_string() != auth_request.request_ip
+            || !auth_request.check_access_code(password)
+        {
+            err!(
+                "Username or access code is incorrect. Try again",
                 format!("IP: {}. Username: {}.", ip.ip, username),
                 ErrorEvent {
                     event: EventType::UserFailedLogIn,
@@ -197,25 +216,14 @@ async fn _password_login(
         )
     }
 
-    // Change the KDF Iterations
-    if user.password_iterations != CONFIG.password_iterations() {
+    // Change the KDF Iterations (only when not logging in with an auth request)
+    if data.auth_request.is_none() && user.password_iterations != CONFIG.password_iterations() {
         user.password_iterations = CONFIG.password_iterations();
         user.set_password(password, None, false, None);
 
         if let Err(e) = user.save(conn).await {
             error!("Error updating user: {:#?}", e);
         }
-    }
-
-    // Check if the user is disabled
-    if !user.enabled {
-        err!(
-            "This user has been disabled",
-            format!("IP: {}. Username: {}.", ip.ip, username),
-            ErrorEvent {
-                event: EventType::UserFailedLogIn
-            }
-        )
     }
 
     let now = Utc::now().naive_utc();


### PR DESCRIPTION
We were checking the user uuid against the authrequest uuid, which would always fail and error out.

Fixes https://github.com/dani-garcia/vaultwarden/issues/5174

I've also noticed that we were rotating the user password hash when login in with auth request (where instead of the password, a randomly generated access code is used), this could lead to inoperable accounts.

Also tried to delete the auth requests after they were used or denied, rather than waiting for the timer to clear them up.