### PR TITLE
allow signup for invited users

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -718,7 +718,10 @@ async fn register_verification_email(
 ) -> ApiResult<RegisterVerificationResponse> {
     let data = data.into_inner();
 
-    if !CONFIG.is_signup_allowed(&data.email) {
+    // the registration can only continue if signup is allowed or there exists an invitation
+    if !(CONFIG.is_signup_allowed(&data.email)
+        || (!CONFIG.mail_enabled() && Invitation::find_by_mail(&data.email, &mut conn).await.is_some()))
+    {
         err!("Registration not allowed or user already exists")
     }
 


### PR DESCRIPTION
invited users (e.g. via /admin panel or org invite) should be able to register if email is disabled.

fixes #5956