### PR TITLE
Add option to prefer IPv6 resolving

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -472,6 +472,11 @@
 ## Setting this to true will enforce the Single Org Policy to be enabled before you can enable the Reset Password policy.
 # ENFORCE_SINGLE_ORG_WITH_RESET_PW_POLICY=false
 
+## Prefer IPv6 (AAAA) resolving
+## This settings configures the DNS resolver to resolve IPv6 first, and if not available try IPv4
+## This could be useful in IPv6 only environments.
+# DNS_PREFER_IPV6=false
+
 #####################################
 ### SSO settings (OpenID Connect) ###
 #####################################

--- a/src/config.rs
+++ b/src/config.rs
@@ -789,6 +789,10 @@ make_config! {
         /// Bitwarden enforces this by default. In Vaultwarden we encouraged to use multiple organizations because groups were not available.
         /// Setting this to true will enforce the Single Org Policy to be enabled before you can enable the Reset Password policy.
         enforce_single_org_with_reset_pw_policy: bool, false, def, false;
+
+        /// Prefer IPv6 (AAAA) resolving |> This settings configures the DNS resolver to resolve IPv6 first, and if not available try IPv4
+        /// This could be useful in IPv6 only environments.
+        dns_prefer_ipv6: bool, true, def, false;
     },
 
     /// OpenID Connect SSO settings

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -185,7 +185,10 @@ impl CustomDnsResolver {
 
     fn new() -> Arc<Self> {
         match TokioResolver::builder(TokioConnectionProvider::default()) {
-            Ok(builder) => {
+            Ok(mut builder) => {
+                if CONFIG.dns_prefer_ipv6() {
+                    builder.options_mut().ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv6thenIpv4;
+                }
                 let resolver = builder.build();
                 Arc::new(Self::Hickory(Arc::new(resolver)))
             }


### PR DESCRIPTION
This PR adds an option to prefer IPv6 resolving before IPv4. On IPv6 only systems this could be very useful, but will not solve IPv4 only domains of course. For that you need a DNS64 + NAT64 solution

Fixes #6301
