### PR TITLE
Allow adding connect-src entries

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -410,6 +410,14 @@
 ## Multiple values must be separated with a whitespace.
 # ALLOWED_IFRAME_ANCESTORS=
 
+## Allowed connect-src (Know the risks!)
+## https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
+## Allows other domains to URLs which can be loaded using script interfaces like the Forwarded email alias feature
+## This adds the configured value to the 'Content-Security-Policy' headers 'connect-src' value.
+## Multiple values must be separated with a whitespace. And only HTTPS values are allowed.
+## Example: "https://my-addy-io.domain.tld https://my-simplelogin.domain.tld"
+# ALLOWED_CONNECT_SRC=""
+
 ## Number of seconds, on average, between login requests from the same IP address before rate limiting kicks in.
 # LOGIN_RATELIMIT_SECONDS=60
 ## Allow a burst of requests of up to this size, while maintaining the average indicated by `LOGIN_RATELIMIT_SECONDS`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -98,10 +98,11 @@ impl Fairing for AppHeaders {
                   https://app.addy.io/api/ \
                   https://api.fastmail.com/ \
                   https://api.forwardemail.net \
-                  ;\
+                  {allowed_connect_src};\
                 ",
                 icon_service_csp = CONFIG._icon_service_csp(),
-                allowed_iframe_ancestors = CONFIG.allowed_iframe_ancestors()
+                allowed_iframe_ancestors = CONFIG.allowed_iframe_ancestors(),
+                allowed_connect_src = CONFIG.allowed_connect_src(),
             );
             res.set_raw_header("Content-Security-Policy", csp);
             res.set_raw_header("X-Frame-Options", "SAMEORIGIN");


### PR DESCRIPTION
Bitwarden allows to use self-hosted forwarded email services. But for this to work you need to add custom URL's to the `connect-src` CSP entry.

This commit allows setting this and checks if the URL starts with `https://` else it will abort loading.

Fixes #5290
