### PR TITLE
fix password hint check

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -842,7 +842,7 @@ struct PasswordHintData {
 
 #[post("/accounts/password-hint", data = "<data>")]
 async fn password_hint(data: Json<PasswordHintData>, mut conn: DbConn) -> EmptyResult {
-    if !CONFIG.mail_enabled() || !CONFIG.show_password_hint() {
+    if !CONFIG.password_hints_allowed() || (!CONFIG.mail_enabled() && !CONFIG.show_password_hint()) {
         err!("This server is not configured to provide password hints.");
     }
 


### PR DESCRIPTION
as noticed by @jjlin https://github.com/dani-garcia/vaultwarden/discussions/5179#discussioncomment-11230716 this is currently not correct.

don't show password hints if you have disabled the hints with `PASSWORD_HINTS_ALLOWED=false` or if you have not configured mail and opted into showing password hints