### PR TITLE
Org.put_policy type not in body anymore

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -2057,8 +2057,6 @@ async fn get_policy(org_id: OrganizationId, pol_type: i32, headers: AdminHeaders
 #[derive(Deserialize)]
 struct PolicyData {
     enabled: bool,
-    #[serde(rename = "type")]
-    _type: i32,
     data: Option<Value>,
 }
 


### PR DESCRIPTION
With [web-v2025.11.3](https://github.com/bitwarden/clients/blob/web-v2025.11.3/libs/common/src/admin-console/models/request/policy.request.ts) the policy type is not sent in the request body anymore.