### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     # Start a local docker registry to extract the compiled binaries to upload as artifacts and attest them
     services:
       registry:
-        image: registry:sha256@1fc7de654f2ac1247f0b67e8a459e273b0993be7d2beda1f3f56fbf1001ed3e7 # v3.0.0 - https://hub.docker.com/_/registry/tags
+        image: registry:3.0.0 # https://hub.docker.com/_/registry/tags
         ports:
           - 5000:5000
     env:


### PR DESCRIPTION
Seems like docker can't use the hash references, and it fails to build: https://github.com/dani-garcia/vaultwarden/actions/runs/16242780267/job/45861396226