### PR TITLE
Fix debian docker building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,26 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,20 +500,11 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
 ]
 
 [[package]]
@@ -584,17 +555,6 @@ checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown 0.14.5",
  "stacker",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -789,9 +749,9 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -1913,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1955,15 +1915,6 @@ dependencies = [
  "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2074,16 +2025,6 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "libm"
@@ -2312,7 +2253,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f29e21174d84e2622ceb7b0146a9187d36458a3a9ee9a66c9cac22e96493ef9"
 dependencies = [
- "bindgen",
  "pkg-config",
  "vcpkg",
 ]
@@ -2806,16 +2746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,12 +3210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -4310,7 +4234,6 @@ dependencies = [
  "log",
  "macros",
  "mimalloc",
- "mysqlclient-sys",
  "num-derive",
  "num-traits",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 # default = ["sqlite"]
 # Empty to keep compatibility, prefer to set USE_SYSLOG=true
 enable_syslog = []
-mysql = ["diesel/mysql", "diesel_migrations/mysql", "dep:mysqlclient-sys"]
+mysql = ["diesel/mysql", "diesel_migrations/mysql"]
 postgresql = ["diesel/postgres", "diesel_migrations/postgres"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite", "dep:libsqlite3-sys"]
 # Enable to use a vendored and statically linked openssl
@@ -87,8 +87,6 @@ diesel-derive-newtype = "2.1.2"
 
 # Bundled/Static SQLite
 libsqlite3-sys = { version = "0.32.0", features = ["bundled"], optional = true }
-# Always enable buildtime bindgen for mysql/mariadb libraries
-mysqlclient-sys = { version = "0.4.4", features = ["buildtime_bindgen"], optional = true }
 
 # Crypto-related libraries
 rand = "0.9.0"

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -89,31 +89,24 @@ RUN USER=root cargo new --bin /app
 WORKDIR /app
 
 # Environment variables for Cargo on Debian based builds
-ARG ARCH_OPENSSL_LIB_DIR \
-    ARCH_OPENSSL_INCLUDE_DIR
+ARG TARGET_PKG_CONFIG_PATH
 
 RUN source /env-cargo && \
     if xx-info is-cross ; then \
-        # Some special variables if needed to override some build paths
-        if [[ -n "${ARCH_OPENSSL_LIB_DIR}" && -n "${ARCH_OPENSSL_INCLUDE_DIR}" ]]; then \
-            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_LIB_DIR=${ARCH_OPENSSL_LIB_DIR}" >> /env-cargo && \
-            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_INCLUDE_DIR=${ARCH_OPENSSL_INCLUDE_DIR}" >> /env-cargo ; \
-        fi && \
         # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
         # Because of this we generate the needed environment variables here which we can load in the needed steps.
         echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
         echo "export CARGO_TARGET_$(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export PKG_CONFIG=/usr/bin/$(xx-info)-pkg-config" >> /env-cargo && \
         echo "export CROSS_COMPILE=1" >> /env-cargo && \
-        # Export build env's for OpenSSL
-        echo "export OPENSSL_INCLUDE_DIR=/usr/include/$(xx-info)" >> /env-cargo && \
-        echo "export OPENSSL_LIB_DIR=/usr/lib/$(xx-info)" >> /env-cargo ; \
-        # Export build env's for mysqlclient-sys (mariadb)
-        # The version is linked to the mariadb-connector-c a.k.a libmariadb-dev version
-        # See: https://mariadb.com/kb/en/about-mariadb-connector-c/
-        echo "export MYSQLCLIENT_VERSION=3.3.14" >> /env-cargo ; \
-        echo "export MYSQLCLIENT_INCLUDE_DIR=/usr/include/mariadb" >> /env-cargo && \
-        echo "export MYSQLCLIENT_LIB_DIR=/usr/lib/$(xx-info)" >> /env-cargo ; \
+        echo "export PKG_CONFIG_ALLOW_CROSS=1" >> /env-cargo && \
+        # For some architectures `xx-info` returns a triple which doesn't matches the path on disk
+        # In those cases you can override this by setting the `TARGET_PKG_CONFIG_PATH` build-arg
+        if [[ -n "${TARGET_PKG_CONFIG_PATH}" ]]; then \
+            echo "export TARGET_PKG_CONFIG_PATH=${TARGET_PKG_CONFIG_PATH}" >> /env-cargo ; \
+        else \
+            echo "export PKG_CONFIG_PATH=/usr/lib/$(xx-info)/pkgconfig" >> /env-cargo ; \
+        fi && \
+        echo "# End of env-cargo" >> /env-cargo ; \
     fi && \
     # Output the current contents of the file
     cat /env-cargo

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -109,31 +109,24 @@ WORKDIR /app
 
 {% if base == "debian" %}
 # Environment variables for Cargo on Debian based builds
-ARG ARCH_OPENSSL_LIB_DIR \
-    ARCH_OPENSSL_INCLUDE_DIR
+ARG TARGET_PKG_CONFIG_PATH
 
 RUN source /env-cargo && \
     if xx-info is-cross ; then \
-        # Some special variables if needed to override some build paths
-        if [[ -n "${ARCH_OPENSSL_LIB_DIR}" && -n "${ARCH_OPENSSL_INCLUDE_DIR}" ]]; then \
-            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_LIB_DIR=${ARCH_OPENSSL_LIB_DIR}" >> /env-cargo && \
-            echo "export $(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_OPENSSL_INCLUDE_DIR=${ARCH_OPENSSL_INCLUDE_DIR}" >> /env-cargo ; \
-        fi && \
         # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
         # Because of this we generate the needed environment variables here which we can load in the needed steps.
         echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
         echo "export CARGO_TARGET_$(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export PKG_CONFIG=/usr/bin/$(xx-info)-pkg-config" >> /env-cargo && \
         echo "export CROSS_COMPILE=1" >> /env-cargo && \
-        # Export build env's for OpenSSL
-        echo "export OPENSSL_INCLUDE_DIR=/usr/include/$(xx-info)" >> /env-cargo && \
-        echo "export OPENSSL_LIB_DIR=/usr/lib/$(xx-info)" >> /env-cargo ; \
-        # Export build env's for mysqlclient-sys (mariadb)
-        # The version is linked to the mariadb-connector-c a.k.a libmariadb-dev version
-        # See: https://mariadb.com/kb/en/about-mariadb-connector-c/
-        echo "export MYSQLCLIENT_VERSION=3.3.14" >> /env-cargo ; \
-        echo "export MYSQLCLIENT_INCLUDE_DIR=/usr/include/mariadb" >> /env-cargo && \
-        echo "export MYSQLCLIENT_LIB_DIR=/usr/lib/$(xx-info)" >> /env-cargo ; \
+        echo "export PKG_CONFIG_ALLOW_CROSS=1" >> /env-cargo && \
+        # For some architectures `xx-info` returns a triple which doesn't matches the path on disk
+        # In those cases you can override this by setting the `TARGET_PKG_CONFIG_PATH` build-arg
+        if [[ -n "${TARGET_PKG_CONFIG_PATH}" ]]; then \
+            echo "export TARGET_PKG_CONFIG_PATH=${TARGET_PKG_CONFIG_PATH}" >> /env-cargo ; \
+        else \
+            echo "export PKG_CONFIG_PATH=/usr/lib/$(xx-info)/pkgconfig" >> /env-cargo ; \
+        fi && \
+        echo "# End of env-cargo" >> /env-cargo ; \
     fi && \
     # Output the current contents of the file
     cat /env-cargo

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -133,8 +133,7 @@ target "debian-386" {
   platforms = ["linux/386"]
   tags = generate_tags("", "-386")
   args = {
-    ARCH_OPENSSL_LIB_DIR = "/usr/lib/i386-linux-gnu"
-    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/i386-linux-gnu"
+    TARGET_PKG_CONFIG_PATH = "/usr/lib/i386-linux-gnu/pkgconfig"
   }
 }
 
@@ -142,20 +141,12 @@ target "debian-ppc64le" {
   inherits = ["debian"]
   platforms = ["linux/ppc64le"]
   tags = generate_tags("", "-ppc64le")
-  args = {
-    ARCH_OPENSSL_LIB_DIR = "/usr/lib/powerpc64le-linux-gnu"
-    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/powerpc64le-linux-gnu"
-  }
 }
 
 target "debian-s390x" {
   inherits = ["debian"]
   platforms = ["linux/s390x"]
   tags = generate_tags("", "-s390x")
-  args = {
-    ARCH_OPENSSL_LIB_DIR = "/usr/lib/s390x-linux-gnu"
-    ARCH_OPENSSL_INCLUDE_DIR = "/usr/include/s390x-linux-gnu"
-  }
 }
 // ==== End of unsupported Debian architecture targets ===
 


### PR DESCRIPTION
In previous attempts to get mysqlclient-sys to build and work I added some extra build variables. These are not needed if you configure pkg-config correctly. The same goes for OpenSSL btw.

This PR configures the pkg-config in the right way and allows the crates to build using the right lib paths automatically. Because of this change also the lib/include paths were not needed anymore for some architectures, except for i386.

Also updated crates again.

Fixes #5751