### PR TITLE
Fix admin invite with SSO

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -378,7 +378,7 @@ async fn post_set_password(data: Json<SetPasswordData>, headers: Headers, conn: 
     }
 
     if let Some(identifier) = data.org_identifier {
-        if identifier != crate::sso::FAKE_IDENTIFIER {
+        if identifier != crate::sso::FAKE_IDENTIFIER && identifier != crate::api::admin::FAKE_ADMIN_UUID {
             let org = match Organization::find_by_uuid(&identifier.into(), &conn).await {
                 None => err!("Failed to retrieve the associated organization"),
                 Some(org) => org,


### PR DESCRIPTION
Handle the fake admin organization identifier to prevent error when on-boarding with SSO.