### PR TITLE
Further fixes for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,8 +362,7 @@ jobs:
       - name: Create manifest list, push it and extract digest SHA
         working-directory: ${{ runner.temp }}/digests
         env:
-          BASE_IMAGE: "${{ matrix.base_image }}"
-          BASE_IMAGE_TAG: "${{ matrix.base_image == 'debian' && '' || format('-{0}', matrix.base_image) }}"
+          BASE_IMAGE_TAG: "${{ matrix.base_image != 'debian' && format('-{0}', matrix.base_image) || '' }}"
           BASE_TAGS: "${{ env.BASE_TAGS }}"
           CONTAINER_REGISTRIES: "${{ env.CONTAINER_REGISTRIES }}"
         run: |
@@ -376,16 +375,16 @@ jobs:
 
               OUTPUT=$(docker buildx imagetools create \
                 -t "${img}:${tag}${BASE_IMAGE_TAG}" \
-                $(printf "${img}:${tag}-${BASE_IMAGE}@sha256:%s " *) 2>&1)
+                $(printf "${img}@sha256:%s " *) 2>&1)
               STATUS=$?
 
               if [ ${STATUS} -ne 0 ]; then
-                echo "Manifest creation failed for ${img}"
+                echo "Manifest creation failed for ${img}:${tag}${BASE_IMAGE_TAG}"
                 echo "${OUTPUT}"
               exit ${STATUS}
               fi
 
-              echo "Manifest created for ${img}"
+              echo "Manifest created for ${img}:${tag}${BASE_IMAGE_TAG}"
               echo "${OUTPUT}"
             done
           done


### PR DESCRIPTION
Not all the fixes necessary were made in https://github.com/dani-garcia/vaultwarden/pull/6532, it still appends `debian` to the tags:
https://github.com/dani-garcia/vaultwarden/actions/runs/20004013122/job/57363788749#step:9:39
```
Creating manifest for index.docker.io/vaultwarden/server:testing-debian
Manifest created for index.docker.io/vaultwarden/server
#1 [internal] pushing docker.io/vaultwarden/server:testing-debian
```
Fixed variant:
```
Creating manifest for index.docker.io/vaultwarden/server:testing
Manifest created for index.docker.io/vaultwarden/server:testing
#1 [internal] pushing docker.io/vaultwarden/server:testing
```