### PR TITLE
make webauthn more optional

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -9,7 +9,6 @@ use rocket::{
 };
 use serde_json::Value;
 
-use crate::api::core::two_factor::webauthn::Webauthn2FaConfig;
 use crate::{
     api::{
         core::{
@@ -49,7 +48,6 @@ async fn login(
     data: Form<ConnectData>,
     client_header: ClientHeaders,
     client_version: Option<ClientVersion>,
-    webauthn: Webauthn2FaConfig<'_>,
     mut conn: DbConn,
 ) -> JsonResult {
     let data: ConnectData = data.into_inner();
@@ -72,7 +70,7 @@ async fn login(
             _check_is_some(&data.device_name, "device_name cannot be blank")?;
             _check_is_some(&data.device_type, "device_type cannot be blank")?;
 
-            _password_login(data, &mut user_id, &mut conn, &client_header.ip, &client_version, webauthn).await
+            _password_login(data, &mut user_id, &mut conn, &client_header.ip, &client_version).await
         }
         "client_credentials" => {
             _check_is_some(&data.client_id, "client_id cannot be blank")?;
@@ -93,7 +91,7 @@ async fn login(
             _check_is_some(&data.device_name, "device_name cannot be blank")?;
             _check_is_some(&data.device_type, "device_type cannot be blank")?;
 
-            _sso_login(data, &mut user_id, &mut conn, &client_header.ip, &client_version, webauthn).await
+            _sso_login(data, &mut user_id, &mut conn, &client_header.ip, &client_version).await
         }
         "authorization_code" => err!("SSO sign-in is not available"),
         t => err!("Invalid type", t),
@@ -171,7 +169,6 @@ async fn _sso_login(
     conn: &mut DbConn,
     ip: &ClientIp,
     client_version: &Option<ClientVersion>,
-    webauthn: Webauthn2FaConfig<'_>,
 ) -> JsonResult {
     AuthMethod::Sso.check_scope(data.scope.as_ref())?;
 
@@ -270,7 +267,7 @@ async fn _sso_login(
         }
         Some((mut user, sso_user)) => {
             let mut device = get_device(&data, conn, &user).await?;
-            let twofactor_token = twofactor_auth(&user, &data, &mut device, ip, client_version, webauthn, conn).await?;
+            let twofactor_token = twofactor_auth(&user, &data, &mut device, ip, client_version, conn).await?;
 
             if user.private_key.is_none() {
                 // User was invited a stub was created
@@ -325,7 +322,6 @@ async fn _password_login(
     conn: &mut DbConn,
     ip: &ClientIp,
     client_version: &Option<ClientVersion>,
-    webauthn: Webauthn2FaConfig<'_>,
 ) -> JsonResult {
     // Validate scope
     AuthMethod::Password.check_scope(data.scope.as_ref())?;
@@ -435,7 +431,7 @@ async fn _password_login(
 
     let mut device = get_device(&data, conn, &user).await?;
 
-    let twofactor_token = twofactor_auth(&user, &data, &mut device, ip, client_version, webauthn, conn).await?;
+    let twofactor_token = twofactor_auth(&user, &data, &mut device, ip, client_version, conn).await?;
 
     let auth_tokens = auth::AuthTokens::new(&device, &user, AuthMethod::Password, data.client_id);
 
@@ -667,7 +663,6 @@ async fn twofactor_auth(
     device: &mut Device,
     ip: &ClientIp,
     client_version: &Option<ClientVersion>,
-    webauthn: Webauthn2FaConfig<'_>,
     conn: &mut DbConn,
 ) -> ApiResult<Option<String>> {
     let twofactors = TwoFactor::find_by_user(&user.uuid, conn).await;
@@ -687,7 +682,7 @@ async fn twofactor_auth(
         Some(ref code) => code,
         None => {
             err_json!(
-                _json_err_twofactor(&twofactor_ids, &user.uuid, data, client_version, webauthn, conn).await?,
+                _json_err_twofactor(&twofactor_ids, &user.uuid, data, client_version, conn).await?,
                 "2FA token not provided"
             )
         }
@@ -704,9 +699,7 @@ async fn twofactor_auth(
         Some(TwoFactorType::Authenticator) => {
             authenticator::validate_totp_code_str(&user.uuid, twofactor_code, &selected_data?, ip, conn).await?
         }
-        Some(TwoFactorType::Webauthn) => {
-            webauthn::validate_webauthn_login(&user.uuid, twofactor_code, webauthn, conn).await?
-        }
+        Some(TwoFactorType::Webauthn) => webauthn::validate_webauthn_login(&user.uuid, twofactor_code, conn).await?,
         Some(TwoFactorType::YubiKey) => yubikey::validate_yubikey_login(twofactor_code, &selected_data?).await?,
         Some(TwoFactorType::Duo) => {
             match CONFIG.duo_use_iframe() {
@@ -738,7 +731,7 @@ async fn twofactor_auth(
                 }
                 _ => {
                     err_json!(
-                        _json_err_twofactor(&twofactor_ids, &user.uuid, data, client_version, webauthn, conn).await?,
+                        _json_err_twofactor(&twofactor_ids, &user.uuid, data, client_version, conn).await?,
                         "2FA Remember token not provided"
                     )
                 }
@@ -772,7 +765,6 @@ async fn _json_err_twofactor(
     user_id: &UserId,
     data: &ConnectData,
     client_version: &Option<ClientVersion>,
-    webauthn: Webauthn2FaConfig<'_>,
     conn: &mut DbConn,
 ) -> ApiResult<Value> {
     let mut result = json!({
@@ -792,7 +784,7 @@ async fn _json_err_twofactor(
             Some(TwoFactorType::Authenticator) => { /* Nothing to do for TOTP */ }
 
             Some(TwoFactorType::Webauthn) if CONFIG.domain_set() => {
-                let request = webauthn::generate_webauthn_login(user_id, webauthn, conn).await?;
+                let request = webauthn::generate_webauthn_login(user_id, conn).await?;
                 result["TwoFactorProviders2"][provider.to_string()] = request.0;
             }
 

--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -64,6 +64,7 @@ fn vaultwarden_css() -> Cached<Css<String>> {
         "sso_enabled": CONFIG.sso_enabled(),
         "sso_only": CONFIG.sso_enabled() && CONFIG.sso_only(),
         "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),
+        "webauthn_2fa_supported": CONFIG.is_webauthn_2fa_supported(),
     });
 
     let scss = match CONFIG.render_template("scss/vaultwarden.scss", &css_options) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1525,6 +1525,10 @@ impl Config {
         }
     }
 
+    pub fn is_webauthn_2fa_supported(&self) -> bool {
+        Url::parse(&self.domain()).expect("DOMAIN not a valid URL").domain().is_some()
+    }
+
     /// Tests whether the admin token is set to a non-empty value.
     pub fn is_admin_token_set(&self) -> bool {
         let token = self.admin_token();

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ mod sso_client;
 mod util;
 
 use crate::api::core::two_factor::duo_oidc::purge_duo_contexts;
-use crate::api::core::two_factor::webauthn::WEBAUTHN_2FA_CONFIG;
 use crate::api::purge_auth_requests;
 use crate::api::{WS_ANONYMOUS_SUBSCRIPTIONS, WS_USERS};
 pub use config::{PathType, CONFIG};
@@ -601,7 +600,6 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         .manage(pool)
         .manage(Arc::clone(&WS_USERS))
         .manage(Arc::clone(&WS_ANONYMOUS_SUBSCRIPTIONS))
-        .manage(Arc::clone(&WEBAUTHN_2FA_CONFIG))
         .attach(util::AppHeaders())
         .attach(util::Cors())
         .attach(util::BetterLogging(extra_debug))

--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -172,6 +172,13 @@ app-root a[routerlink="/signup"] {
 }
 {{/unless}}
 
+{{#unless webauthn_2fa_supported}}
+/* Hide `Passkey` 2FA if it is not supported */
+.providers-2fa-7 {
+  @extend %vw-hide;
+}
+{{/unless}}
+
 {{#unless emergency_access_allowed}}
 /* Hide Emergency Access if not allowed */
 bit-nav-item[route="settings/emergency-access"] {


### PR DESCRIPTION
I don't think that we need initialize webauthn on startup (which currently fails if you set `DOMAIN` to an IP address because [webauthn requires a domain name as `rp_id`](https://www.w3.org/TR/webauthn-2/#relying-party-identifier)). I've also hidden it as an option if you have setup the [domain](https://docs.rs/url/2.5.4/url/struct.Url.html#method.domain) to be an IP address.

This won't touch on the other issues that were reported but I do think that it's important that Vaultwarden can start with something like `DOMAIN=http://127.0.0.1:8000`. 