### PR TITLE
Minor fixes to copy in `.env.template`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -130,7 +130,7 @@
 ## and are always in terms of UTC time (regardless of your local time zone settings).
 ##
 ## The schedule format is a bit different from crontab as crontab does not contains seconds.
-## You can test the the format here: https://crontab.guru, but remove the first digit!
+## You can test the format here: https://crontab.guru, but remove the first digit!
 ## SEC  MIN   HOUR   DAY OF MONTH    MONTH   DAY OF WEEK
 ## "0   30   9,12,15     1,15       May-Aug  Mon,Wed,Fri"
 ## "0   30     *          *            *          *     "
@@ -273,7 +273,7 @@
 ## A comma-separated list means only those users can create orgs:
 # ORG_CREATION_USERS=admin1@example.com,admin2@example.com
 
-## Invitations org admins to invite users, even when signups are disabled
+## Allows org admins to invite users, even when signups are disabled
 # INVITATIONS_ALLOWED=true
 ## Name shown in the invitation emails that don't come from a specific organization
 # INVITATION_ORG_NAME=Vaultwarden
@@ -341,16 +341,16 @@
 
 ## Icon download timeout
 ## Configure the timeout value when downloading the favicons.
-## The default is 10 seconds, but this could be to low on slower network connections
+## The default is 10 seconds, but this could be too low on slower network connections
 # ICON_DOWNLOAD_TIMEOUT=10
 
 ## Block HTTP domains/IPs by Regex
 ## Any domains or IPs that match this regex won't be fetched by the internal HTTP client.
 ## Useful to hide other servers in the local network. Check the WIKI for more details
-## NOTE: Always enclose this regex withing single quotes!
+## NOTE: Always enclose this regex within single quotes!
 # HTTP_REQUEST_BLOCK_REGEX='^(192\.168\.0\.[0-9]+|192\.168\.1\.[0-9]+)$'
 
-## Enabling this will cause the internal HTTP client to refuse to connect to any non global IP address.
+## Enabling this will cause the internal HTTP client to refuse to connect to any non-global IP address.
 ## Useful to secure your internal environment: See https://en.wikipedia.org/wiki/Reserved_IP_addresses for a list of IPs which it will block
 # HTTP_REQUEST_BLOCK_NON_GLOBAL_IPS=true
 


### PR DESCRIPTION
This PR just makes some minor changes to the copy in `.env.template` - fixes some typos, that kinda thing.