### PR TITLE
Verify templates in CI

### DIFF
--- a/.github/workflows/check-templates.yml
+++ b/.github/workflows/check-templates.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
-          fetch-depth: 0
       # End Checkout the repo
 
       - name: Run make to rebuild templates


### PR DESCRIPTION
This way we won't accidentally get them out of sync again, at the moment failing until we fix the current issues