### PR TITLE
Add output dir option to backup command

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -799,7 +799,7 @@ async fn delete_config(_token: AdminToken) -> EmptyResult {
 #[post("/config/backup_db", format = "application/json")]
 fn backup_db(_token: AdminToken) -> ApiResult<String> {
     if *CAN_BACKUP {
-        match backup_sqlite() {
+        match backup_sqlite(None) {
             Ok(f) => Ok(format!("Backup to '{f}' was successful")),
             Err(e) => err!(format!("Backup was unsuccessful {e}")),
         }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -385,7 +385,7 @@ pub mod models;
 /// Creates a back-up of the sqlite database
 /// MySQL/MariaDB and PostgreSQL are not supported.
 #[cfg(sqlite)]
-pub fn backup_sqlite() -> Result<String, Error> {
+pub fn backup_sqlite(output_dir: Option<String>) -> Result<String, Error> {
     use diesel::Connection;
     use std::{fs::File, io::Write};
 
@@ -395,8 +395,18 @@ pub fn backup_sqlite() -> Result<String, Error> {
         // This way we can set a readonly flag on the opening mode without issues.
         let mut conn = diesel::sqlite::SqliteConnection::establish(&format!("sqlite://{db_url}?mode=ro"))?;
 
-        let db_path = std::path::Path::new(&db_url).parent().unwrap();
-        let backup_file = db_path
+        let backup_dir = match &output_dir {
+            Some(dir) => {
+                let output_path = std::path::Path::new(dir);
+                if !output_path.exists() || !output_path.is_dir() {
+                    err!(format!("Backup directory does not exist or is not a directory: {}", dir));
+                }
+                output_path
+            }
+            None => std::path::Path::new(&db_url).parent().unwrap(),
+        };
+
+        let backup_file = backup_dir
             .join(format!("db_{}.sqlite3", chrono::Utc::now().format("%Y%m%d_%H%M%S")))
             .to_string_lossy()
             .into_owned();
@@ -417,7 +427,7 @@ pub fn backup_sqlite() -> Result<String, Error> {
 }
 
 #[cfg(not(sqlite))]
-pub fn backup_sqlite() -> Result<String, Error> {
+pub fn backup_sqlite(_output_dir: Option<String>) -> Result<String, Error> {
     err_silent!("The database type is not SQLite. Backups only works for SQLite databases")
 }
 


### PR DESCRIPTION
Closes #6347, #5973

I added the CLI option as discussed in #6347. As I mentioned, I'm not familiar with Rust. I tested my changes to confirm they work, but I don't know anything about Rust best practices.

While implementing this, I noticed that there seem to be three ways to trigger the backup process: via the CLI, the USR1 signal or an API call. Bearing this in mind, I'm wondering whether the current approach is sensible, given that only the CLI will benefit from the change. Might it be more future-proof to add a config entry for the backup path instead of the CLI option to handle all three variants in the same way? For this reason, I am opening this as a draft to discuss this question.

Thanks in advance for spending time on my PR/feature request.