### PR TITLE
allow CLI to upload send files with truncated filenames

### DIFF
--- a/src/api/core/sends.rs
+++ b/src/api/core/sends.rs
@@ -378,7 +378,11 @@ async fn post_send_file_v2_data(
     };
 
     match data.data.raw_name() {
-        Some(raw_file_name) if raw_file_name.dangerous_unsafe_unsanitized_raw() == send_data.fileName => (),
+        Some(raw_file_name)
+            if raw_file_name.dangerous_unsafe_unsanitized_raw() == send_data.fileName
+            // be less strict only if using CLI, cf. https://github.com/dani-garcia/vaultwarden/issues/5614
+            || (headers.device.is_cli() && send_data.fileName.ends_with(raw_file_name.dangerous_unsafe_unsanitized_raw().as_str())
+            ) => {}
         Some(raw_file_name) => err!(
             "Send file name does not match.",
             format!(

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -135,6 +135,10 @@ impl Device {
     pub fn is_registered(&self) -> bool {
         self.push_uuid.is_some()
     }
+
+    pub fn is_cli(&self) -> bool {
+        matches!(DeviceType::from_i32(self.atype), DeviceType::WindowsCLI | DeviceType::MacOsCLI | DeviceType::LinuxCLI)
+    }
 }
 
 pub struct DeviceWithAuthRequest {


### PR DESCRIPTION
due to a bug in the CLI the filename in the form-data is not complete if the encrypted filename happens to contain a `/`

this should fix #5614