### PR TITLE
Fix Yubico toggle

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -57,7 +57,7 @@ fn vaultwarden_css() -> Cached<Css<String>> {
     let css_options = json!({
         "signup_disabled": !CONFIG.signups_allowed() && CONFIG.signups_domains_whitelist().is_empty(),
         "mail_enabled": CONFIG.mail_enabled(),
-        "yubico_enabled": CONFIG._enable_yubico() && (CONFIG.yubico_client_id().is_some() == CONFIG.yubico_secret_key().is_some()),
+        "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),
         "emergency_access_allowed": CONFIG.emergency_access_allowed(),
         "sends_allowed": CONFIG.sends_allowed(),
         "load_user_scss": true,


### PR DESCRIPTION
While testing the toggle for https://github.com/dani-garcia/vaultwarden/pull/5832

Realized that with the current logic Yubico is considered enabled when both client and secret are not set.
The provider is then visible but trying to enable it will result in the failure:
![yubico](https://github.com/user-attachments/assets/80719abf-dfcd-442d-8c3b-86bdb976e730)

Cf: [yubikey.rs#L69](https://github.com/dani-garcia/vaultwarden/blob/2697fe8aba9b082aca02b48990bc65e9fc526aa4/src/api/core/two_factor/yubikey.rs#L69)