### PR TITLE
Adding token in the subject of 2fa emails

### DIFF
--- a/src/static/templates/email/twofactor_email.hbs
+++ b/src/static/templates/email/twofactor_email.hbs
@@ -1,4 +1,4 @@
-Vaultwarden Login Verification Code
+{{token}} Is Your Vaultwarden Login Verification Code
 <!---------------->
 Your two-step verification code is: {{token}}
 

--- a/src/static/templates/email/twofactor_email.html.hbs
+++ b/src/static/templates/email/twofactor_email.html.hbs
@@ -1,4 +1,4 @@
-Vaultwarden Login Verification Code
+{{token}} Is Your Vaultwarden Login Verification Code
 <!---------------->
 {{> email/email_header }}
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">


### PR DESCRIPTION
This PR Adds the 2FA token in the subject of 2FA emails. This allows user get the code more easily as it will be shown in the notification of most email mobile apps.

Example :

![photo_2024-11-23_11-49-43](https://github.com/user-attachments/assets/06ad1d8f-0bc2-4137-a534-11ca09370314)


![photo_2024-11-23_11-48-44](https://github.com/user-attachments/assets/93298b7b-203a-4dfe-b30e-908215755fcd)
