### PR TITLE
Fix icon redirect not working on desktop

### DIFF
--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -63,6 +63,9 @@ static CLIENT: Lazy<Client> = Lazy::new(|| {
 // Build Regex only once since this takes a lot of time.
 static ICON_SIZE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?x)(\d+)\D*(\d+)").unwrap());
 
+// The function name `icon_external` is checked in the `on_response` function in `AppHeaders`
+// It is used to prevent sending a specific header which breaks icon downloads.
+// If this function needs to be renamed, also adjust the code in `util.rs`
 #[get("/<domain>/icon.png")]
 fn icon_external(domain: &str) -> Option<Redirect> {
     if !is_valid_domain(domain) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -60,7 +60,7 @@ impl Fairing for AppHeaders {
         res.set_raw_header("X-XSS-Protection", "0");
 
         // The `Cross-Origin-Resource-Policy` header should not be set on images or on the `icon_external` route.
-        // Else some clients, like the Bitwardem Desktop will fail to download the icons
+        // Otherwise some clients, like the Bitwarden Desktop, will fail to download the icons
         if !(res.headers().get_one("Content-Type").is_some_and(|v| v.starts_with("image/"))
             || req.route().is_some_and(|v| v.name.as_deref() == Some("icon_external")))
         {

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,12 +56,16 @@ impl Fairing for AppHeaders {
         res.set_raw_header("X-Content-Type-Options", "nosniff");
         res.set_raw_header("X-Robots-Tag", "noindex, nofollow");
 
-        if !res.headers().get_one("Content-Type").is_some_and(|v| v.starts_with("image/")) {
-            res.set_raw_header("Cross-Origin-Resource-Policy", "same-origin");
-        }
-
         // Obsolete in modern browsers, unsafe (XS-Leak), and largely replaced by CSP
         res.set_raw_header("X-XSS-Protection", "0");
+
+        // The `Cross-Origin-Resource-Policy` header should not be set on images or on the `icon_external` route.
+        // Else some clients, like the Bitwardem Desktop will fail to download the icons
+        if !(res.headers().get_one("Content-Type").is_some_and(|v| v.starts_with("image/"))
+            || req.route().is_some_and(|v| v.name.as_deref() == Some("icon_external")))
+        {
+            res.set_raw_header("Cross-Origin-Resource-Policy", "same-origin");
+        }
 
         // Do not send the Content-Security-Policy (CSP) Header and X-Frame-Options for the *-connector.html files.
         // This can cause issues when some MFA requests needs to open a popup or page within the clients like WebAuthn, or Duo.


### PR DESCRIPTION
We also need to exclude the header in case we do an external_icon call.

Fixes #5535