### PR TITLE
fix css to hide login with passkey

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -25,7 +25,7 @@ app-root form.ng-untouched button.\!tw-text-primary-600:nth-child(4) {
   @extend %vw-hide;
 }
 /* Hide Log in with passkey on the login page */
-app-root form.ng-untouched a[routerlink="/login-with-passkey"] {
+app-root form.ng-untouched button.\!tw-text-primary-600:nth-child(3) {
   @extend %vw-hide;
 }
 /* Hide the or text followed by the two buttons hidden above */


### PR DESCRIPTION
handles #5889 as we have not implemented the requested endpoints yet.

we also might want to add custom css classes to our web-vault to make this customization a bit more configurable and future-proof so the or text, passkey and sso buttons are not dependent on the markup or position of the items.