### PR TITLE
Refactor the uri match fix and fix ssh-key sync

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -272,6 +272,19 @@ impl Cipher {
             }
         }
 
+        // Fix invalid SSH Entries
+        // This breaks at least the native mobile client if invalid
+        // The only way to fix this is by setting type_data_json to `null`
+        // Opening this ssh-key in the mobile client will probably crash the client, but you can edit, save and afterwards delete it
+        if self.atype == 5
+            && (type_data_json["keyFingerprint"].as_str().is_none_or(|v| v.is_empty())
+                || type_data_json["privateKey"].as_str().is_none_or(|v| v.is_empty())
+                || type_data_json["publicKey"].as_str().is_none_or(|v| v.is_empty()))
+        {
+            warn!("Error parsing ssh-key, mandatory fields are invalid for {}", self.uuid);
+            type_data_json = Value::Null;
+        }
+
         // Clone the type_data and add some default value.
         let mut data_json = type_data_json.clone();
 


### PR DESCRIPTION
## Refactor uri match

Refactored the uri match fix to also convert numbers within a string to an int. If it fails it will be null.

## Fix ssh-key sync

If any of the mandatory ssh-key json data values are not a string or are an empty string, this will break the mobile clients.
This commit fixes this by checking if any of the values are missing or invalid and converts the json data to `null`.
It will ensure the clients can sync and show the vault.

Fixes https://github.com/dani-garcia/vaultwarden/issues/5343
Fixes https://github.com/dani-garcia/vaultwarden/issues/5322