### PR TITLE
Use insert_into when possible

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1489,7 +1489,7 @@ async fn post_auth_request(
         _ => err!("AuthRequest doesn't exist", "Device verification failed"),
     };
 
-    let mut auth_request = AuthRequest::new(
+    let auth_request = AuthRequest::new(
         user.uuid.clone(),
         data.device_identifier.clone(),
         client_headers.device_type,

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1485,7 +1485,7 @@ async fn post_auth_request(
         _ => err!("AuthRequest doesn't exist", "Device verification failed"),
     };
 
-    let mut auth_request = AuthRequest::new(
+    let auth_request = AuthRequest::new(
         user.uuid.clone(),
         data.device_identifier.clone(),
         client_headers.device_type,

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1611,7 +1611,7 @@ async fn post_auth_request(
         _ => err!("AuthRequest doesn't exist", "Device verification failed"),
     };
 
-    let mut auth_request = AuthRequest::new(
+    let auth_request = AuthRequest::new(
         user.uuid.clone(),
         data.device_identifier.clone(),
         client_headers.device_type,

--- a/src/db/models/archive.rs
+++ b/src/db/models/archive.rs
@@ -41,17 +41,20 @@ impl Archive {
     ) -> EmptyResult {
         User::update_uuid_revision(user_uuid, conn).await;
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(archives::table)
+            mysql {
+                diesel::insert_into(archives::table)
                     .values((
                         archives::user_uuid.eq(user_uuid),
                         archives::cipher_uuid.eq(cipher_uuid),
                         archives::archived_at.eq(archived_at),
                     ))
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(archives::archived_at.eq(archived_at))
                     .execute(conn)
                     .map_res("Error saving archive")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(archives::table)
                     .values((
                         archives::user_uuid.eq(user_uuid),

--- a/src/db/models/attachment.rs
+++ b/src/db/models/attachment.rs
@@ -82,24 +82,16 @@ impl Attachment {
 impl Attachment {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(attachments::table)
+            mysql {
+                diesel::insert_into(attachments::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(attachments::table)
-                            .filter(attachments::id.eq(&self.id))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving attachment")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving attachment")
+                    .map_res("Error saving attachment")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(attachments::table)
                     .values(self)
                     .on_conflict(attachments::id)

--- a/src/db/models/auth_request.rs
+++ b/src/db/models/auth_request.rs
@@ -82,31 +82,23 @@ impl AuthRequest {
 }
 
 impl AuthRequest {
-    pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(auth_requests::table)
-                    .values(&*self)
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(auth_requests::table)
-                            .filter(auth_requests::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error auth_request")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error auth_request")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(auth_requests::table)
-                    .values(&*self)
+                    .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving auth_request")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(auth_requests::table)
+                    .values(self)
                     .on_conflict(auth_requests::uuid)
                     .do_update()
-                    .set(&*self)
+                    .set(self)
                     .execute(conn)
                     .map_res("Error saving auth_request")
             }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -444,24 +444,16 @@ impl Cipher {
         self.updated_at = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(ciphers::table)
+            mysql {
+                diesel::insert_into(ciphers::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(ciphers::table)
-                            .filter(ciphers::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving cipher")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving cipher")
+                    .map_res("Error saving cipher")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(ciphers::table)
                     .values(&*self)
                     .on_conflict(ciphers::uuid)

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -440,24 +440,16 @@ impl Cipher {
         self.updated_at = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(ciphers::table)
+            mysql {
+                diesel::insert_into(ciphers::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(ciphers::table)
-                            .filter(ciphers::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving cipher")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving cipher")
+                    .map_res("Error saving cipher")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(ciphers::table)
                     .values(&*self)
                     .on_conflict(ciphers::uuid)

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -158,24 +158,16 @@ impl Collection {
         self.update_users_revision(conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections::table)
+            mysql {
+                diesel::insert_into(collections::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections::table)
-                            .filter(collections::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving collection")
+                    .map_res("Error saving collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(collections::table)
                     .values(self)
                     .on_conflict(collections::uuid)
@@ -610,53 +602,30 @@ impl CollectionUser {
     ) -> EmptyResult {
         User::update_uuid_revision(user_uuid, conn).await;
 
+        let values = (
+            users_collections::user_uuid.eq(user_uuid),
+            users_collections::collection_uuid.eq(collection_uuid),
+            users_collections::read_only.eq(read_only),
+            users_collections::hide_passwords.eq(hide_passwords),
+            users_collections::manage.eq(manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_collections::table)
-                            .filter(users_collections::user_uuid.eq(user_uuid))
-                            .filter(users_collections::collection_uuid.eq(collection_uuid))
-                            .set((
-                                users_collections::user_uuid.eq(user_uuid),
-                                users_collections::collection_uuid.eq(collection_uuid),
-                                users_collections::read_only.eq(read_only),
-                                users_collections::hide_passwords.eq(hide_passwords),
-                                users_collections::manage.eq(manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding user to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(users_collections::table)
+                    .values(values)
                     .on_conflict((users_collections::user_uuid, users_collections::collection_uuid))
                     .do_update()
-                    .set((
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding user to collection")
             }
@@ -772,19 +741,18 @@ impl CollectionCipher {
         Self::update_users_revision(collection_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here.
-                // Table ciphers_collections does not have ForeignKey Constraints which would cause conflicts.
-                // This table has no constraints pointing to itself, but only to others.
-                diesel::replace_into(ciphers_collections::table)
+            mysql {
+                diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),
                         ciphers_collections::collection_uuid.eq(collection_uuid),
                     ))
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding cipher to collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -162,24 +162,16 @@ impl Collection {
         self.update_users_revision(conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections::table)
+            mysql {
+                diesel::insert_into(collections::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections::table)
-                            .filter(collections::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving collection")
+                    .map_res("Error saving collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(collections::table)
                     .values(self)
                     .on_conflict(collections::uuid)
@@ -681,53 +673,30 @@ impl CollectionUser {
     ) -> EmptyResult {
         User::update_uuid_revision(user_uuid, conn).await;
 
+        let values = (
+            users_collections::user_uuid.eq(user_uuid),
+            users_collections::collection_uuid.eq(collection_uuid),
+            users_collections::read_only.eq(read_only),
+            users_collections::hide_passwords.eq(hide_passwords),
+            users_collections::manage.eq(manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_collections::table)
-                            .filter(users_collections::user_uuid.eq(user_uuid))
-                            .filter(users_collections::collection_uuid.eq(collection_uuid))
-                            .set((
-                                users_collections::user_uuid.eq(user_uuid),
-                                users_collections::collection_uuid.eq(collection_uuid),
-                                users_collections::read_only.eq(read_only),
-                                users_collections::hide_passwords.eq(hide_passwords),
-                                users_collections::manage.eq(manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding user to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(users_collections::table)
+                    .values(values)
                     .on_conflict((users_collections::user_uuid, users_collections::collection_uuid))
                     .do_update()
-                    .set((
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding user to collection")
             }
@@ -862,19 +831,18 @@ impl CollectionCipher {
         Self::update_users_revision(collection_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here.
-                // Table ciphers_collections does not have ForeignKey Constraints which would cause conflicts.
-                // This table has no constraints pointing to itself, but only to others.
-                diesel::replace_into(ciphers_collections::table)
+            mysql {
+                diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),
                         ciphers_collections::collection_uuid.eq(collection_uuid),
                     ))
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding cipher to collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -168,24 +168,16 @@ impl Collection {
         self.update_users_revision(conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections::table)
+            mysql {
+                diesel::insert_into(collections::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections::table)
-                            .filter(collections::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving collection")
+                    .map_res("Error saving collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(collections::table)
                     .values(self)
                     .on_conflict(collections::uuid)
@@ -728,53 +720,30 @@ impl CollectionUser {
     ) -> EmptyResult {
         User::update_uuid_revision(user_uuid, conn).await;
 
+        let values = (
+            users_collections::user_uuid.eq(user_uuid),
+            users_collections::collection_uuid.eq(collection_uuid),
+            users_collections::read_only.eq(read_only),
+            users_collections::hide_passwords.eq(hide_passwords),
+            users_collections::manage.eq(manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_collections::table)
-                            .filter(users_collections::user_uuid.eq(user_uuid))
-                            .filter(users_collections::collection_uuid.eq(collection_uuid))
-                            .set((
-                                users_collections::user_uuid.eq(user_uuid),
-                                users_collections::collection_uuid.eq(collection_uuid),
-                                users_collections::read_only.eq(read_only),
-                                users_collections::hide_passwords.eq(hide_passwords),
-                                users_collections::manage.eq(manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(users_collections::table)
-                    .values((
-                        users_collections::user_uuid.eq(user_uuid),
-                        users_collections::collection_uuid.eq(collection_uuid),
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding user to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(users_collections::table)
+                    .values(values)
                     .on_conflict((users_collections::user_uuid, users_collections::collection_uuid))
                     .do_update()
-                    .set((
-                        users_collections::read_only.eq(read_only),
-                        users_collections::hide_passwords.eq(hide_passwords),
-                        users_collections::manage.eq(manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding user to collection")
             }
@@ -909,19 +878,18 @@ impl CollectionCipher {
         Self::update_users_revision(collection_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here.
-                // Table ciphers_collections does not have ForeignKey Constraints which would cause conflicts.
-                // This table has no constraints pointing to itself, but only to others.
-                diesel::replace_into(ciphers_collections::table)
+            mysql {
+                diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),
                         ciphers_collections::collection_uuid.eq(collection_uuid),
                     ))
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding cipher to collection")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(ciphers_collections::table)
                     .values((
                         ciphers_collections::cipher_uuid.eq(cipher_uuid),

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -148,15 +148,18 @@ impl Device {
         }
 
         db_run! { conn:
-            sqlite, mysql {
+            mysql {
                 crate::util::retry(||
-                    diesel::replace_into(devices::table)
+                    diesel::insert_into(devices::table)
                         .values(&*self)
+                        .on_conflict(diesel::dsl::DuplicatedKeys)
+                        .do_update()
+                        .set(&*self)
                         .execute(conn),
                     10,
                 ).map_res("Error saving device")
             }
-            postgresql {
+            postgresql, sqlite {
                 crate::util::retry(||
                     diesel::insert_into(devices::table)
                         .values(&*self)

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -146,15 +146,18 @@ impl Device {
         }
 
         db_run! { conn:
-            sqlite, mysql {
+            mysql {
                 crate::util::retry(||
-                    diesel::replace_into(devices::table)
+                    diesel::insert_into(devices::table)
                         .values(&*self)
+                        .on_conflict(diesel::dsl::DuplicatedKeys)
+                        .do_update()
+                        .set(&*self)
                         .execute(conn),
                     10,
                 ).map_res("Error saving device")
             }
-            postgresql {
+            postgresql, sqlite {
                 crate::util::retry(||
                     diesel::insert_into(devices::table)
                         .values(&*self)

--- a/src/db/models/emergency_access.rs
+++ b/src/db/models/emergency_access.rs
@@ -146,24 +146,16 @@ impl EmergencyAccess {
         self.updated_at = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(emergency_access::table)
+            mysql {
+                diesel::insert_into(emergency_access::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(emergency_access::table)
-                            .filter(emergency_access::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error updating emergency access")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving emergency access")
+                    .map_res("Error saving emergency access")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(emergency_access::table)
                     .values(&*self)
                     .on_conflict(emergency_access::uuid)

--- a/src/db/models/event.rs
+++ b/src/db/models/event.rs
@@ -202,20 +202,23 @@ impl Event {
     /// Basic Queries
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(event::table)
-                .values(self)
-                .execute(conn)
-                .map_res("Error saving event")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(event::table)
-                .values(self)
-                .on_conflict(event::uuid)
-                .do_update()
-                .set(self)
-                .execute(conn)
-                .map_res("Error saving event")
+                    .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving event")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(event::table)
+                    .values(self)
+                    .on_conflict(event::uuid)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving event")
             }
         }
     }

--- a/src/db/models/event.rs
+++ b/src/db/models/event.rs
@@ -208,20 +208,23 @@ impl Event {
     /// Basic Queries
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(event::table)
-                .values(self)
-                .execute(conn)
-                .map_res("Error saving event")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(event::table)
-                .values(self)
-                .on_conflict(event::uuid)
-                .do_update()
-                .set(self)
-                .execute(conn)
-                .map_res("Error saving event")
+                    .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving event")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(event::table)
+                    .values(self)
+                    .on_conflict(event::uuid)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving event")
             }
         }
     }

--- a/src/db/models/folder.rs
+++ b/src/db/models/folder.rs
@@ -77,24 +77,16 @@ impl Folder {
         self.updated_at = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(folders::table)
+            mysql {
+                diesel::insert_into(folders::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(folders::table)
-                            .filter(folders::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving folder")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving folder")
+                    .map_res("Error saving folder")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(folders::table)
                     .values(&*self)
                     .on_conflict(folders::uuid)
@@ -147,16 +139,15 @@ impl Folder {
 impl FolderCipher {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here.
-                // Table folders_ciphers does not have ForeignKey Constraints which would cause conflicts.
-                // This table has no constraints pointing to itself, but only to others.
-                diesel::replace_into(folders_ciphers::table)
+            mysql {
+                diesel::insert_into(folders_ciphers::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding cipher to folder")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(folders_ciphers::table)
                     .values(self)
                     .on_conflict((folders_ciphers::cipher_uuid, folders_ciphers::folder_uuid))

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -160,24 +160,16 @@ impl Group {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups::table)
+            mysql {
+                diesel::insert_into(groups::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups::table)
-                            .filter(groups::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving group")
+                    .map_res("Error saving group")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(groups::table)
                     .values(&*self)
                     .on_conflict(groups::uuid)
@@ -312,53 +304,30 @@ impl CollectionGroup {
             group_user.update_user_revision(conn).await;
         }
 
+        let values = (
+            collections_groups::collections_uuid.eq(&self.collections_uuid),
+            collections_groups::groups_uuid.eq(&self.groups_uuid),
+            collections_groups::read_only.eq(&self.read_only),
+            collections_groups::hide_passwords.eq(&self.hide_passwords),
+            collections_groups::manage.eq(&self.manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(&self.read_only),
-                        collections_groups::hide_passwords.eq(&self.hide_passwords),
-                        collections_groups::manage.eq(&self.manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections_groups::table)
-                            .filter(collections_groups::collections_uuid.eq(&self.collections_uuid))
-                            .filter(collections_groups::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                collections_groups::collections_uuid.eq(&self.collections_uuid),
-                                collections_groups::groups_uuid.eq(&self.groups_uuid),
-                                collections_groups::read_only.eq(&self.read_only),
-                                collections_groups::hide_passwords.eq(&self.hide_passwords),
-                                collections_groups::manage.eq(&self.manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding group to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding group to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding group to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(collections_groups::table)
+                    .values(values)
                     .on_conflict((collections_groups::collections_uuid, collections_groups::groups_uuid))
                     .do_update()
-                    .set((
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding group to collection")
             }
@@ -477,43 +446,25 @@ impl GroupUser {
     pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
         self.update_user_revision(conn).await;
 
+        let values = (
+            groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
+            groups_users::groups_uuid.eq(&self.groups_uuid),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups_users::table)
-                            .filter(groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid))
-                            .filter(groups_users::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                                groups_users::groups_uuid.eq(&self.groups_uuid),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to group")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
+                    .execute(conn)
+                    .map_res("Error adding user to group")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(groups_users::table)
+                    .values(values)
                     .on_conflict((groups_users::users_organizations_uuid, groups_users::groups_uuid))
-                    .do_update()
-                    .set((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding user to group")
             }

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -166,24 +166,16 @@ impl Group {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups::table)
+            mysql {
+                diesel::insert_into(groups::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups::table)
-                            .filter(groups::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving group")
+                    .map_res("Error saving group")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(groups::table)
                     .values(&*self)
                     .on_conflict(groups::uuid)
@@ -324,53 +316,30 @@ impl CollectionGroup {
             group_user.update_user_revision(conn).await;
         }
 
+        let values = (
+            collections_groups::collections_uuid.eq(&self.collections_uuid),
+            collections_groups::groups_uuid.eq(&self.groups_uuid),
+            collections_groups::read_only.eq(&self.read_only),
+            collections_groups::hide_passwords.eq(&self.hide_passwords),
+            collections_groups::manage.eq(&self.manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(&self.read_only),
-                        collections_groups::hide_passwords.eq(&self.hide_passwords),
-                        collections_groups::manage.eq(&self.manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections_groups::table)
-                            .filter(collections_groups::collections_uuid.eq(&self.collections_uuid))
-                            .filter(collections_groups::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                collections_groups::collections_uuid.eq(&self.collections_uuid),
-                                collections_groups::groups_uuid.eq(&self.groups_uuid),
-                                collections_groups::read_only.eq(&self.read_only),
-                                collections_groups::hide_passwords.eq(&self.hide_passwords),
-                                collections_groups::manage.eq(&self.manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding group to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding group to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding group to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(collections_groups::table)
+                    .values(values)
                     .on_conflict((collections_groups::collections_uuid, collections_groups::groups_uuid))
                     .do_update()
-                    .set((
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding group to collection")
             }
@@ -495,43 +464,25 @@ impl GroupUser {
     pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
         self.update_user_revision(conn).await;
 
+        let values = (
+            groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
+            groups_users::groups_uuid.eq(&self.groups_uuid),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups_users::table)
-                            .filter(groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid))
-                            .filter(groups_users::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                                groups_users::groups_uuid.eq(&self.groups_uuid),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to group")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
+                    .execute(conn)
+                    .map_res("Error adding user to group")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(groups_users::table)
+                    .values(values)
                     .on_conflict((groups_users::users_organizations_uuid, groups_users::groups_uuid))
-                    .do_update()
-                    .set((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding user to group")
             }

--- a/src/db/models/group.rs
+++ b/src/db/models/group.rs
@@ -166,24 +166,16 @@ impl Group {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups::table)
+            mysql {
+                diesel::insert_into(groups::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups::table)
-                            .filter(groups::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving group")
+                    .map_res("Error saving group")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(groups::table)
                     .values(&*self)
                     .on_conflict(groups::uuid)
@@ -326,53 +318,30 @@ impl CollectionGroup {
             group_user.update_user_revision(conn).await;
         }
 
+        let values = (
+            collections_groups::collections_uuid.eq(&self.collections_uuid),
+            collections_groups::groups_uuid.eq(&self.groups_uuid),
+            collections_groups::read_only.eq(&self.read_only),
+            collections_groups::hide_passwords.eq(&self.hide_passwords),
+            collections_groups::manage.eq(&self.manage),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(&self.read_only),
-                        collections_groups::hide_passwords.eq(&self.hide_passwords),
-                        collections_groups::manage.eq(&self.manage),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(collections_groups::table)
-                            .filter(collections_groups::collections_uuid.eq(&self.collections_uuid))
-                            .filter(collections_groups::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                collections_groups::collections_uuid.eq(&self.collections_uuid),
-                                collections_groups::groups_uuid.eq(&self.groups_uuid),
-                                collections_groups::read_only.eq(&self.read_only),
-                                collections_groups::hide_passwords.eq(&self.hide_passwords),
-                                collections_groups::manage.eq(&self.manage),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding group to collection")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding group to collection")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(collections_groups::table)
-                    .values((
-                        collections_groups::collections_uuid.eq(&self.collections_uuid),
-                        collections_groups::groups_uuid.eq(&self.groups_uuid),
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(values)
+                    .execute(conn)
+                    .map_res("Error adding group to collection")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(collections_groups::table)
+                    .values(values)
                     .on_conflict((collections_groups::collections_uuid, collections_groups::groups_uuid))
                     .do_update()
-                    .set((
-                        collections_groups::read_only.eq(self.read_only),
-                        collections_groups::hide_passwords.eq(self.hide_passwords),
-                        collections_groups::manage.eq(self.manage),
-                    ))
+                    .set(values)
                     .execute(conn)
                     .map_res("Error adding group to collection")
             }
@@ -497,43 +466,25 @@ impl GroupUser {
     pub async fn save(&mut self, conn: &DbConn) -> EmptyResult {
         self.update_user_revision(conn).await;
 
+        let values = (
+            groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
+            groups_users::groups_uuid.eq(&self.groups_uuid),
+        );
+
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
-                    .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(groups_users::table)
-                            .filter(groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid))
-                            .filter(groups_users::groups_uuid.eq(&self.groups_uuid))
-                            .set((
-                                groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                                groups_users::groups_uuid.eq(&self.groups_uuid),
-                            ))
-                            .execute(conn)
-                            .map_res("Error adding user to group")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to group")
-            }
-            postgresql {
+            mysql {
                 diesel::insert_into(groups_users::table)
-                    .values((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .values(values)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
+                    .execute(conn)
+                    .map_res("Error adding user to group")
+            }
+            postgresql, sqlite {
+                diesel::insert_into(groups_users::table)
+                    .values(values)
                     .on_conflict((groups_users::users_organizations_uuid, groups_users::groups_uuid))
-                    .do_update()
-                    .set((
-                        groups_users::users_organizations_uuid.eq(&self.users_organizations_uuid),
-                        groups_users::groups_uuid.eq(&self.groups_uuid),
-                    ))
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error adding user to group")
             }

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -338,25 +338,16 @@ impl Organization {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organizations::table)
+            mysql {
+                diesel::insert_into(organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organizations::table)
-                            .filter(organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organizations::table)
                     .values(self)
                     .on_conflict(organizations::uuid)
@@ -745,24 +736,16 @@ impl Membership {
         User::update_uuid_revision(&self.user_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_organizations::table)
+            mysql {
+                diesel::insert_into(users_organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_organizations::table)
-                            .filter(users_organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error adding user to organization")
-                    },
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to organization")
+                    .map_res("Error adding user to organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(users_organizations::table)
                     .values(self)
                     .on_conflict(users_organizations::uuid)
@@ -1155,25 +1138,16 @@ impl Membership {
 impl OrganizationApiKey {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organization_api_key::table)
+            mysql {
+                diesel::insert_into(organization_api_key::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organization_api_key::table)
-                            .filter(organization_api_key::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organization_api_key::table)
                     .values(self)
                     .on_conflict((organization_api_key::uuid, organization_api_key::org_uuid))

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -346,25 +346,16 @@ impl Organization {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organizations::table)
+            mysql {
+                diesel::insert_into(organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organizations::table)
-                            .filter(organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organizations::table)
                     .values(self)
                     .on_conflict(organizations::uuid)
@@ -740,24 +731,16 @@ impl Membership {
         User::update_uuid_revision(&self.user_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_organizations::table)
+            mysql {
+                diesel::insert_into(users_organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_organizations::table)
-                            .filter(users_organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error adding user to organization")
-                    },
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to organization")
+                    .map_res("Error adding user to organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(users_organizations::table)
                     .values(self)
                     .on_conflict(users_organizations::uuid)
@@ -1173,25 +1156,16 @@ impl Membership {
 impl OrganizationApiKey {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organization_api_key::table)
+            mysql {
+                diesel::insert_into(organization_api_key::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organization_api_key::table)
-                            .filter(organization_api_key::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organization_api_key::table)
                     .values(self)
                     .on_conflict((organization_api_key::uuid, organization_api_key::org_uuid))

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -353,25 +353,16 @@ impl Organization {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organizations::table)
+            mysql {
+                diesel::insert_into(organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organizations::table)
-                            .filter(organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organizations::table)
                     .values(self)
                     .on_conflict(organizations::uuid)
@@ -753,24 +744,16 @@ impl Membership {
         User::update_uuid_revision(&self.user_uuid, conn).await;
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(users_organizations::table)
+            mysql {
+                diesel::insert_into(users_organizations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(users_organizations::table)
-                            .filter(users_organizations::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error adding user to organization")
-                    },
-                    Err(e) => Err(e.into()),
-                }.map_res("Error adding user to organization")
+                    .map_res("Error adding user to organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(users_organizations::table)
                     .values(self)
                     .on_conflict(users_organizations::uuid)
@@ -1186,25 +1169,16 @@ impl Membership {
 impl OrganizationApiKey {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(organization_api_key::table)
+            mysql {
+                diesel::insert_into(organization_api_key::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(organization_api_key::table)
-                            .filter(organization_api_key::uuid.eq(&self.uuid))
-                            .set(self)
-                            .execute(conn)
-                            .map_res("Error saving organization")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving organization")
-
+                    .map_res("Error saving organization")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(organization_api_key::table)
                     .values(self)
                     .on_conflict((organization_api_key::uuid, organization_api_key::org_uuid))

--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -203,24 +203,16 @@ impl Send {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(sends::table)
+            mysql {
+                diesel::insert_into(sends::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(sends::table)
-                            .filter(sends::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving send")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving send")
+                    .map_res("Error saving send")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sends::table)
                     .values(&*self)
                     .on_conflict(sends::uuid)

--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -199,24 +199,16 @@ impl Send {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(sends::table)
+            mysql {
+                diesel::insert_into(sends::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(sends::table)
-                            .filter(sends::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving send")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving send")
+                    .map_res("Error saving send")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sends::table)
                     .values(&*self)
                     .on_conflict(sends::uuid)

--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -202,24 +202,16 @@ impl Send {
         self.revision_date = Utc::now().naive_utc();
 
         db_run! { conn:
-            sqlite, mysql {
-                match diesel::replace_into(sends::table)
+            mysql {
+                diesel::insert_into(sends::table)
                     .values(&*self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_update()
+                    .set(&*self)
                     .execute(conn)
-                {
-                    Ok(_) => Ok(()),
-                    // Record already exists and causes a Foreign Key Violation because replace_into() wants to delete the record first.
-                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
-                        diesel::update(sends::table)
-                            .filter(sends::uuid.eq(&self.uuid))
-                            .set(&*self)
-                            .execute(conn)
-                            .map_res("Error saving send")
-                    }
-                    Err(e) => Err(e.into()),
-                }.map_res("Error saving send")
+                    .map_res("Error saving send")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sends::table)
                     .values(&*self)
                     .on_conflict(sends::uuid)

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -447,15 +447,15 @@ impl Invitation {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here
-                // Table invitations does not have any ForeignKey Constraints.
-                diesel::replace_into(invitations::table)
+            mysql {
+                diesel::insert_into(invitations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error saving invitation")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(invitations::table)
                     .values(self)
                     .on_conflict(invitations::email)
@@ -515,13 +515,13 @@ pub struct UserId(String);
 impl SsoUser {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(sso_users::table)
+            mysql {
+                diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)
                     .map_res("Error saving SSO user")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -446,15 +446,17 @@ impl Invitation {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here
-                // Table invitations does not have any ForeignKey Constraints.
-                diesel::replace_into(invitations::table)
+            // Not checking for ForeignKey Constraints here
+            // Table invitations does not have any ForeignKey Constraints.
+            mysql {
+                diesel::insert_into(invitations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error saving invitation")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(invitations::table)
                     .values(self)
                     .on_conflict(invitations::email)
@@ -511,13 +513,13 @@ pub struct UserId(String);
 impl SsoUser {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(sso_users::table)
+            mysql {
+                diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)
                     .map_res("Error saving SSO user")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -463,15 +463,17 @@ impl Invitation {
         }
 
         db_run! { conn:
-            sqlite, mysql {
-                // Not checking for ForeignKey Constraints here
-                // Table invitations does not have any ForeignKey Constraints.
-                diesel::replace_into(invitations::table)
+            // Not checking for ForeignKey Constraints here
+            // Table invitations does not have any ForeignKey Constraints.
+            mysql {
+                diesel::insert_into(invitations::table)
                     .values(self)
+                    .on_conflict(diesel::dsl::DuplicatedKeys)
+                    .do_nothing()
                     .execute(conn)
                     .map_res("Error saving invitation")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(invitations::table)
                     .values(self)
                     .on_conflict(invitations::email)
@@ -528,13 +530,13 @@ pub struct UserId(String);
 impl SsoUser {
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
         db_run! { conn:
-            sqlite, mysql {
-                diesel::replace_into(sso_users::table)
+            mysql {
+                diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)
                     .map_res("Error saving SSO user")
             }
-            postgresql {
+            postgresql, sqlite {
                 diesel::insert_into(sso_users::table)
                     .values(self)
                     .execute(conn)


### PR DESCRIPTION
Replace most `replace_into` with `insert_into` to avoid deleting a record to update it.

There is still two left :
 - [org_policy.rs#L130](https://github.com/dani-garcia/vaultwarden/blob/9017ca265a28ff1370e6047b8e85c0a6c3327306/src/db/models/org_policy.rs#L130)
 - [two_factor.rs#L99](https://github.com/dani-garcia/vaultwarden/blob/9017ca265a28ff1370e6047b8e85c0a6c3327306/src/db/models/two_factor.rs#L99)
 
 But changing those would be more complex, the composite key could be used as primary instead of an `uuid`. 
 But at least for the `OrgPolicy` the `uuid` appears to be used when logging an event.