### PR TITLE
Some more authrequest changes

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1190,11 +1190,19 @@ async fn put_auth_request(
         err!("AuthRequest doesn't exist", "User uuid's do not match")
     }
 
+    if auth_request.approved.is_some() {
+        err!("An authentication request with the same device already exists")
+    }
+
+    let response_date = Utc::now().naive_utc();
+    let response_date_utc = format_date(&response_date);
+
     if data.request_approved {
         auth_request.approved = Some(data.request_approved);
         auth_request.enc_key = Some(data.key);
         auth_request.master_password_hash = data.master_password_hash;
         auth_request.response_device_id = Some(data.device_identifier.clone());
+        auth_request.response_date = Some(response_date);
         auth_request.save(&mut conn).await?;
 
         ant.send_auth_response(&auth_request.user_uuid, &auth_request.uuid).await;
@@ -1203,8 +1211,6 @@ async fn put_auth_request(
         // If denied, there's no reason to keep the request
         auth_request.delete(&mut conn).await?;
     }
-
-    let response_date_utc = auth_request.response_date.map(|response_date| format_date(&response_date));
 
     Ok(Json(json!({
         "id": uuid,

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -190,8 +190,12 @@ async fn _password_login(
             )
         };
 
+        let expiration_time = auth_request.creation_date + chrono::Duration::minutes(5);
+        let request_expired = Utc::now().naive_utc() >= expiration_time;
+
         if auth_request.user_uuid != user.uuid
             || !auth_request.approved.unwrap_or(false)
+            || request_expired
             || ip.ip.to_string() != auth_request.request_ip
             || !auth_request.check_access_code(password)
         {


### PR DESCRIPTION
- Previously we weren't setting the response date anywhere, it doesn't seem used but might as well return it just in case.
- If an authentication request was approved already, we don't allow to do it again. This is to match with what Bitwarden is doing, though I don't think there's a way to actually do it or exploit it somehow.
- Added an explicit time limit for the auth requests, previously we relied on our scheduled job to clean them up, and a user could technically disable that.
