### PR TITLE
Fix v2025.6.x clients and newer to delete items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3648,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e81996ab38ccfb2e295ecd3250c0fb7717e29ab8814d4bc0fd6097338d87518"
+checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3681,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "4c8cea6b35bcceb099f30173754403d2eba0a5dc18cea3630fccd88251909288"
 dependencies = [
  "async-compression",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ aws-config = { version = "1.8.0", features = ["behavior-version-latest", "rt-tok
 aws-credential-types = { version = "1.2.3", optional = true }
 aws-smithy-runtime-api = { version = "1.8.1", optional = true }
 http = { version = "1.3.1", optional = true }
-reqsign = { version = "0.16.4", optional = true }
+reqsign = { version = "0.16.5", optional = true }
 
 # Strip debuginfo from the release builds
 # The debug symbols are to provide better panic traces

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -382,7 +382,7 @@ impl Cipher {
             // the "Read Only" or "Hide Passwords" restrictions for the user.
             json_object["edit"] = json!(!read_only);
             json_object["viewPassword"] = json!(!hide_passwords);
-            // The new key used by clients since v2025.6.1
+            // The new key used by clients since v2025.6.0
             json_object["permissions"] = json!({
                 "delete": !read_only,
                 "restore": !read_only,

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -382,6 +382,11 @@ impl Cipher {
             // the "Read Only" or "Hide Passwords" restrictions for the user.
             json_object["edit"] = json!(!read_only);
             json_object["viewPassword"] = json!(!hide_passwords);
+            // The new key used by clients since v2025.6.1
+            json_object["permissions"] = json!({
+                "delete": !read_only,
+                "restore": !read_only,
+            });
         }
 
         let key = match self.atype {


### PR DESCRIPTION
The new v2025.6.1 clients need the new `permissions` key/value to support deleting. By using the same flag as the current `edit` key/value we can fix this.

More fine-grained control is something we should still code, so for not this should solve those issues

Fixes #6003
Fixes #5996