### PR TITLE
Fix Duo Field Names for Web Client

### DIFF
--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -26,8 +26,8 @@ pub fn routes() -> Vec<Route> {
 #[derive(Serialize, Deserialize)]
 struct DuoData {
     host: String, // Duo API hostname
-    ik: String,   // integration key
-    sk: String,   // secret key
+    ik: String,   // client id
+    sk: String,   // client secret
 }
 
 impl DuoData {

--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -129,8 +129,8 @@ async fn get_duo(data: Json<PasswordOrOtpData>, headers: Headers, mut conn: DbCo
 #[serde(rename_all = "camelCase")]
 struct EnableDuoData {
     host: String,
-    secret_key: String,
-    integration_key: String,
+    client_secret: String,
+    client_id: String,
     master_password_hash: Option<String>,
     otp: Option<String>,
 }
@@ -139,8 +139,8 @@ impl From<EnableDuoData> for DuoData {
     fn from(d: EnableDuoData) -> Self {
         Self {
             host: d.host,
-            ik: d.integration_key,
-            sk: d.secret_key,
+            ik: d.client_id,
+            sk: d.client_secret,
         }
     }
 }
@@ -151,7 +151,7 @@ fn check_duo_fields_custom(data: &EnableDuoData) -> bool {
         st.is_empty() || s == DISABLED_MESSAGE_DEFAULT
     }
 
-    !empty_or_default(&data.host) && !empty_or_default(&data.secret_key) && !empty_or_default(&data.integration_key)
+    !empty_or_default(&data.host) && !empty_or_default(&data.client_secret) && !empty_or_default(&data.client_id)
 }
 
 #[post("/two-factor/duo", data = "<data>")]

--- a/src/api/core/two_factor/duo.rs
+++ b/src/api/core/two_factor/duo.rs
@@ -111,8 +111,8 @@ async fn get_duo(data: Json<PasswordOrOtpData>, headers: Headers, mut conn: DbCo
         json!({
             "enabled": enabled,
             "host": data.host,
-            "secretKey": data.sk,
-            "integrationKey": data.ik,
+            "clientSecret": data.sk,
+            "clientId": data.ik,
             "object": "twoFactorDuo"
         })
     } else {
@@ -186,8 +186,8 @@ async fn activate_duo(data: Json<EnableDuoData>, headers: Headers, mut conn: DbC
     Ok(Json(json!({
         "enabled": true,
         "host": data.host,
-        "secretKey": data.sk,
-        "integrationKey": data.ik,
+        "clientSecret": data.sk,
+        "clientId": data.ik,
         "object": "twoFactorDuo"
     })))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -670,9 +670,9 @@ make_config! {
         _enable_duo:            bool,   true,   def,     true;
         /// Attempt to use deprecated iframe-based Traditional Prompt (Duo WebSDK 2)
         duo_use_iframe:         bool,   false,  def,     false;
-        /// Integration Key
+        /// Client Id
         duo_ikey:               String, true,   option;
-        /// Secret Key
+        /// Client Secret
         duo_skey:               Pass,   true,   option;
         /// Host
         duo_host:               String, true,   option;


### PR DESCRIPTION
Looks like the web client expects different fields for duo integration.
The changes were introduced in the following commit:
https://github.com/bitwarden/clients/commit/41e1d9155850581be85d11e4b74088aa022f8381#diff-2be3b52c1ad01eac329688bca2644e0aa1f819167ed8a9d52ed57f72e18b8aa8L4
https://github.com/bitwarden/clients/commit/41e1d9155850581be85d11e4b74088aa022f8381#diff-8813d04cfcaad734e34e034e8a85eeb4a528d55aeb52b5c88e6bcbfced9fc260L13


Web client sends different fields to the API (and also receives wrong ones):
`clientSecret` instead of `secretKey` and `clientId` instead of `integrationKey`

I believe, this PR can address this.


When saving:
![image](https://github.com/user-attachments/assets/21f13310-fce4-442f-baaa-df62d7bfc691)

When loading (Client Id and Client Secret is empty):
![image](https://github.com/user-attachments/assets/dd70d557-4eaf-467e-b2ba-e2a03154be08)
