### PR TITLE
Switch to multiple runners per arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,23 @@ concurrency:
   # Don't cancel other runs when creating a tag
   cancel-in-progress: ${{ github.ref_type == 'branch' }}
 
+defaults:
+  run:
+    shell: bash
+
+env:
+  # The *_REPO variables need to be configured as repository variables
+  # Append `/settings/variables/actions` to your repo url
+  # DOCKERHUB_REPO needs to be 'index.docker.io/<user>/<repo>'
+  # Check for Docker hub credentials in secrets
+  HAVE_DOCKERHUB_LOGIN: ${{ vars.DOCKERHUB_REPO != '' && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+  # GHCR_REPO needs to be 'ghcr.io/<user>/<repo>'
+  # Check for Github credentials in secrets
+  HAVE_GHCR_LOGIN: ${{ vars.GHCR_REPO != '' && github.repository_owner != '' && secrets.GITHUB_TOKEN != '' }}
+  # QUAY_REPO needs to be 'quay.io/<user>/<repo>'
+  # Check for Quay.io credentials in secrets
+  HAVE_QUAY_LOGIN: ${{ vars.QUAY_REPO != '' && secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
+
 jobs:
   docker-build:
     name: Build Vaultwarden containers
@@ -25,7 +42,7 @@ jobs:
       contents: read
       attestations: write # Needed to generate an artifact attestation for a build
       id-token: write # Needed to mint the OIDC token necessary to request a Sigstore signing certificate
-    runs-on: ubuntu-24.04
+    runs-on: ${{ contains(matrix.arch, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 120
     # Start a local docker registry to extract the compiled binaries to upload as artifacts and attest them
     services:
@@ -36,20 +53,12 @@ jobs:
     env:
       SOURCE_COMMIT: ${{ github.sha }}
       SOURCE_REPOSITORY_URL: "https://github.com/${{ github.repository }}"
-      # The *_REPO variables need to be configured as repository variables
-      # Append `/settings/variables/actions` to your repo url
-      # DOCKERHUB_REPO needs to be 'index.docker.io/<user>/<repo>'
-      # Check for Docker hub credentials in secrets
-      HAVE_DOCKERHUB_LOGIN: ${{ vars.DOCKERHUB_REPO != '' && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
-      # GHCR_REPO needs to be 'ghcr.io/<user>/<repo>'
-      # Check for Github credentials in secrets
-      HAVE_GHCR_LOGIN: ${{ vars.GHCR_REPO != '' && github.repository_owner != '' && secrets.GITHUB_TOKEN != '' }}
-      # QUAY_REPO needs to be 'quay.io/<user>/<repo>'
-      # Check for Quay.io credentials in secrets
-      HAVE_QUAY_LOGIN: ${{ vars.QUAY_REPO != '' && secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
     strategy:
       matrix:
+        arch: ["amd64", "arm64", "arm/v7", "arm/v6"]
         base_image: ["debian","alpine"]
+    outputs:
+      base-tags: ${{ steps.determine-version.outputs.BASE_TAGS }}
 
     steps:
       - name: Initialize QEMU binfmt support
@@ -78,17 +87,26 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # Normalize the architecture string for use in paths and cache keys
+      - name: Normalize architecture string
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+        run: |
+          # Replace slashes with nothing to create a safe string for paths/cache keys
+          NORMALIZED_ARCH="${MATRIX_ARCH//\/}"
+          echo "NORMALIZED_ARCH=${NORMALIZED_ARCH}" | tee -a "${GITHUB_ENV}"
+
       # Determine Base Tags and Source Version
       - name: Determine Base Tags and Source Version
-        shell: bash
+        id: determine-version
         env:
           REF_TYPE: ${{ github.ref_type }}
         run: |
           # Check which main tag we are going to build determined by ref_type
           if [[ "${REF_TYPE}" == "tag" ]]; then
-            echo "BASE_TAGS=latest,${GITHUB_REF#refs/*/}" | tee -a "${GITHUB_ENV}"
+            echo "BASE_TAGS=latest,${GITHUB_REF#refs/*/}" | tee -a "${GITHUB_OUTPUT}"
           elif [[ "${REF_TYPE}" == "branch" ]]; then
-            echo "BASE_TAGS=testing" | tee -a "${GITHUB_ENV}"
+            echo "BASE_TAGS=testing" | tee -a "${GITHUB_OUTPUT}"
           fi
 
           # Get the Source Version for this release
@@ -111,7 +129,6 @@ jobs:
 
       - name: Add registry for DockerHub
         if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' }}
-        shell: bash
         env:
           DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
         run: |
@@ -128,7 +145,6 @@ jobs:
 
       - name: Add registry for ghcr.io
         if: ${{ env.HAVE_GHCR_LOGIN == 'true' }}
-        shell: bash
         env:
           GHCR_REPO: ${{ vars.GHCR_REPO }}
         run: |
@@ -145,23 +161,22 @@ jobs:
 
       - name: Add registry for Quay.io
         if: ${{ env.HAVE_QUAY_LOGIN == 'true' }}
-        shell: bash
         env:
           QUAY_REPO: ${{ vars.QUAY_REPO }}
         run: |
           echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${QUAY_REPO}" | tee -a "${GITHUB_ENV}"
 
       - name: Configure build cache from/to
-        shell: bash
         env:
           GHCR_REPO: ${{ vars.GHCR_REPO }}
           BASE_IMAGE: ${{ matrix.base_image }}
+          NORMALIZED_ARCH: ${{ env.NORMALIZED_ARCH }}
         run: |
           #
           # Check if there is a GitHub Container Registry Login and use it for caching
           if [[ -n "${HAVE_GHCR_LOGIN}" ]]; then
-            echo "BAKE_CACHE_FROM=type=registry,ref=${GHCR_REPO}-buildcache:${BASE_IMAGE}" | tee -a "${GITHUB_ENV}"
-            echo "BAKE_CACHE_TO=type=registry,ref=${GHCR_REPO}-buildcache:${BASE_IMAGE},compression=zstd,mode=max" | tee -a "${GITHUB_ENV}"
+            echo "BAKE_CACHE_FROM=type=registry,ref=${GHCR_REPO}-buildcache:${BASE_IMAGE}-${NORMALIZED_ARCH}" | tee -a "${GITHUB_ENV}"
+            echo "BAKE_CACHE_TO=type=registry,ref=${GHCR_REPO}-buildcache:${BASE_IMAGE}-${NORMALIZED_ARCH},compression=zstd,mode=max" | tee -a "${GITHUB_ENV}"
           else
             echo "BAKE_CACHE_FROM="
             echo "BAKE_CACHE_TO="
@@ -169,31 +184,45 @@ jobs:
           #
 
       - name: Add localhost registry
-        shell: bash
         run: |
           echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}localhost:5000/vaultwarden/server" | tee -a "${GITHUB_ENV}"
+
+      - name: Generate tags
+        id: tags
+        env:
+          CONTAINER_REGISTRIES: "${{ env.CONTAINER_REGISTRIES }}"
+        run: |
+          # Convert comma-separated list to newline-separated set commands
+          TAGS=$(echo "${CONTAINER_REGISTRIES}" | tr ',' '\n' | sed "s|.*|*.tags=&|")
+
+          # Output for use in next step
+          {
+            echo "TAGS<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Bake ${{ matrix.base_image }} containers
         id: bake_vw
         uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6.9.0
         env:
-          BASE_TAGS: "${{ env.BASE_TAGS }}"
+          BASE_TAGS: "${{ steps.determine-version.outputs.BASE_TAGS }}"
           SOURCE_COMMIT: "${{ env.SOURCE_COMMIT }}"
           SOURCE_VERSION: "${{ env.SOURCE_VERSION }}"
           SOURCE_REPOSITORY_URL: "${{ env.SOURCE_REPOSITORY_URL }}"
-          CONTAINER_REGISTRIES: "${{ env.CONTAINER_REGISTRIES }}"
         with:
           pull: true
-          push: true
           source: .
           files: docker/docker-bake.hcl
           targets: "${{ matrix.base_image }}-multi"
           set: |
             *.cache-from=${{ env.BAKE_CACHE_FROM }}
             *.cache-to=${{ env.BAKE_CACHE_TO }}
+            *.platform=linux/${{ matrix.arch }}
+            ${{ env.TAGS }}
+            *.output=type=image,push-by-digest=true,name-canonical=true,push=true,compression=zstd
 
       - name: Extract digest SHA
-        shell: bash
         env:
           BAKE_METADATA: ${{ steps.bake_vw.outputs.metadata }}
           BASE_IMAGE: ${{ matrix.base_image }}
@@ -201,38 +230,30 @@ jobs:
           GET_DIGEST_SHA="$(jq -r --arg base "$BASE_IMAGE" '.[$base + "-multi"]."containerimage.digest"' <<< "${BAKE_METADATA}")"
           echo "DIGEST_SHA=${GET_DIGEST_SHA}" | tee -a "${GITHUB_ENV}"
 
-      # Attest container images
-      - name: Attest - docker.io - ${{ matrix.base_image }}
-        if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' && steps.bake_vw.outputs.metadata != ''}}
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-name: ${{ vars.DOCKERHUB_REPO }}
-          subject-digest: ${{ env.DIGEST_SHA }}
-          push-to-registry: true
+      - name: Export digest
+        env:
+          DIGEST_SHA: ${{ env.DIGEST_SHA }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}"/digests
+          digest="${DIGEST_SHA}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
 
-      - name: Attest - ghcr.io - ${{ matrix.base_image }}
-        if: ${{ env.HAVE_GHCR_LOGIN == 'true' && steps.bake_vw.outputs.metadata != ''}}
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      - name: Upload digest
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          subject-name: ${{ vars.GHCR_REPO }}
-          subject-digest: ${{ env.DIGEST_SHA }}
-          push-to-registry: true
-
-      - name: Attest - quay.io - ${{ matrix.base_image }}
-        if: ${{ env.HAVE_QUAY_LOGIN == 'true' && steps.bake_vw.outputs.metadata != ''}}
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-name: ${{ vars.QUAY_REPO }}
-          subject-digest: ${{ env.DIGEST_SHA }}
-          push-to-registry: true
-
+          name: digests-${{ env.NORMALIZED_ARCH }}-${{ matrix.base_image }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
       # Extract the Alpine binaries from the containers
       - name: Extract binaries
-        shell: bash
         env:
           REF_TYPE: ${{ github.ref_type }}
           BASE_IMAGE: ${{ matrix.base_image }}
+          DIGEST_SHA: ${{ env.DIGEST_SHA }}
+          NORMALIZED_ARCH: ${{ env.NORMALIZED_ARCH }}
         run: |
           # Check which main tag we are going to build determined by ref_type
           if [[ "${REF_TYPE}" == "tag" ]]; then
@@ -246,60 +267,151 @@ jobs:
             EXTRACT_TAG="${EXTRACT_TAG}-alpine"
           fi
 
-          # After each extraction the image is removed.
-          # This is needed because using different platforms doesn't trigger a new pull/download
+          CONTAINER_ID="$(docker create "localhost:5000/vaultwarden/server:${EXTRACT_TAG}@${DIGEST_SHA}")"
 
-          # Extract amd64 binary
-          docker create --name amd64 --platform=linux/amd64 "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-          docker cp amd64:/vaultwarden vaultwarden-amd64-${BASE_IMAGE}
-          docker rm --force amd64
-          docker rmi --force "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
+          # Copy the binary
+          docker cp "$CONTAINER_ID":/vaultwarden vaultwarden-"${NORMALIZED_ARCH}"
 
-          # Extract arm64 binary
-          docker create --name arm64 --platform=linux/arm64 "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-          docker cp arm64:/vaultwarden vaultwarden-arm64-${BASE_IMAGE}
-          docker rm --force arm64
-          docker rmi --force "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-
-          # Extract armv7 binary
-          docker create --name armv7 --platform=linux/arm/v7 "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-          docker cp armv7:/vaultwarden vaultwarden-armv7-${BASE_IMAGE}
-          docker rm --force armv7
-          docker rmi --force "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-
-          # Extract armv6 binary
-          docker create --name armv6 --platform=linux/arm/v6 "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
-          docker cp armv6:/vaultwarden vaultwarden-armv6-${BASE_IMAGE}
-          docker rm --force armv6
-          docker rmi --force "localhost:5000/vaultwarden/server:${EXTRACT_TAG}"
+          # Clean up
+          docker rm "$CONTAINER_ID"
 
       # Upload artifacts to Github Actions and Attest the binaries
-      - name: "Upload amd64 artifact ${{ matrix.base_image }}"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-amd64-${{ matrix.base_image }}
-          path: vaultwarden-amd64-${{ matrix.base_image }}
-
-      - name: "Upload arm64 artifact ${{ matrix.base_image }}"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-arm64-${{ matrix.base_image }}
-          path: vaultwarden-arm64-${{ matrix.base_image }}
-
-      - name: "Upload armv7 artifact ${{ matrix.base_image }}"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv7-${{ matrix.base_image }}
-          path: vaultwarden-armv7-${{ matrix.base_image }}
-
-      - name: "Upload armv6 artifact ${{ matrix.base_image }}"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-armv6-${{ matrix.base_image }}
-          path: vaultwarden-armv6-${{ matrix.base_image }}
-
-      - name: "Attest artifacts ${{ matrix.base_image }}"
+      - name: Attest binaries
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
-          subject-path: vaultwarden-*
-      # End Upload artifacts to Github Actions
+          subject-path: vaultwarden-${{ env.NORMALIZED_ARCH }}
+
+      - name: Upload binaries as artifacts
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: vaultwarden-${{ env.SOURCE_VERSION }}-linux-${{ env.NORMALIZED_ARCH }}-${{ matrix.base_image }}
+          path: vaultwarden-${{ env.NORMALIZED_ARCH }}
+
+  merge-manifests:
+    name: Merge manifests
+    runs-on: ubuntu-latest
+    needs: docker-build
+
+    env:
+      BASE_TAGS: ${{ needs.docker-build.outputs.base-tags }}
+
+    permissions:
+      packages: write # Needed to upload packages and artifacts
+      attestations: write # Needed to generate an artifact attestation for a build
+      id-token: write # Needed to mint the OIDC token necessary to request a Sigstore signing certificate
+
+    strategy:
+      matrix:
+        base_image: ["debian","alpine"]
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*-${{ matrix.base_image }}
+          merge-multiple: true
+
+      # Login to Docker Hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' }}
+
+      - name: Add registry for DockerHub
+        if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' }}
+        env:
+          DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
+        run: |
+          echo "CONTAINER_REGISTRIES=${DOCKERHUB_REPO}" | tee -a "${GITHUB_ENV}"
+
+      # Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.HAVE_GHCR_LOGIN == 'true' }}
+
+      - name: Add registry for ghcr.io
+        if: ${{ env.HAVE_GHCR_LOGIN == 'true' }}
+        env:
+          GHCR_REPO: ${{ vars.GHCR_REPO }}
+        run: |
+          echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${GHCR_REPO}" | tee -a "${GITHUB_ENV}"
+
+      # Login to Quay.io
+      - name: Login to Quay.io
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+        if: ${{ env.HAVE_QUAY_LOGIN == 'true' }}
+
+      - name: Add registry for Quay.io
+        if: ${{ env.HAVE_QUAY_LOGIN == 'true' }}
+        env:
+          QUAY_REPO: ${{ vars.QUAY_REPO }}
+        run: |
+          echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${QUAY_REPO}" | tee -a "${GITHUB_ENV}"
+
+      - name: Create manifest list, push it and extract digest SHA
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          BASE_IMAGE: "${{ matrix.base_image }}"
+          BASE_TAGS: "${{ env.BASE_TAGS }}"
+          CONTAINER_REGISTRIES: "${{ env.CONTAINER_REGISTRIES }}"
+        run: |
+          set +e
+          IFS=',' read -ra IMAGES <<< "${CONTAINER_REGISTRIES}"
+          for img in "${IMAGES[@]}"; do
+            echo "Creating manifest for $img:${BASE_TAGS}-${BASE_IMAGE}"
+
+            OUTPUT=$(docker buildx imagetools create \
+              -t "$img:${BASE_TAGS}-${BASE_IMAGE}" \
+              $(printf "$img:${BASE_TAGS}-${BASE_IMAGE}@sha256:%s " *) 2>&1)
+            STATUS=$?
+
+            if [ $STATUS -ne 0 ]; then
+              echo "Manifest creation failed for $img"
+              echo "$OUTPUT"
+            exit $STATUS
+            fi
+
+            echo "Manifest created for $img"
+            echo "$OUTPUT"
+          done
+          set -e
+
+          # Extract digest SHA for subsequent steps
+          GET_DIGEST_SHA="$(echo "$OUTPUT" | grep -oE 'sha256:[a-f0-9]{64}' | tail -1)"
+          echo "DIGEST_SHA=${GET_DIGEST_SHA}" | tee -a "${GITHUB_ENV}"
+
+      # Attest container images
+      - name: Attest - docker.io - ${{ matrix.base_image }}
+        if: ${{ env.HAVE_DOCKERHUB_LOGIN == 'true' && env.DIGEST_SHA != ''}}
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-name: ${{ vars.DOCKERHUB_REPO }}
+          subject-digest: ${{ env.DIGEST_SHA }}
+          push-to-registry: true
+
+      - name: Attest - ghcr.io - ${{ matrix.base_image }}
+        if: ${{ env.HAVE_GHCR_LOGIN == 'true' && env.DIGEST_SHA != ''}}
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-name: ${{ vars.GHCR_REPO }}
+          subject-digest: ${{ env.DIGEST_SHA }}
+          push-to-registry: true
+
+      - name: Attest - quay.io - ${{ matrix.base_image }}
+        if: ${{ env.HAVE_QUAY_LOGIN == 'true' && env.DIGEST_SHA != ''}}
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-name: ${{ vars.QUAY_REPO }}
+          subject-digest: ${{ env.DIGEST_SHA }}
+          push-to-registry: true

--- a/docker/DockerSettings.yaml
+++ b/docker/DockerSettings.yaml
@@ -17,7 +17,6 @@ build_stage_image:
     platform: "$BUILDPLATFORM"
   alpine:
     image: "build_${TARGETARCH}${TARGETVARIANT}"
-    platform: "linux/amd64" # The Alpine build images only have linux/amd64 images
     arch_image:
       amd64: "ghcr.io/blackdex/rust-musl:x86_64-musl-stable-{{rust_version}}"
       arm64: "ghcr.io/blackdex/rust-musl:aarch64-musl-stable-{{rust_version}}"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -30,16 +30,16 @@
 FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:50662dccf4908ac2128cd44981c52fcb4e3e8dd56f21823c8d5e91267ff741fa AS vault
 
 ########################## ALPINE BUILD IMAGES ##########################
-## NOTE: The Alpine Base Images do not support other platforms then linux/amd64
+## NOTE: The Alpine Base Images do not support other platforms then linux/amd64 and linux/arm64
 ## And for Alpine we define all build images here, they will only be loaded when actually used
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.91.0 AS build_amd64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.91.0 AS build_arm64
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.91.0 AS build_armv7
-FROM --platform=linux/amd64 ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.91.0 AS build_armv6
+FROM --platform=$BUILDPLATFORM ghcr.io/blackdex/rust-musl:x86_64-musl-stable-1.91.0 AS build_amd64
+FROM --platform=$BUILDPLATFORM ghcr.io/blackdex/rust-musl:aarch64-musl-stable-1.91.0 AS build_arm64
+FROM --platform=$BUILDPLATFORM ghcr.io/blackdex/rust-musl:armv7-musleabihf-stable-1.91.0 AS build_armv7
+FROM --platform=$BUILDPLATFORM ghcr.io/blackdex/rust-musl:arm-musleabi-stable-1.91.0 AS build_armv6
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform=linux/amd64 build_${TARGETARCH}${TARGETVARIANT} AS build
+FROM --platform=$BUILDPLATFORM build_${TARGETARCH}${TARGETVARIANT} AS build
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG TARGETPLATFORM

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -36,16 +36,16 @@ FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_diges
 FROM --platform=linux/amd64 docker.io/tonistiigi/xx@{{ xx_image_digest }} AS xx
 {% elif base == "alpine" %}
 ########################## ALPINE BUILD IMAGES ##########################
-## NOTE: The Alpine Base Images do not support other platforms then linux/amd64
+## NOTE: The Alpine Base Images do not support other platforms then linux/amd64 and linux/arm64
 ## And for Alpine we define all build images here, they will only be loaded when actually used
 {% for arch in build_stage_image[base].arch_image %}
-FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].arch_image[arch] }} AS build_{{ arch }}
+FROM --platform=$BUILDPLATFORM {{ build_stage_image[base].arch_image[arch] }} AS build_{{ arch }}
 {% endfor %}
 {% endif %}
 
 ########################## BUILD IMAGE ##########################
 # hadolint ignore=DL3006
-FROM --platform={{ build_stage_image[base].platform }} {{ build_stage_image[base].image }} AS build
+FROM --platform=$BUILDPLATFORM {{ build_stage_image[base].image }} AS build
 {% if base == "debian" %}
 COPY --from=xx / /
 {% endif %}


### PR DESCRIPTION
- now uses arm64 native runners for faster compilation

Here's an example workflow run with all cache cleaned:
https://github.com/dfunkt/vaultwarden/actions/runs/19406766594
13m 10s for all Vaultwarden default target platforms (amd64, arm64, armv6 and armv7)

There's a lot of duplication in the second job that could be reduced via YAML anchors, but unfortunately zizmor has problems with parsing them atm (https://github.com/zizmorcore/zizmor/issues/1304)

And lastly, here's the reference documentation that I used for creating this: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners