### PR TITLE
fix email as 2fa provider

### DIFF
--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -1,4 +1,4 @@
-use crate::db::schema::{devices, invitations, sso_users, users};
+use crate::db::schema::{invitations, sso_users, users};
 use chrono::{NaiveDateTime, TimeDelta, Utc};
 use derive_more::{AsRef, Deref, Display, From};
 use diesel::prelude::*;
@@ -10,7 +10,6 @@ use super::{
 use crate::{
     api::EmptyResult,
     crypto,
-    db::models::DeviceId,
     db::DbConn,
     error::MapResult,
     sso::OIDCIdentifier,
@@ -382,17 +381,6 @@ impl User {
         db_run! { conn: {
             users::table
                 .filter(users::uuid.eq(uuid))
-                .first::<Self>(conn)
-                .ok()
-        }}
-    }
-
-    pub async fn find_by_device_id(device_uuid: &DeviceId, conn: &DbConn) -> Option<Self> {
-        db_run! { conn: {
-            users::table
-                .inner_join(devices::table.on(devices::user_uuid.eq(users::uuid)))
-                .filter(devices::uuid.eq(device_uuid))
-                .select(users::all_columns)
                 .first::<Self>(conn)
                 .ok()
         }}


### PR DESCRIPTION
as discussed in https://github.com/dani-garcia/vaultwarden/discussions/6471#discussioncomment-14978860 we want to get the correct user account for a given mail address when sending the 2fa via mail so I've reverted some of the changes introduced by https://github.com/dani-garcia/vaultwarden/commit/e3d66216f66e25d27a017232205c08dec94e0d32

NOTE: this won't fix the invitation flow change because we can only activate email as second factor, so this will still be set up automatically between signup and login if 2fa is required. after registration you will be sent an email (unless you have disabled mail as second factor) which you have to confirm. if you do everything in one session this will also accept the invitation. (if you have disabled 2fa as second factor the flow will be broken a bit because you will have to setup 2fa the old fashioned way after signup. you will also likely have to be reinvited because the generated link is missing the needed parameter `orgUserHasExistingUser=true` to redirect you to login instead of the signup form.)