### PR TITLE
Revert to gzip compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
             *.cache-to=${{ env.BAKE_CACHE_TO }}
             *.platform=linux/${{ matrix.arch }}
             ${{ env.TAGS }}
-            *.output=type=image,push-by-digest=true,name-canonical=true,push=true,compression=zstd
+            *.output=type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Extract digest SHA
         env:


### PR DESCRIPTION
- zstd support has been added in Docker v23
- Debian Bookworm/Bullseye ships with Docker v20.10
- Revert for now to maintain compatibility with older releases