### PR TITLE
Fix panic around sso_master_password_policy

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -2063,12 +2063,12 @@ async fn list_policies_token(org_id: OrganizationId, token: &str, mut conn: DbCo
 async fn get_master_password_policy(org_id: OrganizationId, _headers: Headers, mut conn: DbConn) -> JsonResult {
     let policy =
         OrgPolicy::find_by_org_and_type(&org_id, OrgPolicyType::MasterPassword, &mut conn).await.unwrap_or_else(|| {
-            let data = match CONFIG.sso_master_password_policy() {
-                Some(policy) => policy,
-                None => "null".to_string(),
+            let (enabled, data) = match CONFIG.sso_master_password_policy_value() {
+                Some(policy) if CONFIG.sso_enabled() => (true, policy.to_string()),
+                _ => (false, "null".to_string()),
             };
 
-            OrgPolicy::new(org_id, OrgPolicyType::MasterPassword, CONFIG.sso_master_password_policy().is_some(), data)
+            OrgPolicy::new(org_id, OrgPolicyType::MasterPassword, enabled, data)
         });
 
     Ok(Json(policy.to_json()))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -110,8 +110,8 @@ async fn master_password_policy(user: &User, conn: &DbConn) -> Value {
                 enforce_on_login: acc.enforce_on_login || policy.enforce_on_login,
             }
         }))
-    } else if let Some(policy_str) = CONFIG.sso_master_password_policy().filter(|_| CONFIG.sso_enabled()) {
-        serde_json::from_str(&policy_str).unwrap_or(json!({}))
+    } else if CONFIG.sso_enabled() {
+        CONFIG.sso_master_password_policy_value().unwrap_or(json!({}))
     } else {
         json!({})
     };


### PR DESCRIPTION
Should fix https://github.com/dani-garcia/vaultwarden/issues/6163 which happened when the config was a valid `serde_json::Value` but not an `Object`.