### PR TITLE
Fix an issue with yubico keys not validating

### DIFF
--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -145,15 +145,23 @@ async fn activate_yubikey(data: Json<EnableYubikeyData>, headers: Headers, mut c
 
     // Ensure they are valid OTPs
     for yubikey in &yubikeys {
-        if yubikey.len() == 12 {
-            // YubiKey ID
+        if yubikey.is_empty() || yubikey.len() == 12 {
             continue;
         }
 
         verify_yubikey_otp(yubikey.to_owned()).await.map_res("Invalid Yubikey OTP provided")?;
     }
 
-    let yubikey_ids: Vec<String> = yubikeys.into_iter().map(|x| (x[..12]).to_owned()).collect();
+    let yubikey_ids: Vec<String> = yubikeys
+        .into_iter()
+        .filter_map(|x| {
+            if x.len() >= 12 {
+                Some((x[..12]).to_owned())
+            } else {
+                None
+            }
+        })
+        .collect();
 
     let yubikey_metadata = YubikeyMetadata {
         keys: yubikey_ids,

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -152,8 +152,7 @@ async fn activate_yubikey(data: Json<EnableYubikeyData>, headers: Headers, mut c
         verify_yubikey_otp(yubikey.to_owned()).await.map_res("Invalid Yubikey OTP provided")?;
     }
 
-    let yubikey_ids: Vec<String> =
-        yubikeys.into_iter().filter_map(|x| (x.len() >= 12).then(|| x[..12].to_owned())).collect();
+    let yubikey_ids: Vec<String> = yubikeys.into_iter().filter_map(|x| x.get(..12).map(str::to_owned)).collect();
 
     let yubikey_metadata = YubikeyMetadata {
         keys: yubikey_ids,

--- a/src/api/core/two_factor/yubikey.rs
+++ b/src/api/core/two_factor/yubikey.rs
@@ -152,16 +152,8 @@ async fn activate_yubikey(data: Json<EnableYubikeyData>, headers: Headers, mut c
         verify_yubikey_otp(yubikey.to_owned()).await.map_res("Invalid Yubikey OTP provided")?;
     }
 
-    let yubikey_ids: Vec<String> = yubikeys
-        .into_iter()
-        .filter_map(|x| {
-            if x.len() >= 12 {
-                Some((x[..12]).to_owned())
-            } else {
-                None
-            }
-        })
-        .collect();
+    let yubikey_ids: Vec<String> =
+        yubikeys.into_iter().filter_map(|x| (x.len() >= 12).then(|| x[..12].to_owned())).collect();
 
     let yubikey_metadata = YubikeyMetadata {
         keys: yubikey_ids,


### PR DESCRIPTION
When adding or updating yubico otp keys there were some issues with the validation. Looks like the web-vault sends all keys, not only filled-in keys, which triggered a check on empty keys. Also, we should only return filled-in keys, not the empty ones too.

Fixes #5986