### PR TITLE
Make database connection pool dynamic

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -636,8 +636,14 @@ make_config! {
         /// Timeout when acquiring database connection
         database_timeout:       u64,    false,  def,    30;
 
-        /// Database connection pool size
+        /// Timeout in seconds before idle connections to the database are closed
+        database_idle_timeout:  u64,    false, def,     60;
+
+        /// Database connection max pool size
         database_max_conns:     u32,    false,  def,    10;
+
+        /// Database connection min pool size
+        database_min_conns:     u32,    false,  def,    2;
 
         /// Database connection init |> SQL statements to run when creating a new database connection, mainly useful for connection-scoped pragmas. If empty, a database-specific default is used.
         database_conn_init:     String, false,  def,    String::new();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -134,6 +134,8 @@ macro_rules! generate_connections {
                             let manager = ConnectionManager::new(&url);
                             let pool = Pool::builder()
                                 .max_size(CONFIG.database_max_conns())
+                                .min_idle(Some(CONFIG.database_min_conns()))
+                                .idle_timeout(Some(Duration::from_secs(CONFIG.database_idle_timeout())))
                                 .connection_timeout(Duration::from_secs(CONFIG.database_timeout()))
                                 .connection_customizer(Box::new(DbConnOptions{
                                     init_stmts: conn_type.get_init_stmts()


### PR DESCRIPTION
Hello,

I've notice that Vaultwarden always keep his database pool fully connected to the database. Since my instance of Vaultwarden has a light load this resulted in 10 database connections being almost always in idle.

This PR fix this by using `min_idle` and `idle_timeout` options of the database pool manager. This allow the app to keep only 2 sessions at minimum while allowing the pool to grow when there is more load.