### PR TITLE
add seat limit for the invite dialog

### DIFF
--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -473,7 +473,7 @@ impl Membership {
             "id": self.org_uuid,
             "identifier": null, // Not supported
             "name": org.name,
-            "seats": null,
+            "seats": 20, // hardcoded maxEmailsCount in the web-vault
             "maxCollections": null,
             "usersGetPremium": true,
             "use2fa": true,


### PR DESCRIPTION
Adding a seat limit so that (as discussed/suggested here https://github.com/dani-garcia/bw_web_builds/pull/218#issuecomment-3415682716) the invite dialog shows the help text that you can invite multiple members by separating the mail addresses with a comma:
<img width="925" height="387" alt="image" src="https://github.com/user-attachments/assets/8be7b0a7-9ef2-493a-9cf1-4680d56fe4c5" />

The number 20 was chosen because it is the [hardcoded limit](https://github.com/bitwarden/clients/blob/f3af6a813aa7ae7ec3c0581609af0f0c2e81146c/apps/web/src/app/admin-console/organizations/members/components/member-dialog/validators/input-email-limit.validator.ts#L30) in the web-vault:
<img width="426" height="115" alt="image" src="https://github.com/user-attachments/assets/cc4ac7c1-c39e-453f-bc4f-9bc0e0dfa080" />