### PR TITLE
Allow building with Rust v1.84.0 or newer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,10 @@ unused_import_braces = "deny"
 unused_lifetimes = "deny"
 unused_qualifications = "deny"
 variant_size_differences = "deny"
+# Allow the following lints since these cause issues with Rust v1.84.0 or newer
+# Building Vaultwarden with Rust v1.85.0 and edition 2024 also works without issues
+if_let_rescope = "allow"
+tail_expr_drop_order = "allow"
 
 # https://rust-lang.github.io/rust-clippy/stable/index.html
 [lints.clippy]

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -101,6 +101,7 @@ impl Drop for WSAnonymousEntryMapGuard {
     }
 }
 
+#[allow(tail_expr_drop_order)]
 #[get("/hub?<data..>")]
 fn websockets_hub<'r>(
     ws: WebSocket,
@@ -186,6 +187,7 @@ fn websockets_hub<'r>(
     })
 }
 
+#[allow(tail_expr_drop_order)]
 #[get("/anonymous-hub?<token..>")]
 fn anonymous_websockets_hub<'r>(ws: WebSocket, token: String, ip: ClientIp) -> Result<rocket_ws::Stream!['r], Error> {
     let addr = ip.ip;
@@ -290,7 +292,7 @@ fn serialize(val: Value) -> Vec<u8> {
 fn serialize_date(date: NaiveDateTime) -> Value {
     let seconds: i64 = date.and_utc().timestamp();
     let nanos: i64 = date.and_utc().timestamp_subsec_nanos().into();
-    let timestamp = nanos << 34 | seconds;
+    let timestamp = (nanos << 34) | seconds;
 
     let bs = timestamp.to_be_bytes();
 


### PR DESCRIPTION
These changes allow building Vaultwarden using Rust v1.84.0 or newer. The two lints specifically allowed are part of the `rust_2024_compatibility` list. These two lint checks seem to have no impact on our code as far as i could tell. Also building and running both 2021 edition and 2024 edition binary works fine.

Closes #5370