### PR TITLE
Add Docker Templates pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,11 @@ repos:
       types_or: [rust, file]
       files: (Cargo.toml|Cargo.lock|rust-toolchain|clippy.toml|.*\.rs$)
       pass_filenames: false
+    - id: check-docker-templates
+      name: check docker templates
+      desciption: Check if the Docker templates are updated
+      language: system
+      entry: sh
+      args:
+        - "-c"
+        - "cd docker && make"


### PR DESCRIPTION
Added the same check as done via GitHub Actions to check template changes to the pre-commit checks. This should catch these mistakes before they are commited and pushed.