### PR TITLE
Add `pm-25373-windows-biometrics-v2` feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -376,6 +376,7 @@
 ## - "inline-menu-totp": Enable the use of inline menu TOTP codes in the browser extension.
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Needs desktop >=2024.12.0)
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Needs clients >=2024.12.0)
+## - "pm-25373-windows-biometrics-v2": Enable the new implementation of biometrics on Windows. (Needs desktop >= 2025.11.0)
 ## - "export-attachments": Enable support for exporting attachments (Clients >=2025.4.0)
 ## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Needs Android >=2025.3.0, iOS >=2025.4.0)
 ## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Needs Android >=2025.3.0, iOS >=2025.4.0)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1035,6 +1035,7 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "ssh-agent",
         // Key Management Team
         "ssh-key-vault-item",
+        "pm-25373-windows-biometrics-v2",
         // Tools
         "export-attachments",
         // Mobile Team


### PR DESCRIPTION
Add a feature flag to enable the new implementation of biometrics on Windows, allowing to unlock the vault with biometrics immediately after the Windows desktop app restarts.

This feature flag requires the upcoming client release [Desktop 2025.11.0](https://bitwarden.com/help/releasenotes/#2025-11-0).