### PR TITLE
Add Bulk Collection Modification Endpoint

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -783,6 +783,10 @@ async fn post_bulk_collections(
             err!("Cipher is not write accessible")
         }
 
+        // If the request is for mass adding collections, we need remove the cipher from all collections first.
+        if (!data.remove_collections) {
+            CollectionCipher::delete_all_by_cipher(&cipher.uuid, &mut conn).await?;
+        }
         for collection in &data.collection_ids {
             match Collection::find_by_uuid_and_org(collection, &data.organization_id, &mut conn).await {
                 None => err!("Invalid collection ID provided"),

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -809,7 +809,7 @@ async fn post_bulk_collections(
             &mut conn,
         )
         .await;
-    
+
         log_event(
             EventType::CipherUpdatedCollections as i32,
             &cipher.uuid,

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -776,7 +776,7 @@ async fn post_bulk_collections(
 
     for cipher in &data.cipher_ids {
         let Some(cipher) = Cipher::find_by_uuid(cipher, &mut conn).await else {
-            err!("Cipher doesn't exist")
+            err!(format!("Cipher '{}' doesn't exist", cipher))
         };
 
         if !cipher.is_write_accessible_to_user(&headers.user.uuid, &mut conn).await {
@@ -785,7 +785,7 @@ async fn post_bulk_collections(
 
         for collection in &data.collection_ids {
             match Collection::find_by_uuid_and_org(collection, &data.organization_id, &mut conn).await {
-                None => err!("Invalid collection ID provided"),
+                None => err!(format!("Invalid collection ID provided: {}", collection)),
                 Some(collection) => {
                     if collection.is_writable_by_user(&headers.user.uuid, &mut conn).await {
                         if data.remove_collections {

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -784,7 +784,7 @@ async fn post_bulk_collections(
         }
 
         // If the request is for mass adding collections, we need remove the cipher from all collections first.
-        if (!data.remove_collections) {
+        if !data.remove_collections {
             CollectionCipher::delete_all_by_cipher(&cipher.uuid, &mut conn).await?;
         }
         for collection in &data.collection_ids {

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -776,7 +776,7 @@ async fn post_bulk_collections(
 
     for cipher in &data.cipher_ids {
         let Some(cipher) = Cipher::find_by_uuid(cipher, &mut conn).await else {
-            err!(format!("Cipher '{}' doesn't exist", cipher))
+            err!("Cipher doesn't exist")
         };
 
         if !cipher.is_write_accessible_to_user(&headers.user.uuid, &mut conn).await {
@@ -785,7 +785,7 @@ async fn post_bulk_collections(
 
         for collection in &data.collection_ids {
             match Collection::find_by_uuid_and_org(collection, &data.organization_id, &mut conn).await {
-                None => err!(format!("Invalid collection ID provided: {}", collection)),
+                None => err!("Invalid collection ID provided"),
                 Some(collection) => {
                     if collection.is_writable_by_user(&headers.user.uuid, &mut conn).await {
                         if data.remove_collections {


### PR DESCRIPTION
This pull request introduces a new API endpoint to handle bulk updates to cipher collections, along with the necessary data structure and logic to support it.

### Changes:

* Added a new route `post_bulk_collections` to the `routes` function in `src/api/core/ciphers.rs` to register the new endpoint.
* Introduced the `BulkCollectionsData` struct to encapsulate the data required for bulk operations, including organization ID, collection IDs, cipher IDs, and a flag to indicate whether to remove collections.
* Implemented the `post_bulk_collections` function to handle bulk updates.

Closes #5830 

_Note: I am fairly new to Rust so any suggestions are appreciated._ 😃 