### PR TITLE
Get rid of global env variable DEBIAN_FRONTEND

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -170,12 +170,12 @@ FROM --platform=$TARGETPLATFORM docker.io/library/debian:bookworm-slim
 
 ENV ROCKET_PROFILE="release" \
     ROCKET_ADDRESS=0.0.0.0 \
-    ROCKET_PORT=80 \
-    DEBIAN_FRONTEND=noninteractive
+    ROCKET_PORT=80    
 
 # Create data folder and Install needed libraries
 RUN mkdir /data && \
-    apt-get update && apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         --no-install-recommends \
         ca-certificates \
         curl \


### PR DESCRIPTION
When setting the DEBIAN_FRONTEND environment variable, it's best to apply it directly to apt commands rather than setting it globally. If DEBIAN_FRONTEND=noninteractive is set as a persistent environment variable in the container image, it can affect other Debian-specific commands run after the container starts, potentially leading to unintended behavior.

Instead, consider using it like this:

DEBIAN_FRONTEND=noninteractive apt-get update
DEBIAN_FRONTEND=noninteractive apt-get install ...

This ensures the variable is only active during the apt operations and isn't retained in the final image, preventing any lingering side effects.