### PR TITLE
Remove auth-request deletion

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -190,9 +190,6 @@ async fn _password_login(
             )
         };
 
-        // Delete the request after we used it
-        auth_request.delete(conn).await?;
-
         if auth_request.user_uuid != user.uuid
             || !auth_request.approved.unwrap_or(false)
             || ip.ip.to_string() != auth_request.request_ip


### PR DESCRIPTION
2FA is needed to login even when using login-with-device. If the user didn't saved the 2FA token they still need to provide this. We deleted the auth-request after validation the request, but before 2FA was triggered.

Removing the deletion of this record from that point as it will get cleaned-up automatically anyways.