### PR TITLE
Add support for mutual-tls feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -353,6 +353,7 @@
 ## - "inline-menu-positioning-improvements": Enable the use of inline menu password generator and identity suggestions in the browser extension.
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Needs clients >=2024.12.0)
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Needs desktop >=2024.12.0)
+## - "mutual-tls": Enable the use of mutual TLS on Android (Client >= 2025.2.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 
 ## Require new device emails. When a user logs in an email is required to be sent.

--- a/src/config.rs
+++ b/src/config.rs
@@ -842,6 +842,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "inline-menu-positioning-improvements",
         "ssh-key-vault-item",
         "ssh-agent",
+        "mutual-tls"
     ];
     let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
     let invalid_flags: Vec<_> = configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -842,7 +842,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "inline-menu-positioning-improvements",
         "ssh-key-vault-item",
         "ssh-agent",
-        "mutual-tls"
+        "mutual-tls",
     ];
     let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
     let invalid_flags: Vec<_> = configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();


### PR DESCRIPTION
Hello!

I use split-horizon DNS to access Vaultwarden. When a client is on my home network, it talks to vaultwarden directly. When not on my home network, connections are routed through Cloudflare tunnels, which enforces a mutual TLS/client cert requirement. As such, this means that outside my home network, Bitwarden is unable to sync with Vaultwarden on Android.

Changes have been made on the Android client side to support mTLS, which were added in the 2025.2.0 release ([ref](https://github.com/bitwarden/android/releases/tag/v2025.2.0)). Namely:
- https://github.com/bitwarden/android/pull/4606
- https://github.com/bitwarden/android/pull/4701
- https://github.com/bitwarden/android/pull/4486

A server-side change was merged as well
- https://github.com/bitwarden/server/pull/5335

This PR adds support for the mTLS flag in Vaultwarden.

### Validation

Default config

```
docker run --rm -p 3333:80 -e I_REALLY_WANT_VOLATILE_STORAGE=true 8aa21278e7eb

curl --silent localhost:3333/api/config | jq 
{
  "environment": {
    "api": "http://localhost/api",
    "identity": "http://localhost/identity",
    "notifications": "http://localhost/notifications",
    "sso": "",
    "vault": "http://localhost"
  },
  "featureStates": {
    "fido2-vault-credentials": true,
    "flexible-collections-v-1": false,
    "key-rotation-improvements": true
  },
  "gitHash": null,
  "object": "config",
  "server": {
    "name": "Vaultwarden",
    "url": "https://github.com/dani-garcia/vaultwarden"
  },
  "settings": {
    "disableUserRegistration": false
  },
  "version": "2025.1.0"
}
```

With the new flag set:

```
docker run --rm -p 3333:80 -e I_REALLY_WANT_VOLATILE_STORAGE=true -e EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials,mutual-tls 8aa21278e7eb

curl --silent localhost:3333/api/config | jq 
{
  "environment": {
    "api": "http://localhost/api",
    "identity": "http://localhost/identity",
    "notifications": "http://localhost/notifications",
    "sso": "",
    "vault": "http://localhost"
  },
  "featureStates": {
    "fido2-vault-credentials": true,
    "flexible-collections-v-1": false,
    "key-rotation-improvements": true,
    "mutual-tls": true <----------------------------- woo hoo!
  },
  "gitHash": null,
  "object": "config",
  "server": {
    "name": "Vaultwarden",
    "url": "https://github.com/dani-garcia/vaultwarden"
  },
  "settings": {
    "disableUserRegistration": false
  },
  "version": "2025.1.0"
}
```

On the Android side (client version `2025.2.0`):
- Open login page
- Select `Logging in on...` -> `Self-hosted`
- Set the URL for Vaultwarden
- Hit "save". You'll be redirected back to the login page.
- Select `Logging in on...` -> `Self-hosted`
- A `Client Certificate (MTLS)` section should now appear to provide cert details.

In my case, I had already been logged in on the BW app. I had to update the server URL to a bogus value, then reset it to the proper value to have BW pick up the new config.