### PR TITLE
Android want response property in camelCase

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -405,8 +405,8 @@ async fn post_set_password(data: Json<SetPasswordData>, headers: Headers, conn: 
     user.save(&conn).await?;
 
     Ok(Json(json!({
-      "Object": "set-password",
-      "CaptchaBypassToken": "",
+      "object": "set-password",
+      "captchaBypassToken": "",
     })))
 }
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -370,9 +370,9 @@ async fn get_auto_enroll_status(identifier: &str, headers: Headers, conn: DbConn
     };
 
     Ok(Json(json!({
-        "Id": id,
-        "Identifier": identifier,
-        "ResetPasswordEnabled": rp_auto_enroll,
+        "id": id,
+        "identifier": identifier,
+        "resetPasswordEnabled": rp_auto_enroll,
     })))
 }
 


### PR DESCRIPTION
The web client use [getResponseProperty](https://github.com/bitwarden/clients/blob/main/libs/common/src/models/response/base.response.ts) to handle case variation but I believe that android application require camelCase (https://github.com/Timshel/OIDCWarden/issues/59).