### PR TITLE
don't infer manage permission for groups

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -2305,14 +2305,14 @@ async fn _restore_organization_user(
 }
 
 #[get("/organizations/<org_id>/groups")]
-async fn get_groups(org_id: &str, headers: ManagerHeadersLoose, mut conn: DbConn) -> JsonResult {
+async fn get_groups(org_id: &str, _headers: ManagerHeadersLoose, mut conn: DbConn) -> JsonResult {
     let groups: Vec<Value> = if CONFIG.org_groups_enabled() {
         // Group::find_by_organization(&org_id, &mut conn).await.iter().map(Group::to_json).collect::<Value>()
         let groups = Group::find_by_organization(org_id, &mut conn).await;
         let mut groups_json = Vec::with_capacity(groups.len());
 
         for g in groups {
-            groups_json.push(g.to_json_details(&headers.org_user.atype, &mut conn).await)
+            groups_json.push(g.to_json_details(&mut conn).await)
         }
         groups_json
     } else {
@@ -2500,7 +2500,7 @@ async fn add_update_group(
 }
 
 #[get("/organizations/<_org_id>/groups/<group_id>/details")]
-async fn get_group_details(_org_id: &str, group_id: &str, headers: AdminHeaders, mut conn: DbConn) -> JsonResult {
+async fn get_group_details(_org_id: &str, group_id: &str, _headers: AdminHeaders, mut conn: DbConn) -> JsonResult {
     if !CONFIG.org_groups_enabled() {
         err!("Group support is disabled");
     }
@@ -2510,7 +2510,7 @@ async fn get_group_details(_org_id: &str, group_id: &str, headers: AdminHeaders,
         _ => err!("Group could not be found!"),
     };
 
-    Ok(Json(group.to_json_details(&(headers.org_user_type as i32), &mut conn).await))
+    Ok(Json(group.to_json_details(&mut conn).await))
 }
 
 #[post("/organizations/<org_id>/groups/<group_id>/delete")]

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -1,4 +1,4 @@
-use super::{User, UserOrgType, UserOrganization};
+use super::{User, UserOrganization};
 use crate::api::EmptyResult;
 use crate::db::DbConn;
 use crate::error::MapResult;
@@ -73,7 +73,7 @@ impl Group {
         })
     }
 
-    pub async fn to_json_details(&self, user_org_type: &i32, conn: &mut DbConn) -> Value {
+    pub async fn to_json_details(&self, conn: &mut DbConn) -> Value {
         let collections_groups: Vec<Value> = CollectionGroup::find_by_group(&self.uuid, conn)
             .await
             .iter()
@@ -82,7 +82,7 @@ impl Group {
                     "id": entry.collections_uuid,
                     "readOnly": entry.read_only,
                     "hidePasswords": entry.hide_passwords,
-                    "manage": *user_org_type >= UserOrgType::Admin || (*user_org_type == UserOrgType::Manager && !entry.read_only && !entry.hide_passwords)
+                    "manage": false
                 })
             })
             .collect();


### PR DESCRIPTION
the web-vault v2024.6.2 currently cannot deal with manage permission so instead of relying on the org user type this should just default to `false` (until we implement this correctly).

should fix #5160