### PR TITLE
Show assigned collections on member edit

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -517,7 +517,7 @@ impl Membership {
             CONFIG.org_groups_enabled() && Group::is_in_full_access_group(&self.user_uuid, &self.org_uuid, conn).await;
 
         // If collections are to be included, only include them if the user does not have full access via a group or defined to the user it self
-        let collections: Vec<Value> = if include_collections && !(full_access_group || self.has_full_access()) {
+        let collections: Vec<Value> = if include_collections && !(full_access_group || self.access_all) {
             // Get all collections for the user here already to prevent more queries
             let cu: HashMap<CollectionId, CollectionUser> =
                 CollectionUser::find_by_organization_and_user_uuid(&self.org_uuid, &self.user_uuid, conn)


### PR DESCRIPTION
Because we were using the `has_full_access()` function we did not returned assigned collections for an owner/admin even if the did not have the `access_all` flag set. This commit will change that to use the `access_all` flag instead, and return assigned collections too.

While saving a member and having it assigned collections would still save those rights, and it was also visible in the collection management, it wasn't at the member it self. So, it did work, but was not visible.

Fixes #5554
Fixes #5555