### PR TITLE
fix manager role in admin users overview

### DIFF
--- a/src/static/scripts/admin_users.js
+++ b/src/static/scripts/admin_users.js
@@ -152,7 +152,7 @@ const ORG_TYPES = {
         "name": "User",
         "bg": "blue"
     },
-    "3": {
+    "4": {
         "name": "Manager",
         "bg": "green"
     },


### PR DESCRIPTION
due to this hack the returned type in the overview has changed:
https://github.com/dani-garcia/vaultwarden/blob/ef4bff09eb4414117cd8ea25c809988872e2016b/src/db/models/organization.rs#L383-L385