### PR TITLE
Fix `sso_user` dropped on `User::save`

### DIFF
--- a/src/static/scripts/admin_users.js
+++ b/src/static/scripts/admin_users.js
@@ -33,11 +33,11 @@ function deleteSSOUser(event) {
         alert("Required parameters not found!");
         return false;
     }
-    const input_email = prompt(`To delete user "${email}", please type the email below`);
+    const input_email = prompt(`To delete user "${email}" SSO association, please type the email below`);
     if (input_email != null) {
         if (input_email == email) {
             _delete(`${BASE_URL}/admin/users/${id}/sso`,
-                "User SSO Associtation deleted correctly",
+                "User SSO association deleted correctly",
                 "Error deleting user SSO association"
             );
         } else {


### PR DESCRIPTION
Should fix https://github.com/dani-garcia/vaultwarden/issues/6179#issuecomment-3242088962

The issue is that if there is no `ForeignKeyViolation` a `User::save` first delete the record with `sqlite` and `mysql`.

Since the `sso_user` table was added with `ON UPDATE CASCADE ON DELETE CASCADE`, the violation was not triggered and the entry was deleted.

I thought changing the `save` logic was better than changing the cascade logic since :

- Especially for users `update` is the happy path (as opposed to the violation being triggered in most cases).
- It does not prevent using cascade
- Less of a trap (it was missed during the review and testing, running with `SSO_SIGNUPS_MATCH_EMAIL` the association was just restored).

Made the change only for `User` but it probably would apply to most table.