### PR TITLE
Remove Hide Business scss rules

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -39,22 +39,6 @@ a[href$="/settings/two-factor"] {
   @extend %vw-hide;
 }
 
-/* Hide Business Owned checkbox */
-app-org-info > form:nth-child(1) > div:nth-child(3) {
-  @extend %vw-hide;
-}
-
-/* Hide the `This account is owned by a business` checkbox and label */
-#ownedBusiness,
-label[for^="ownedBusiness"] {
-  @extend %vw-hide;
-}
-
-/* Hide Business Name */
-app-org-account form div bit-form-field.tw-block:nth-child(3) {
-  @extend %vw-hide;
-}
-
 /* Hide organization plans */
 app-organization-plans > form > bit-section:nth-child(2) {
   @extend %vw-hide;


### PR DESCRIPTION
I believe those rules are unnecessary since https://github.com/bitwarden/clients/commit/b914260705901ff32783e3eebb5ac8dab4e93a92

Last client with the `businessName` field appears to be [web-v2024.4.1](https://github.com/bitwarden/clients/blob/web-v2024.4.1/apps/web/src/app/admin-console/organizations/settings/account.component.html#L24)
 
