### PR TITLE
fix invitation logic for new registration flow

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -487,7 +487,7 @@
 ## Maximum attempts before an email token is reset and a new email will need to be sent.
 # EMAIL_ATTEMPTS_LIMIT=3
 ##
-## Setup email 2FA regardless of any organization policy
+## Setup email 2FA on registration regardless of any organization policy
 # EMAIL_2FA_ENFORCE_ON_VERIFIED_INVITE=false
 ## Automatically setup email 2FA as fallback provider when needed
 # EMAIL_2FA_AUTO_FALLBACK=false

--- a/src/config.rs
+++ b/src/config.rs
@@ -735,7 +735,7 @@ make_config! {
         email_expiration_time:  u64,    true,   def,      600;
         /// Maximum attempts |> Maximum attempts before an email token is reset and a new email will need to be sent
         email_attempts_limit:   u64,    true,   def,      3;
-        /// Automatically enforce at login |> Setup email 2FA provider regardless of any organization policy
+        /// Setup email 2FA at signup |> Setup email 2FA provider on registration regardless of any organization policy
         email_2fa_enforce_on_verified_invite: bool,   true,   def,      false;
         /// Auto-enable 2FA (Know the risks!) |> Automatically setup email 2FA as fallback provider when needed
         email_2fa_auto_fallback: bool,  true,   def,      false;


### PR DESCRIPTION
My suggestions for your open pull request #5215 which should be backwards compatible with the old registration flow as well as make it possible to enforce email 2fa for all users regardless of any organization policy as discussed here https://github.com/dani-garcia/vaultwarden/discussions/5662#discussioncomment-12398665.