### PR TITLE
only validate SMTP_FROM if necessary

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -942,7 +942,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
             }
         }
 
-        if !is_valid_email(&cfg.smtp_from) {
+        if (cfg.smtp_host.is_some() || cfg.use_sendmail) && !is_valid_email(&cfg.smtp_from) {
             err!(format!("SMTP_FROM '{}' is not a valid email address", cfg.smtp_from))
         }
 


### PR DESCRIPTION
#5438 seems to break setups by always requiring `smtp_from` to be a valid email, even if mail is disabled

reverted part of the change to fix #5441 