### PR TITLE
Fix minimum Android version for self-host email alias feature flags

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -354,8 +354,8 @@
 ## - "inline-menu-positioning-improvements": Enable the use of inline menu password generator and identity suggestions in the browser extension.
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Needs clients >=2024.12.0)
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Needs desktop >=2024.12.0)
-## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.2.0)
-## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.2.0)
+## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.3.0)
+## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.3.0)
 ## - "mutual-tls": Enable the use of mutual TLS on Android (Client >= 2025.2.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 

--- a/.env.template
+++ b/.env.template
@@ -354,8 +354,8 @@
 ## - "inline-menu-positioning-improvements": Enable the use of inline menu password generator and identity suggestions in the browser extension.
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Needs clients >=2024.12.0)
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Needs desktop >=2024.12.0)
-## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.3.0)
-## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.3.0)
+## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.3.0, iOS >=2025.4.0)
+## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.3.0, iOS >=2025.4.0)
 ## - "mutual-tls": Enable the use of mutual TLS on Android (Client >= 2025.2.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 


### PR DESCRIPTION
This is very minor, but I just noticed I made a typo in the minimum Android client versions for the AnonAddy/Addy.io and SimpleLogin self hosted feature flags from #5694.

They require a minimum of [2025.3.0](https://github.com/bitwarden/android/releases/tag/untagged-4731eaadac73f3dfbbb8), not 2025.2.0!