### PR TITLE
Update flags version and enable manual error reporting

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -200,15 +200,17 @@ fn get_api_webauthn(_headers: Headers) -> Json<Value> {
 fn config() -> Json<Value> {
     let domain = crate::CONFIG.domain();
     // Official available feature flags can be found here:
-    // Server (v2025.5.0): https://github.com/bitwarden/server/blob/4a7db112a0952c6df8bacf36c317e9c4e58c3651/src/Core/Constants.cs#L102
-    // Client (v2025.5.0): https://github.com/bitwarden/clients/blob/9df8a3cc50ed45f52513e62c23fcc8a4b745f078/libs/common/src/enums/feature-flag.enum.ts#L10
-    // Android (v2025.4.0): https://github.com/bitwarden/android/blob/bee09de972c3870de0d54a0067996be473ec55c7/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt#L27
-    // iOS (v2025.4.0): https://github.com/bitwarden/ios/blob/956e05db67344c912e3a1b8cb2609165d67da1c9/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
+    // Server (v2025.6.2): https://github.com/bitwarden/server/blob/d094be3267f2030bd0dc62106bc6871cf82682f5/src/Core/Constants.cs#L103
+    // Client (web-v2025.6.1): https://github.com/bitwarden/clients/blob/747c2fd6a1c348a57a76e4a7de8128466ffd3c01/libs/common/src/enums/feature-flag.enum.ts#L12
+    // Android (v2025.6.0): https://github.com/bitwarden/android/blob/b5b022caaad33390c31b3021b2c1205925b0e1a2/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt#L22
+    // iOS (v2025.6.0): https://github.com/bitwarden/ios/blob/ff06d9c6cc8da89f78f37f376495800201d7261a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
     let mut feature_states =
         parse_experimental_client_feature_flags(&crate::CONFIG.experimental_client_feature_flags());
     feature_states.insert("duo-redirect".to_string(), true);
     feature_states.insert("email-verification".to_string(), true);
     feature_states.insert("unauth-ui-refresh".to_string(), true);
+    feature_states.insert("enable-pm-flight-recorder".to_string(), true);
+    feature_states.insert("mobile-error-reporting".to_string(), true);
 
     Json(json!({
         // Note: The clients use this version to handle backwards compatibility concerns
@@ -216,7 +218,7 @@ fn config() -> Json<Value> {
         // We should make sure that we keep this updated when we support the new server features
         // Version history:
         // - Individual cipher key encryption: 2024.2.0
-        "version": "2025.4.0",
+        "version": "2025.6.0",
         "gitHash": option_env!("GIT_REV"),
         "server": {
           "name": "Vaultwarden",

--- a/src/config.rs
+++ b/src/config.rs
@@ -856,10 +856,10 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         }
     }
 
-    // Server (v2025.5.0): https://github.com/bitwarden/server/blob/4a7db112a0952c6df8bacf36c317e9c4e58c3651/src/Core/Constants.cs#L102
-    // Client (v2025.5.0): https://github.com/bitwarden/clients/blob/9df8a3cc50ed45f52513e62c23fcc8a4b745f078/libs/common/src/enums/feature-flag.enum.ts#L10
-    // Android (v2025.4.0): https://github.com/bitwarden/android/blob/bee09de972c3870de0d54a0067996be473ec55c7/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt#L27
-    // iOS (v2025.4.0): https://github.com/bitwarden/ios/blob/956e05db67344c912e3a1b8cb2609165d67da1c9/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
+    // Server (v2025.6.2): https://github.com/bitwarden/server/blob/d094be3267f2030bd0dc62106bc6871cf82682f5/src/Core/Constants.cs#L103
+    // Client (web-v2025.6.1): https://github.com/bitwarden/clients/blob/747c2fd6a1c348a57a76e4a7de8128466ffd3c01/libs/common/src/enums/feature-flag.enum.ts#L12
+    // Android (v2025.6.0): https://github.com/bitwarden/android/blob/b5b022caaad33390c31b3021b2c1205925b0e1a2/app/src/main/kotlin/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt#L22
+    // iOS (v2025.6.0): https://github.com/bitwarden/ios/blob/ff06d9c6cc8da89f78f37f376495800201d7261a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
     //
     // NOTE: Move deprecated flags to the utils::parse_experimental_client_feature_flags() DEPRECATED_FLAGS const!
     const KNOWN_FLAGS: &[&str] = &[


### PR DESCRIPTION
The recent version 2025.6.0 of the mobile application contain some helpful error reporting improvements that we can probably benefit from, but they're behind feature flags:

- `mobile-error-reporting`: When an error happens, the `An error occurred` dialog now has a `Share error log` button. This will open a system share sheet so you can send the error logs through email/github/etc.

- `enable-pm-flight-recorder`: This will allow a user to enable and share temporary event logging in the application, might be helpful to debug strange behaviors. The official help page has more info: https://bitwarden.com/help/flight-recorder/

Important to mention that both actions need to be user triggered, and they don't send the data to any server (neither Bitwarden nor Vaultwardens). The user is expected to manually send these logs through another medium like email.

I've also updated the config version and the permalinks to point to the latest version.