### PR TITLE
Fix issue with key-rotate

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -366,7 +366,12 @@ async fn post_password(data: Json<ChangePassData>, headers: Headers, mut conn: D
         &data.new_master_password_hash,
         Some(data.key),
         true,
-        Some(vec![String::from("post_rotatekey"), String::from("get_contacts"), String::from("get_public_keys")]),
+        Some(vec![
+            String::from("post_rotatekey"),
+            String::from("get_contacts"),
+            String::from("get_public_keys"),
+            String::from("get_api_webauthn"),
+        ]),
     );
 
     let save_result = user.save(&mut conn).await;

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -18,7 +18,7 @@ pub use sends::purge_sends;
 pub fn routes() -> Vec<Route> {
     let mut eq_domains_routes = routes![get_eq_domains, post_eq_domains, put_eq_domains];
     let mut hibp_routes = routes![hibp_breach];
-    let mut meta_routes = routes![alive, now, version, config];
+    let mut meta_routes = routes![alive, now, version, config, get_api_webauthn];
 
     let mut routes = Vec::new();
     routes.append(&mut accounts::routes());
@@ -182,6 +182,18 @@ pub fn now() -> Json<String> {
 #[get("/version")]
 fn version() -> Json<&'static str> {
     Json(crate::VERSION.unwrap_or_default())
+}
+
+#[get("/webauthn")]
+fn get_api_webauthn(_headers: Headers) -> Json<Value> {
+    // Prevent a 404 error, which also causes key-rotation issues
+    // It looks like this is used when login with passkeys is enabled, which Vaultwarden does not (yet) support
+    // An empty list/data also works fine
+    Json(json!({
+        "object": "list",
+        "data": [],
+        "continuationToken": null
+    }))
 }
 
 #[get("/config")]


### PR DESCRIPTION
The new web-vault seems to call an extra endpoint, which looks like it is only used when passkeys can be used for login. Since we do not support this (yet), we can just return an empty data object.