### PR TITLE
Fix Email 2FA for mobile apps

### DIFF
--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -24,6 +24,7 @@ pub fn routes() -> Vec<Route> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SendEmailLoginData {
+    #[serde(alias = "DeviceIdentifier")]
     device_identifier: DeviceId,
 
     #[allow(unused)]


### PR DESCRIPTION
Encountered this when trying to set up the Android app (2025.7.2): 
```
[vaultwarden::api::core::two_factor::email::_][WARN] Data guard `Json < SendEmailLoginData >` failed: Parse("{\"DeviceIdentifier\":info_here\"\",\"Email\":\"\",\"MasterPasswordHash\":\""}", Error("missing field `deviceIdentifier`", line: 1, column: 163)).
```