### PR TITLE
improve admin invite

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -99,6 +99,7 @@ const DT_FMT: &str = "%Y-%m-%d %H:%M:%S %Z";
 const BASE_TEMPLATE: &str = "admin/base";
 
 const ACTING_ADMIN_USER: &str = "vaultwarden-admin-00000-000000000000";
+pub const FAKE_ADMIN_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
 fn admin_path() -> String {
     format!("{}{}", CONFIG.domain_path(), ADMIN_PATH)
@@ -299,7 +300,9 @@ async fn invite_user(data: Json<InviteData>, _token: AdminToken, mut conn: DbCon
 
     async fn _generate_invite(user: &User, conn: &mut DbConn) -> EmptyResult {
         if CONFIG.mail_enabled() {
-            mail::send_invite(user, None, None, &CONFIG.invitation_org_name(), None).await
+            let org_id: OrganizationId = FAKE_ADMIN_UUID.to_string().into();
+            let member_id: MembershipId = FAKE_ADMIN_UUID.to_string().into();
+            mail::send_invite(user, org_id, member_id, &CONFIG.invitation_org_name(), None).await
         } else {
             let invitation = Invitation::new(&user.email);
             invitation.save(conn).await
@@ -475,7 +478,9 @@ async fn resend_user_invite(user_id: UserId, _token: AdminToken, mut conn: DbCon
         }
 
         if CONFIG.mail_enabled() {
-            mail::send_invite(&user, None, None, &CONFIG.invitation_org_name(), None).await
+            let org_id: OrganizationId = FAKE_ADMIN_UUID.to_string().into();
+            let member_id: MembershipId = FAKE_ADMIN_UUID.to_string().into();
+            mail::send_invite(&user, org_id, member_id, &CONFIG.invitation_org_name(), None).await
         } else {
             Ok(())
         }

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1148,6 +1148,10 @@ async fn accept_invite(
             Invitation::take(&claims.email, &mut conn).await;
 
             if let (Some(member), Some(org)) = (&claims.member_id, &claims.org_id) {
+                if **member == "00000000-0000-0000-0000-000000000000" {
+                    // exit early when the invitation was done via admin panel
+                    return Ok(());
+                }
                 let Some(mut member) = Membership::find_by_uuid_and_org(member, org, &mut conn).await else {
                     err!("Error accepting the invitation")
                 };

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1818,17 +1818,15 @@ async fn list_policies(org_id: OrganizationId, _headers: AdminHeaders, mut conn:
 
 #[get("/organizations/<org_id>/policies/token?<token>")]
 async fn list_policies_token(org_id: OrganizationId, token: &str, mut conn: DbConn) -> JsonResult {
-    // web-vault 2024.6.2 seems to send these values and cause logs to output errors
-    // Catch this and prevent errors in the logs
-    // TODO: CleanUp after 2024.6.x is not used anymore.
-    if org_id.as_ref() == "undefined" && token == "undefined" || org_id.as_ref() == FAKE_ADMIN_UUID {
-        return Ok(Json(json!({})));
-    }
-
     let invite = decode_invite(token)?;
 
     if invite.org_id != org_id {
         err!("Token doesn't match request organization");
+    }
+
+    // exit early when we have been invited via /admin panel
+    if org_id.as_ref() == FAKE_ADMIN_UUID {
+        return Ok(Json(json!({})));
     }
 
     // TODO: We receive the invite token as ?token=<>, validate it contains the org id

--- a/src/api/core/public.rs
+++ b/src/api/core/public.rs
@@ -119,14 +119,8 @@ async fn ldap_import(data: Json<OrgImportData>, token: PublicToken, mut conn: Db
                     None => err!("Error looking up organization"),
                 };
 
-                if let Err(e) = mail::send_invite(
-                    &user,
-                    Some(org_id.clone()),
-                    Some(new_member.uuid.clone()),
-                    &org_name,
-                    Some(org_email),
-                )
-                .await
+                if let Err(e) =
+                    mail::send_invite(&user, org_id.clone(), new_member.uuid.clone(), &org_name, Some(org_email)).await
                 {
                     // Upon error delete the user, invite and org member records when needed
                     if user_created {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -194,16 +194,16 @@ pub struct InviteJwtClaims {
     pub sub: UserId,
 
     pub email: String,
-    pub org_id: Option<OrganizationId>,
-    pub member_id: Option<MembershipId>,
+    pub org_id: OrganizationId,
+    pub member_id: MembershipId,
     pub invited_by_email: Option<String>,
 }
 
 pub fn generate_invite_claims(
     user_id: UserId,
     email: String,
-    org_id: Option<OrganizationId>,
-    member_id: Option<MembershipId>,
+    org_id: OrganizationId,
+    member_id: MembershipId,
     invited_by_email: Option<String>,
 ) -> InviteJwtClaims {
     let time_now = Utc::now();

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -259,24 +259,16 @@ pub async fn send_single_org_removed_from_org(address: &str, org_name: &str) -> 
 
 pub async fn send_invite(
     user: &User,
-    org_id: Option<OrganizationId>,
-    member_id: Option<MembershipId>,
+    org_id: OrganizationId,
+    member_id: MembershipId,
     org_name: &str,
     invited_by_email: Option<String>,
 ) -> EmptyResult {
-    let org_id = match org_id {
-        Some(ref org_id) => org_id.as_ref(),
-        None => "00000000-0000-0000-0000-000000000000",
-    };
-    let member_id = match member_id {
-        Some(ref member_id) => member_id.as_ref(),
-        None => "00000000-0000-0000-0000-000000000000",
-    };
     let claims = generate_invite_claims(
         user.uuid.clone(),
         user.email.clone(),
-        Some(org_id.to_string().into()),
-        Some(member_id.to_string().into()),
+        org_id.clone(),
+        member_id.clone(),
         invited_by_email,
     );
     let invite_token = encode_jwt(&claims);
@@ -286,8 +278,8 @@ pub async fn send_invite(
         query_params
             .append_pair("email", &user.email)
             .append_pair("organizationName", org_name)
-            .append_pair("organizationId", org_id)
-            .append_pair("organizationUserId", member_id)
+            .append_pair("organizationId", &org_id)
+            .append_pair("organizationUserId", &member_id)
             .append_pair("token", &invite_token);
         if user.private_key.is_some() {
             query_params.append_pair("orgUserHasExistingUser", "true");

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -264,22 +264,22 @@ pub async fn send_invite(
     org_name: &str,
     invited_by_email: Option<String>,
 ) -> EmptyResult {
-    let claims = generate_invite_claims(
-        user.uuid.clone(),
-        user.email.clone(),
-        org_id.clone(),
-        member_id.clone(),
-        invited_by_email,
-    );
-    let invite_token = encode_jwt(&claims);
     let org_id = match org_id {
         Some(ref org_id) => org_id.as_ref(),
-        None => "_",
+        None => "00000000-0000-0000-0000-000000000000",
     };
     let member_id = match member_id {
         Some(ref member_id) => member_id.as_ref(),
-        None => "_",
+        None => "00000000-0000-0000-0000-000000000000",
     };
+    let claims = generate_invite_claims(
+        user.uuid.clone(),
+        user.email.clone(),
+        Some(org_id.to_string().into()),
+        Some(member_id.to_string().into()),
+        invited_by_email,
+    );
+    let invite_token = encode_jwt(&claims);
     let mut query = url::Url::parse("https://query.builder").unwrap();
     {
         let mut query_params = query.query_pairs_mut();


### PR DESCRIPTION
As pointed out by @Timshel the `OrganizationId` guard  and especially the `MembershipId` guard is unhappy with the `_` we use when inviting via the `/admin` panel.

By introducing a fake UUID `"00000000-0000-0000-0000-000000000000"` the guards will not fail and we can also check the claim and exit early.