### PR TITLE
add mail address change warning for invited accounts

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -909,10 +909,20 @@ async fn post_email_token(data: Json<EmailTokenData>, headers: Headers, mut conn
         err!("Invalid password")
     }
 
-    if User::find_by_mail(&data.new_email, &mut conn).await.is_some() {
+    if let Some(existing_user) = User::find_by_mail(&data.new_email, &mut conn).await {
         if CONFIG.mail_enabled() {
-            if let Err(e) = mail::send_change_email_existing(&data.new_email, &user.email).await {
-                error!("Error sending change-email-existing email: {e:#?}");
+            // check if existing_user has already registered
+            if existing_user.password_hash.is_empty() {
+                // inform an invited user about how to delete their temporary account if the
+                // request was done intentionally and they want to update their mail address
+                if let Err(e) = mail::send_change_email_invited(&data.new_email, &user.email).await {
+                    error!("Error sending change-email-invited email: {e:#?}");
+                }
+            } else {
+                // inform existing user about the failed attempt to change their mail address
+                if let Err(e) = mail::send_change_email_existing(&data.new_email, &user.email).await {
+                    error!("Error sending change-email-existing email: {e:#?}");
+                }
             }
         }
         err!("Email already in use");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1643,6 +1643,7 @@ where
 
     reg!("email/admin_reset_password", ".html");
     reg!("email/change_email_existing", ".html");
+    reg!("email/change_email_invited", ".html");
     reg!("email/change_email", ".html");
     reg!("email/delete_account", ".html");
     reg!("email/emergency_access_invite_accepted", ".html");

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -588,6 +588,20 @@ pub async fn send_change_email_existing(address: &str, acting_address: &str) -> 
     send_email(address, &subject, body_html, body_text).await
 }
 
+pub async fn send_change_email_invited(address: &str, acting_address: &str) -> EmptyResult {
+    let (subject, body_html, body_text) = get_text(
+        "email/change_email_invited",
+        json!({
+            "url": CONFIG.domain(),
+            "img_src": CONFIG._smtp_img_src(),
+            "existing_address": address,
+            "acting_address": acting_address,
+        }),
+    )?;
+
+    send_email(address, &subject, body_html, body_text).await
+}
+
 pub async fn send_sso_change_email(address: &str) -> EmptyResult {
     let (subject, body_html, body_text) = get_text(
         "email/sso_change_email",

--- a/src/static/templates/email/change_email_invited.hbs
+++ b/src/static/templates/email/change_email_invited.hbs
@@ -1,0 +1,11 @@
+Your Email Change
+<!---------------->
+A user ({{ acting_address }}) recently tried to change their account to use this email address ({{ existing_address }}). You already have been invited to join Vaultwarden using this address.
+
+To change your email address you first would have to delete the account associated with this email address ({{ existing_address }}):
+Request account deletion: {{url}}/#/recover-delete
+
+Once that is done you can change the email address of your existing account to this address. Any invitation would have to be redone.
+
+If you did not try to change an email address, contact your administrator.
+{{> email/email_footer_text }}

--- a/src/static/templates/email/change_email_invited.html.hbs
+++ b/src/static/templates/email/change_email_invited.html.hbs
@@ -1,0 +1,30 @@
+Your Email Change
+<!---------------->
+{{> email/email_header }}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+   <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+      <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
+      A user ({{ acting_address }}) recently tried to change their account to use this email address ({{ existing_address }}). You already have been invited to join Vaultwarden using this address.
+      </td>
+   </tr>
+   <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+      <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
+      To change your email address you first would have to delete the account associated with this email address ({{ existing_address }}):
+         <a data-testid="recover-delete" href="{{url}}/#/recover-delete"
+            clicktracking=off target="_blank" style="color: #ffffff; text-decoration: none; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; background-color: #3c8dbc; border-color: #3c8dbc; border-style: solid; border-width: 10px 20px; margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+	    Request account deletion
+	 </a>
+      </td>
+   </tr>
+   <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+      <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
+      Once that is done you can change the email address of your existing account to this address. Any invitation would have to be redone.
+      </td>
+   </tr>
+   <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+      <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; text-align: center;" valign="top" align="center">
+         If you did not try to change an email address, contact your administrator.
+      </td>
+   </tr>
+</table>
+{{> email/email_footer }}


### PR DESCRIPTION
add a new mail template to differentiate between existing accounts and only invited accounts, so that they can easier delete an existing placeholder account.

E.g. if an existing user (`existing_user@example.com`) tried to change their mail to an account that has not registered (`invited_user@example.net`), `invited_user@example.net` would get a new warning mail:

<img width="871" height="541" alt="fixed_example" src="https://github.com/user-attachments/assets/6db1b99a-ddbb-47fe-86c2-1b9d8e9a6d1f" />

If an user account for the new mail already exists (i.e. the account has been registered) they would still get the old warning information because we don't want them to delete their accounts. (If they want that they can easily do that on their own when they have logged in in their account settings page...)