### PR TITLE
Fix Org Import duplicate collections

### DIFF
--- a/src/api/core/two_factor/duo_oidc.rs
+++ b/src/api/core/two_factor/duo_oidc.rs
@@ -211,10 +211,7 @@ impl DuoClient {
             nonce,
         };
 
-        let token = match self.encode_duo_jwt(jwt_payload) {
-            Ok(token) => token,
-            Err(e) => return Err(e),
-        };
+        let token = self.encode_duo_jwt(jwt_payload)?;
 
         let authz_endpoint = format!("https://{}/oauth/v1/authorize", self.api_host);
         let mut auth_url = match Url::parse(authz_endpoint.as_str()) {


### PR DESCRIPTION
This fixes an issue with collections be duplicated same as was an issue with folders. Also made some optimizations by using HashSet where possible and define the Vec/Hash capacity. And instead of passing objects only use the UUID which was the only value we needed.

Also found an issue with importing a personal export via the Org import where folders are used. Since Org's do not use folder we needed to clear those out, same as Bitwarden does.

Fixes #5193