### PR TITLE
Fix around singleorg policy

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     api::{EmptyResult, JsonResult, Notify, UpdateType},
     auth::Headers,
     db::{
-        models::{Membership, MembershipStatus, MembershipType, OrgPolicy, OrgPolicyErr, Organization, User},
+        models::{Membership, MembershipStatus, OrgPolicy, Organization, User},
         DbConn,
     },
     error::Error,
@@ -269,26 +269,11 @@ async fn accept_org_invite(
         err!("User already accepted the invitation");
     }
 
-    // This check is also done at accept_invite, _confirm_invite, _activate_member, edit_member, admin::update_membership_type
-    // It returns different error messages per function.
-    if member.atype < MembershipType::Admin {
-        match OrgPolicy::is_user_allowed(&member.user_uuid, &member.org_uuid, false, conn).await {
-            Ok(_) => {}
-            Err(OrgPolicyErr::TwoFactorMissing) => {
-                if crate::CONFIG.email_2fa_auto_fallback() {
-                    two_factor::email::activate_email_2fa(user, conn).await?;
-                } else {
-                    err!("You cannot join this organization until you enable two-step login on your user account");
-                }
-            }
-            Err(OrgPolicyErr::SingleOrgEnforced) => {
-                err!("You cannot join this organization because you are a member of an organization which forbids it");
-            }
-        }
-    }
-
     member.status = MembershipStatus::Accepted as i32;
     member.reset_password_key = reset_password_key;
+
+    // This check is also done at accept_invite, _confirm_invite, _activate_member, edit_member, admin::update_membership_type
+    OrgPolicy::check_user_allowed(&member, "join", conn).await?;
 
     member.save(conn).await?;
 

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -27,7 +27,7 @@ pub use self::event::{Event, EventType};
 pub use self::favorite::Favorite;
 pub use self::folder::{Folder, FolderCipher, FolderId};
 pub use self::group::{CollectionGroup, Group, GroupId, GroupUser};
-pub use self::org_policy::{OrgPolicy, OrgPolicyErr, OrgPolicyId, OrgPolicyType};
+pub use self::org_policy::{OrgPolicy, OrgPolicyId, OrgPolicyType};
 pub use self::organization::{
     Membership, MembershipId, MembershipStatus, MembershipType, OrgApiKeyId, Organization, OrganizationApiKey,
     OrganizationId,

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -883,10 +883,15 @@ impl Membership {
         }}
     }
 
-    pub async fn count_accepted_and_confirmed_by_user(user_uuid: &UserId, conn: &DbConn) -> i64 {
+    pub async fn count_accepted_and_confirmed_by_user(
+        user_uuid: &UserId,
+        excluded_org: &OrganizationId,
+        conn: &DbConn,
+    ) -> i64 {
         db_run! { conn: {
             users_organizations::table
                 .filter(users_organizations::user_uuid.eq(user_uuid))
+                .filter(users_organizations::org_uuid.ne(excluded_org))
                 .filter(users_organizations::status.eq(MembershipStatus::Accepted as i32).or(users_organizations::status.eq(MembershipStatus::Confirmed as i32)))
                 .count()
                 .first::<i64>(conn)

--- a/src/static/templates/email/send_single_org_removed_from_org.hbs
+++ b/src/static/templates/email/send_single_org_removed_from_org.hbs
@@ -1,4 +1,4 @@
-You have been removed from {{{org_name}}}
+Your access to {{{org_name}}} has been revoked
 <!---------------->
-Your user account has been removed from the *{{org_name}}* organization because you are a part of another organization. The {{org_name}} organization has enabled a policy that prevents users from being a part of multiple organizations. Before you can re-join this organization you need to leave all other organizations or join with a different account.
+Your access to the *{{org_name}}* organization has been revoked because you are a part of another organization. The {{org_name}} organization has enabled a policy that prevents users from being a part of multiple organizations. Before your access can be restored you need to leave all other organizations or join with a different account.
 {{> email/email_footer_text }}

--- a/src/static/templates/email/send_single_org_removed_from_org.html.hbs
+++ b/src/static/templates/email/send_single_org_removed_from_org.html.hbs
@@ -1,10 +1,10 @@
-You have been removed from {{{org_name}}}
+Your access to {{{org_name}}} has been revoked
 <!---------------->
 {{> email/email_header }}
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
       <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
-         Your user account has been removed from the <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{org_name}}</b> organization because you are a part of another organization. The {{org_name}} organization has enabled a policy that prevents users from being a part of multiple organizations. Before you can re-join this organization you need to leave all other organizations or join with a different account.
+         Your access to the <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{org_name}}</b> organization has been revoked because you are a part of another organization. The {{org_name}} organization has enabled a policy that prevents users from being a part of multiple organizations. Before your access can be restored you need to leave all other organizations or join with a different account.
       </td>
    </tr>
 </table>


### PR DESCRIPTION
Should fix:

- Prevent a user already in an org to join an organization with the single org policy activated
- When activating the single org policy revoke the membership (as mentioned in the warning) instead of deleting.
- Allow to restore an invitation

Moved all the logic back to the `check_user_allowed` instead of having to duplicate it from all call site, might make sense to move it out, inside a mod.rs maybe ?

Add the Admin and Invited membership test in `check_user_allowed`, means that all membership modification need to be done before calling the  check.