### PR TITLE
improve the usage section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,20 @@ A nearly complete implementation of the Bitwarden Client API is provided, includ
 ## Usage
 
 > [!IMPORTANT]
-> Most modern web browsers disallow the use of Web Crypto APIs in insecure contexts. In this case, you might get an error like `Cannot read property 'importKey'`. To solve this problem, you need to access the web vault via HTTPS or localhost.
->
->This can be configured in [Vaultwarden directly](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS) or using a third-party reverse proxy ([some examples](https://github.com/dani-garcia/vaultwarden/wiki/Proxy-examples)).
->
->If you have an available domain name, you can get HTTPS certificates with [Let's Encrypt](https://letsencrypt.org/), or you can generate self-signed certificates with utilities like [mkcert](https://github.com/FiloSottile/mkcert). Some proxies automatically do this step, like Caddy or Traefik (see examples linked above).
+> The web-vault requires the use a secure context for the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).
+> That means it will only work via `http://localhost:8000` (using the port from the example below) or if you [enable HTTPS](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS).
+
+The recommended way to install and use Vaultwarden is via our container images which are published to [ghcr.io](https://github.com/dani-garcia/vaultwarden/pkgs/container/vaultwarden), [docker.io](https://hub.docker.com/r/vaultwarden/server) and [quay.io](https://quay.io/repository/vaultwarden/server).
+See [which container image to use](https://github.com/dani-garcia/vaultwarden/wiki/Which-container-image-to-use) for an explanation of the provided tags.
+
+There are also [community driven packages](https://github.com/dani-garcia/vaultwarden/wiki/Third-party-packages) which can be used, but those might be lagging behind the latest version or might deviate in the way Vaultwarden is configured, as described in our [Wiki](https://github.com/dani-garcia/vaultwarden/wiki).
+
+Alternatively, you can also [build Vaultwarden](https://github.com/dani-garcia/vaultwarden/wiki/Building-binary) yourself.
+
+While Vaultwarden is based upon the [Rocket web framework](https://rocket.rs) which has built-in support for TLS our recommendation would be that you setup a reverse proxy (see [proxy examples](https://github.com/dani-garcia/vaultwarden/wiki/Proxy-examples).
 
 > [!TIP]
 >**For more detailed examples on how to install, use and configure Vaultwarden you can check our [Wiki](https://github.com/dani-garcia/vaultwarden/wiki).**
-
-The main way to use Vaultwarden is via our container images which are published to [ghcr.io](https://github.com/dani-garcia/vaultwarden/pkgs/container/vaultwarden), [docker.io](https://hub.docker.com/r/vaultwarden/server) and [quay.io](https://quay.io/repository/vaultwarden/server).
-
-There are also [community driven packages](https://github.com/dani-garcia/vaultwarden/wiki/Third-party-packages) which can be used, but those might be lagging behind the latest version or might deviate in the way Vaultwarden is configured, as described in our [Wiki](https://github.com/dani-garcia/vaultwarden/wiki).
 
 ### Docker/Podman CLI
 
@@ -83,7 +85,7 @@ docker run --detach --name vaultwarden \
   --env DOMAIN="https://vw.domain.tld" \
   --volume /vw-data/:/data/ \
   --restart unless-stopped \
-  --publish 80:80 \
+  --publish 127.0.0.1:8000:80 \
   vaultwarden/server:latest
 ```
 
@@ -104,7 +106,7 @@ services:
     volumes:
       - ./vw-data/:/data/
     ports:
-      - 80:80
+      - 127.0.0.1:8000:80
 ```
 
 <br>


### PR DESCRIPTION
Given a recent influx of people having issues with the infinite loading/spinning circle (cf. #5486, #5506, #5602, #5815, #5820, #5864, #5971 and also [this guy](https://www.youtube.com/embed/u_Lxkt50xOg?start=688&end=718)) I think that it might be helpful to reword the usage section a bit because at the moment it sounds a bit like this is optional and also dependent on an error message that does not show up any more. (The web-vault used [to show a toast with a warning](https://github.com/bitwarden/clients/commit/df01025dabbb1b01a7c82bde4b303fd8932e3701) but since a few releases it requires the secure context earlier and just throws an exception about that in the web console which many beginners won't check.)

Setting the port to publish to `127.0.0.1:8000` should also make it clearer that you need to open the Web-Vault via localhost or setup a reverse proxy that enables access via HTTPS if you want it accessible on other hosts.

My next TODO would be to streamline the [Proxy examples](https://github.com/dani-garcia/vaultwarden/wiki/Proxy-examples) page because at the moment they differ a lot (some using `127.0.0.1:8080`, `localhost:8080` some using `<SERVER>:80`, `<SERVER>:8080` or `<SERVER>:<SERVER_PORT>`) and also updating the [Enabling HTTPS page](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS).

I'm not that sure about the docker compose example however if I compare it with [this wiki page](https://github.com/dani-garcia/vaultwarden/wiki/Using-Docker-Compose). (Maybe it would be better to just remove it again?)