### PR TITLE
Remove unnecessary output sharing between jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
       matrix:
         arch: ["amd64", "arm64", "arm/v7", "arm/v6"]
         base_image: ["debian","alpine"]
-    outputs:
-      base-tags: ${{ steps.determine-version.outputs.BASE_TAGS }}
 
     steps:
       - name: Initialize QEMU binfmt support
@@ -96,19 +94,9 @@ jobs:
           NORMALIZED_ARCH="${MATRIX_ARCH//\/}"
           echo "NORMALIZED_ARCH=${NORMALIZED_ARCH}" | tee -a "${GITHUB_ENV}"
 
-      # Determine Base Tags and Source Version
-      - name: Determine Base Tags and Source Version
-        id: determine-version
-        env:
-          REF_TYPE: ${{ github.ref_type }}
+      # Determine Source Version
+      - name: Determine Source Version
         run: |
-          # Check which main tag we are going to build determined by ref_type
-          if [[ "${REF_TYPE}" == "tag" ]]; then
-            echo "BASE_TAGS=latest,${GITHUB_REF#refs/*/}" | tee -a "${GITHUB_OUTPUT}"
-          elif [[ "${REF_TYPE}" == "branch" ]]; then
-            echo "BASE_TAGS=testing" | tee -a "${GITHUB_OUTPUT}"
-          fi
-
           # Get the Source Version for this release
           GIT_EXACT_TAG="$(git describe --tags --abbrev=0 --exact-match 2>/dev/null || true)"
           if [[ -n "${GIT_EXACT_TAG}" ]]; then
@@ -117,7 +105,6 @@ jobs:
               GIT_LAST_TAG="$(git describe --tags --abbrev=0)"
               echo "SOURCE_VERSION=${GIT_LAST_TAG}-${SOURCE_COMMIT:0:8}" | tee -a "${GITHUB_ENV}"
           fi
-      # End Determine Base Tags
 
       # Login to Docker Hub
       - name: Login to Docker Hub
@@ -291,15 +278,10 @@ jobs:
     name: Merge manifests
     runs-on: ubuntu-latest
     needs: docker-build
-
-    env:
-      BASE_TAGS: ${{ needs.docker-build.outputs.base-tags }}
-
     permissions:
       packages: write # Needed to upload packages and artifacts
       attestations: write # Needed to generate an artifact attestation for a build
       id-token: write # Needed to mint the OIDC token necessary to request a Sigstore signing certificate
-
     strategy:
       matrix:
         base_image: ["debian","alpine"]
@@ -358,6 +340,18 @@ jobs:
           QUAY_REPO: ${{ vars.QUAY_REPO }}
         run: |
           echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${QUAY_REPO}" | tee -a "${GITHUB_ENV}"
+
+      # Determine Base Tags
+      - name: Determine Base Tags
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          # Check which main tag we are going to build determined by ref_type
+          if [[ "${REF_TYPE}" == "tag" ]]; then
+            echo "BASE_TAGS=latest,${GITHUB_REF#refs/*/}" | tee -a "${GITHUB_ENV}"
+          elif [[ "${REF_TYPE}" == "branch" ]]; then
+            echo "BASE_TAGS=testing" | tee -a "${GITHUB_ENV}"
+          fi
 
       - name: Create manifest list, push it and extract digest SHA
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
Split step into 2 parts, since only 1 part is needed in the build job