### PR TITLE
Fix another sync issue with native clients

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -511,7 +511,7 @@ pub async fn update_cipher_from_data(
     cipher.fields = data.fields.map(|f| _clean_cipher_data(f).to_string());
     cipher.data = type_data.to_string();
     cipher.password_history = data.password_history.map(|f| f.to_string());
-    cipher.reprompt = data.reprompt;
+    cipher.reprompt = data.reprompt.filter(|r| *r == RepromptType::None as i32 || *r == RepromptType::Password as i32);
 
     cipher.save(conn).await?;
     cipher.move_to_folder(data.folder_id, &headers.user.uuid, conn).await?;

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -46,10 +46,9 @@ db_object! {
     }
 }
 
-#[allow(dead_code)]
 pub enum RepromptType {
     None = 0,
-    Password = 1, // not currently used in server
+    Password = 1,
 }
 
 /// Local methods
@@ -296,7 +295,7 @@ impl Cipher {
             "creationDate": format_date(&self.created_at),
             "revisionDate": format_date(&self.updated_at),
             "deletedDate": self.deleted_at.map_or(Value::Null, |d| Value::String(format_date(&d))),
-            "reprompt": self.reprompt.unwrap_or(RepromptType::None as i32),
+            "reprompt": self.reprompt.filter(|r| *r == RepromptType::None as i32 || *r == RepromptType::Password as i32).unwrap_or(RepromptType::None as i32),
             "organizationId": self.organization_uuid,
             "key": self.key,
             "attachments": attachments_json,

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -18,7 +18,7 @@ mod user;
 
 pub use self::attachment::Attachment;
 pub use self::auth_request::AuthRequest;
-pub use self::cipher::Cipher;
+pub use self::cipher::{Cipher, RepromptType};
 pub use self::collection::{Collection, CollectionCipher, CollectionUser};
 pub use self::device::{Device, DeviceType};
 pub use self::emergency_access::{EmergencyAccess, EmergencyAccessStatus, EmergencyAccessType};


### PR DESCRIPTION
The `reprompt` value somehow sometimes has a value of `4`. This isn't a valid value, and doesn't cause issues with other clients, but the native clients are more strict.

This commit fixes this by validating the value before storing and returning.

Fixes #5237 