### PR TITLE
Enable block-browser-injections-by-domain feature

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -212,6 +212,7 @@ fn config() -> Json<Value> {
     feature_states.insert("unauth-ui-refresh".to_string(), true);
     feature_states.insert("enable-pm-flight-recorder".to_string(), true);
     feature_states.insert("mobile-error-reporting".to_string(), true);
+    feature_states.insert("block-browser-injections-by-domain".to_string(), true);
 
     Json(json!({
         // Note: The clients use this version to handle backwards compatibility concerns


### PR DESCRIPTION
I tried to follow https://bitwarden.com/help/blocking-uris/, but the option is not visible in my browser extension.
It's an important feature, as the extension messes up some sites.

I tracked it down to the `block-browser-injections-by-domain` feature flag.

It seems to be enabled in the official client, so it makes sense to also enable here.

Btw. it would have been much easier if the `experimental_client_feature_flags` would not be checked against a hardcoded list of `KNOWN_FLAGS`.

Would it be possible to remove that check? Would have saved me a couple of hours...