### PR TITLE
fix css for locked screen

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -25,7 +25,7 @@ app-root form.ng-untouched button.\!tw-text-primary-600:nth-child(4) {
   @extend %vw-hide;
 }
 /* Hide Log in with passkey on the login page */
-app-root form.ng-untouched button.\!tw-text-primary-600:nth-child(3) {
+app-root form.ng-untouched > div > div > button.\!tw-text-primary-600:nth-child(3) {
   @extend %vw-hide;
 }
 /* Hide the or text followed by the two buttons hidden above */


### PR DESCRIPTION
by making the selector more specific to the login page the logout button on the locked screen should be visible again

cf. https://github.com/dani-garcia/vaultwarden/pull/5890#issuecomment-2916665937 for more context