### PR TITLE
Toggle providers using class

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -112,14 +112,14 @@ app-login form div + div + div + div + hr + p {
 
 {{#unless mail_enabled}}
 /* Hide `Email` 2FA if mail is not enabled */
-app-two-factor-setup ul.list-group.list-group-2fa li.list-group-item:nth-child(1) {
+.providers-2fa-1 {
   @extend %vw-hide;
 }
 {{/unless}}
 
 {{#unless yubico_enabled}}
 /* Hide `YubiKey OTP security key` 2FA if it is not enabled */
-app-two-factor-setup ul.list-group.list-group-2fa li.list-group-item:nth-child(4) {
+.providers-2fa-3 {
   @extend %vw-hide;
 }
 {{/unless}}


### PR DESCRIPTION
Starting with `web-vault` release `v2025.4.0` it will become possible to toggle the 2fa providers using a class. 
Cf https://github.com/vaultwarden/vw_web_builds/pull/15

Without this change the selector will start breaking with  `v2025.4.1` since the element switched to `bit-item` (cf [166cb75](https://github.com/vaultwarden/vw_web_builds/commit/166cb75401f4578a8d809186df3ca9e1134c0113)).
