### PR TITLE
feat: mask _smtp_img_src in support string

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -248,6 +248,7 @@ macro_rules! make_config {
                     "smtp_from",
                     "smtp_host",
                     "smtp_username",
+                    "_smtp_img_src",
                 ];
 
                 let cfg = {


### PR DESCRIPTION
The following item in the support string should be masked as well, because it reveals the domain:

```
"_smtp_img_src": "https://vault.example.com/vw_static/",
```

P.S.: `domain` is masked, so it's kind of strange that it then shows up in `_smtp_img_src`