### PR TITLE
Re-add `if` check to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   docker-build:
     name: Build Vaultwarden containers
+    if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
- prevents container builds from running on forks