### PR TITLE
fix hiding email as 2fa provider

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -57,6 +57,7 @@ fn vaultwarden_css() -> Cached<Css<String>> {
     let css_options = json!({
         "signup_disabled": !CONFIG.signups_allowed() && CONFIG.signups_domains_whitelist().is_empty(),
         "mail_enabled": CONFIG.mail_enabled(),
+        "mail_2fa_enabled": CONFIG._enable_email_2fa(),
         "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),
         "emergency_access_allowed": CONFIG.emergency_access_allowed(),
         "sends_allowed": CONFIG.sends_allowed(),

--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -118,7 +118,7 @@ app-root a[routerlink="/signup"] {
 {{/if}}
 {{/if}}
 
-{{#unless mail_enabled}}
+{{#unless mail_2fa_enabled}}
 /* Hide `Email` 2FA if mail is not enabled */
 .providers-2fa-1 {
   @extend %vw-hide;


### PR DESCRIPTION
as pointed out in #6025 we should also hide the email as 2fa provider if it was disabled explicitly.