### PR TITLE
fix hiding of signup link

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -225,7 +225,7 @@ fn config() -> Json<Value> {
           "url": "https://github.com/dani-garcia/vaultwarden"
         },
         "settings": {
-            "disableUserRegistration": !crate::CONFIG.signups_allowed() && crate::CONFIG.signups_domains_whitelist().is_empty(),
+            "disableUserRegistration": crate::CONFIG.is_signup_disabled()
         },
         "environment": {
           "vault": domain,

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -55,7 +55,7 @@ fn not_found() -> ApiResult<Html<String>> {
 #[get("/css/vaultwarden.css")]
 fn vaultwarden_css() -> Cached<Css<String>> {
     let css_options = json!({
-        "signup_disabled": !CONFIG.signups_allowed() && CONFIG.signups_domains_whitelist().is_empty(),
+        "signup_disabled": CONFIG.is_signup_disabled(),
         "mail_enabled": CONFIG.mail_enabled(),
         "mail_2fa_enabled": CONFIG._enable_email_2fa(),
         "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1354,6 +1354,14 @@ impl Config {
         }
     }
 
+    // The registration link should be hidden if signup is not allowed and whitelist is empty
+    // unless mail is disabled and invitations are allowed
+    pub fn is_signup_disabled(&self) -> bool {
+        !self.signups_allowed()
+            && self.signups_domains_whitelist().is_empty()
+            && (self.mail_enabled() || !self.invitations_allowed())
+    }
+
     /// Tests whether the specified user is allowed to create an organization.
     pub fn is_org_creation_allowed(&self, email: &str) -> bool {
         let users = self.org_creation_users();


### PR DESCRIPTION
The registration link should be hidden if signup is not allowed and whitelist is empty unless mail is disabled and invitations are allowed

fixes #6109 