### PR TITLE
add and use new event types

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -403,7 +403,7 @@ async fn delete_user(user_id: UserId, token: AdminToken, mut conn: DbConn) -> Em
 
     for membership in memberships {
         log_event(
-            EventType::OrganizationUserRemoved as i32,
+            EventType::OrganizationUserDeleted as i32,
             &membership.uuid,
             &membership.org_uuid,
             &ACTING_ADMIN_USER.into(),

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -251,7 +251,7 @@ async fn leave_organization(org_id: OrganizationId, headers: Headers, mut conn: 
             }
 
             log_event(
-                EventType::OrganizationUserRemoved as i32,
+                EventType::OrganizationUserLeft as i32,
                 &member.uuid,
                 &org_id,
                 &headers.user.uuid,

--- a/src/db/models/event.rs
+++ b/src/db/models/event.rs
@@ -49,6 +49,8 @@ pub enum EventType {
     UserClientExportedVault = 1007,
     // UserUpdatedTempPassword = 1008, // Not supported
     // UserMigratedKeyToKeyConnector = 1009, // Not supported
+    UserRequestedDeviceApproval = 1010,
+    // UserTdeOffboardingPasswordSet = 1011, // Not supported
 
     // Cipher
     CipherCreated = 1100,
@@ -69,6 +71,7 @@ pub enum EventType {
     CipherSoftDeleted = 1115,
     CipherRestored = 1116,
     CipherClientToggledCardNumberVisible = 1117,
+    CipherClientToggledTOTPSeedVisible = 1118,
 
     // Collection
     CollectionCreated = 1300,
@@ -94,6 +97,10 @@ pub enum EventType {
     // OrganizationUserFirstSsoLogin = 1510, // Not supported
     OrganizationUserRevoked = 1511,
     OrganizationUserRestored = 1512,
+    OrganizationUserApprovedAuthRequest = 1513,
+    OrganizationUserRejectedAuthRequest = 1514,
+    OrganizationUserDeleted = 1515,
+    OrganizationUserLeft = 1516,
 
     // Organization
     OrganizationUpdated = 1600,
@@ -105,6 +112,7 @@ pub enum EventType {
     // OrganizationEnabledKeyConnector = 1606, // Not supported
     // OrganizationDisabledKeyConnector = 1607, // Not supported
     // OrganizationSponsorshipsSynced = 1608, // Not supported
+    // OrganizationCollectionManagementUpdated = 1609, // Not supported
 
     // Policy
     PolicyUpdated = 1700,
@@ -117,6 +125,13 @@ pub enum EventType {
     // ProviderOrganizationAdded = 1901, // Not supported
     // ProviderOrganizationRemoved = 1902, // Not supported
     // ProviderOrganizationVaultAccessed = 1903, // Not supported
+
+    // OrganizationDomainAdded = 2000, // Not supported
+    // OrganizationDomainRemoved = 2001, // Not supported
+    // OrganizationDomainVerified = 2002, // Not supported
+    // OrganizationDomainNotVerified = 2003, // Not supported
+
+    // SecretRetrieved = 2100, // Not supported
 }
 
 /// Local methods


### PR DESCRIPTION
It seems like the web-vault has [some additional event types](https://github.com/bitwarden/clients/blob/web-v2025.1.1/libs/common/src/enums/event-type.enum.ts), so I've updated our list accordingly. Most of them are added only for reference  (and it seems like the web-vault does not even have support to [display all of them correctly](https://github.com/bitwarden/clients/blob/web-v2025.1.1/apps/web/src/app/core/event.service.ts) at the moment).

I've used the new ones for auth requests and to differentiate between a member leaving an organization
![image](https://github.com/user-attachments/assets/04da1345-b6b7-4ec0-8151-c32b900005bc)
and getting the whole account deleted by an admin (<del>possibly this should also be when it's deleted by yourself?</del>).
![image](https://github.com/user-attachments/assets/c002ec2f-0776-4d1c-85f3-5e89d95c384f)


Lastly I also changed it so that the membership info is also stored in the `log_user_event` for the found organizations, so the link to the member id won't show up as `undefined` in the report:
![Screenshot 2025-01-27 at 23-43-07 Event logs Vaultwarden Web](https://github.com/user-attachments/assets/814893b2-2e5d-4109-ac99-6013dce3fe22)
(I'm not sure why this is not also linked for other User events as it seems useful to have a quick link to list the associated items for a given member...)