### PR TITLE
#6163: Fix panic when SSO_MASTER_PASSWORD_POLICY is non-json

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -111,7 +111,14 @@ async fn master_password_policy(user: &User, conn: &DbConn) -> Value {
             }
         }))
     } else if let Some(policy_str) = CONFIG.sso_master_password_policy().filter(|_| CONFIG.sso_enabled()) {
-        serde_json::from_str(&policy_str).unwrap_or(json!({}))
+        // Use a match statement to handle Ok and Err results gracefully.
+        match serde_json::from_str(&policy_str) {
+            Ok(val) => val,
+            Err(_) => {
+                warn!("Failed to parse sso_master_password_policy configuration string: {}", policy_str);
+                json!({})
+            },
+        }
     } else {
         json!({})
     };


### PR DESCRIPTION
Dear Maintainers,

Thanks for this project. I replaced gmail drafts (as my secret store lol), Google authenticator, Apple Notes & several others with this vaultwarden & authenticator services.

Regarding this PR, it's a proposal to [#6163](https://github.com/dani-garcia/vaultwarden/issues/6163). I am novice when it comes go `rust` but I think I got the problem right. I hope this will address this problem.

