### PR TITLE
add missing media-src directive

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -95,6 +95,7 @@ impl Fairing for AppHeaders {
                     manifest-src 'self'; \
                     base-uri 'self'; \
                     form-action 'self'; \
+                    media-src 'self'; \
                     object-src 'self' blob:; \
                     script-src 'self' 'wasm-unsafe-eval'; \
                     style-src 'self' 'unsafe-inline'; \


### PR DESCRIPTION
In `web-v2025.10.0` if you don't have the extension installed a new splash screen will show up after your first login on a device and before showing the vault - which embeds three video files that require `media-src: self;` to be added. Cf. https://github.com/dani-garcia/bw_web_builds/pull/218#issuecomment-3422578201

[Peek 2025-10-20 17-31.webm](https://github.com/user-attachments/assets/b4705a0f-47e2-4a98-876b-6c3346afdc3c)