### PR TITLE
Fix version detection on bake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
         with:
           pull: true
           push: true
+          source: .
           files: docker/docker-bake.hcl
           targets: "${{ matrix.base_image }}-multi"
           set: |


### PR DESCRIPTION
Because of some changes in the bake action the version was not able to be extracted.

Fixes #5381
