### PR TITLE
Add AnonAddy/SimpleLogin self host feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -353,6 +353,8 @@
 ## - "inline-menu-positioning-improvements": Enable the use of inline menu password generator and identity suggestions in the browser extension.
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Needs clients >=2024.12.0)
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Needs desktop >=2024.12.0)
+## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.2.0)
+## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.2.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 
 ## Require new device emails. When a user logs in an email is required to be sent.

--- a/src/config.rs
+++ b/src/config.rs
@@ -839,9 +839,11 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "browser-fileless-import",
         "extension-refresh",
         "fido2-vault-credentials",
-        "inline-menu-positioning-improvements",
+        "inline-menu-positioning-improvements", 
         "ssh-key-vault-item",
         "ssh-agent",
+        "anon-addy-self-host-alias",
+        "simple-login-self-host-alias",
     ];
     let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
     let invalid_flags: Vec<_> = configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();


### PR DESCRIPTION
This adds the feature flags for bitwarden/android/pull/4711 and bitwarden/android/pull/4715. These only apply to Android at the moment unfortunately, but hopefully will come to iOS soon.