### PR TITLE
docs(readme): add reference to data backup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ A nearly complete implementation of the Bitwarden Client API is provided, includ
 > [!TIP]
 >**For more detailed examples on how to install, use and configure Vaultwarden you can check our [Wiki](https://github.com/dani-garcia/vaultwarden/wiki).**
 
+For information on how to back up your Vaultwarden data, refer to the [Data Backup Documentation](./resources/data-backup.md).
+
 The main way to use Vaultwarden is via our container images which are published to [ghcr.io](https://github.com/dani-garcia/vaultwarden/pkgs/container/vaultwarden), [docker.io](https://hub.docker.com/r/vaultwarden/server) and [quay.io](https://quay.io/repository/vaultwarden/server).
 
 There are also [community driven packages](https://github.com/dani-garcia/vaultwarden/wiki/Third-party-packages) which can be used, but those might be lagging behind the latest version or might deviate in the way Vaultwarden is configured, as described in our [Wiki](https://github.com/dani-garcia/vaultwarden/wiki).

--- a/resources/data-backup.md
+++ b/resources/data-backup.md
@@ -1,0 +1,127 @@
+## Data Backup Instructions
+Regular data backups are critical to maintaining the integrity and availability of your Vaultwarden instance. Whether you're operating a personal password manager or managing access for a small organization, unexpected data loss can result in severe consequences—including permanent loss of credentials. Vaultwarden backups ensure that, in the event of hardware failure, configuration errors, or user mistakes, your encrypted vault data can be reliably recovered.
+
+### Why Backups Matter
+
+Vaultwarden stores sensitive information—passwords, secure notes, and credentials—for individuals and teams. Without proper backups:
+
+* You risk **total data loss** if the server is corrupted or compromised.
+* You lack a recovery option after unintended file deletions or misconfigurations.
+* You limit your ability to safely **migrate Vaultwarden to another machine or VM**.
+
+---
+
+## Backup Script and Setup
+
+The following script safely stops Vaultwarden, compresses your data directory, and transfers it to a secondary virtual machine (for offsite protection). This method is designed to work with Docker-based Vaultwarden deployments, but you can adapt it for your setup.
+
+### Features
+
+* Timestamped `.zip` archives of the entire data directory.
+* Uses `scp` for secure file transfer.
+* Works with SSH keys.
+* Can be automated via `cron`.
+
+### Backup Script (`transfer_vaultwarden_logs.sh`)
+
+```bash
+#!/bin/bash
+
+# Stop Vaultwarden container to ensure data consistency
+docker-compose down
+
+# Create timestamp for backup filename
+datestamp=$(date +%m-%d-%Y)
+
+# Define local backup directory (customize this path as needed)
+backup_dir="/home/<user>/vw-backups"
+
+# Compress Vaultwarden data directory into a timestamped zip archive
+zip -9 -r "${backup_dir}/${datestamp}.zip" /opt/vw-data*
+
+# Transfer backup to a remote machine using scp (customize SSH identity and remote user/IP)
+scp -i ~/.ssh/id_rsa "${backup_dir}/${datestamp}.zip" user@<REMOTE_IP>:~/vw-backups/
+
+# Restart Vaultwarden container
+docker-compose up -d
+```
+
+### Optional Automation Recommendation
+
+To run this daily at midnight, you can add the script to `crontab -e`:
+
+```bash
+0 0 * * * /root/transfer_vaultwarden_logs.sh
+```
+
+---
+
+## Cleanup Script (`cleanup_backups.sh`)
+
+To avoid storage bloat on the remote VM, this script keeps only the most recent backup file (last 24 hours) and deletes the rest.
+
+```bash
+#!/bin/bash
+
+# Path to directory containing backups
+backup_dir=~/backups
+
+# Navigate to backup directory
+cd "$backup_dir" || exit
+
+# Delete all zip files except those modified in the last 24 hours
+find . -type f -name '*.zip' ! -mtime -1 -exec rm {} +
+
+exit 0
+```
+
+You may also schedule this cleanup script daily on the remote VM using `crontab`.
+
+---
+
+## Using the Backup
+
+If your Vaultwarden instance becomes corrupted or you’re migrating to a new server, you can easily restore from a previous backup.
+
+### Restore Instructions
+
+1. **Stop Vaultwarden**:
+
+   ```bash
+   docker-compose down
+   ```
+
+2. **Delete the current data directory**:
+
+   ```bash
+   rm -rf /opt/vw-data/*
+   ```
+
+3. **Unzip the backup archive into `/opt/vw-data`**:
+
+   ```bash
+   unzip backups/MM-DD-YYYY.zip -d /opt/
+   ```
+
+   > Ensure that the extracted folder replaces `/opt/vw-data`, or move its contents accordingly.
+
+4. **Restart the container**:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+Your Vaultwarden instance should now be restored to the state captured in the backup file.
+
+---
+
+## Example Use Cases
+
+* **Migrating** Vaultwarden from one VM to another.
+* **Disaster recovery** after filesystem corruption or misconfiguration.
+* **Scheduled daily backups** for operational peace of mind.
+* **Testing upgrades**: Back up before a major version upgrade to roll back if needed.
+
+---
+
+If you're running Vaultwarden in a production environment, we strongly recommend integrating this backup process into your regular operations. Always test restores periodically to ensure your backups are reliable.


### PR DESCRIPTION
this pr adds a new data backup documentation in the "resources" folder, detailing backup and restore processes for vaultwarden, including automated scripts for backups and cleanup. a reference to this documentation is added under the "Usage" section in the main README.md. addresses partially the database migration point mentioned in: https://github.com/dani-garcia/vaultwarden/issues/246 . i believe in the future this documentation can be updated to support those different databases, but for now, a basic data backup walk thru is important

why this pr Is needed: vaultwarden users need reliable backup solutions to prevent data loss, enable disaster recovery, and support migrations. many community networks have asked my team how we add backup capabilities to vaultwarden. i thought it'd be easier to put this information out here instead, for ease of access to everyone. 