### PR TITLE
fix group issue in send_invite

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -907,7 +907,7 @@ async fn send_invite(org_id: &str, data: Json<InviteData>, headers: AdminHeaders
         new_user.save(&mut conn).await?;
 
         for group in data.groups.iter() {
-            let mut group_entry = GroupUser::new(String::from(group), user.uuid.clone());
+            let mut group_entry = GroupUser::new(String::from(group), new_user.uuid.clone());
             group_entry.save(&mut conn).await?;
         }
 


### PR DESCRIPTION
As pointed out in #5320 we have a small bug in this call:
> For example I noticed that we are passing the wrong id here:
> 
> https://github.com/dani-garcia/vaultwarden/blob/ed4ad67e732c213beaec78970cdb68e48bee3dc1/src/api/core/organizations.rs#L910
> 
> Because in contrast to `CollectionUser` the `GroupUser::new` actually expects a different id:
> 
> https://github.com/dani-garcia/vaultwarden/blob/ed4ad67e732c213beaec78970cdb68e48bee3dc1/src/db/models/group.rs#L122
> This was probably overlooked because it's not a major issue when a user is not correctly invited to a group and it only shows up as a small warning in the logs:
> 
> ```
> [2024-12-22 21:23:47.022][request][INFO] POST /api/organizations/152bd996-19f9-40ee-b991-e52333a7e719/users/invite
> [2024-12-22 21:23:47.031][vaultwarden::db::models::group][WARN] User could not be found!
> [2024-12-22 21:23:48.082][response][INFO] (send_invite) POST /api/organizations/<org_id>/users/invite => 200 OK
> ```

Since reviewing my other PR will probably take a while this is a separate fix to address this one issue I found and remembered.