### PR TITLE
Add multi-level version tags to docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,19 @@ jobs:
         run: |
           # Check which main tag we are going to build determined by ref_type
           if [[ "${REF_TYPE}" == "tag" ]]; then
-            echo "BASE_TAGS=latest,${GITHUB_REF#refs/*/}" | tee -a "${GITHUB_ENV}"
+            VERSION_TAGS=${GITHUB_REF#refs/*/}
+            # Add `Major` and `Major.Minor` version tags if GH Ref matches SemVer
+            SEMVER_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$"
+            if [[ "${VERSION_TAGS}" =~ $SEMVER_REGEX ]]; then
+                VERSION_TAGS+=",${BASH_REMATCH[1]}"
+                VERSION_TAGS+=",${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                # Add `Major.Minor.Patch` version tag if GH Ref contains SemVer extension
+                if [[ "${BASH_REMATCH[4]}" ]]; then
+                    VERSION_TAGS+=",${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+                fi
+            fi
+
+            echo "BASE_TAGS=latest,${VERSION_TAGS}" | tee -a "${GITHUB_ENV}"
           elif [[ "${REF_TYPE}" == "branch" ]]; then
             echo "BASE_TAGS=testing" | tee -a "${GITHUB_ENV}"
           fi


### PR DESCRIPTION
As I consider Vaultwarden to be a vital part of my selfhosted services I do not like to roll the dice and auto update my Docker containers and sticking to the `latest` label. However, manually updating the container version every time a new _patch_ release is out is too manual.

This PR bridges the gap between the two. The rationale is well explained [here](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699), but the gist of it is that having the option to pin the docker tag to `major`, or `major.minor` allows users enable automatic updates up to the level they are comfortable with. I.e. automatically staying secure for security patches, but not automatically updating when a breaking change is introduced.

What this PR does:
When a new version is released, e.g. `1.34.5`, and if this tag complies with SemVer formatting, the following tags are also added to the docker images:
- `1`: Major version
- `1.34`: Major.Minor version

(In case it does not match the SemVer formatting, nothing is added)