### PR TITLE
support UriMatchDefaults policy

### DIFF
--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -42,6 +42,10 @@ pub enum OrgPolicyType {
     // FreeFamiliesSponsorshipPolicy = 13,
     RemoveUnlockWithPin = 14,
     RestrictedItemTypes = 15,
+    UriMatchDefaults = 16,
+    // AutotypeDefaultSetting = 17, // Not supported yet
+    // AutoConfirm = 18, // Not supported (not implemented yet)
+    // BlockClaimedDomainAccountCreation = 19, // Not supported (Not AGPLv3 Licensed)
 }
 
 // https://github.com/bitwarden/server/blob/9ebe16587175b1c0e9208f84397bb75d0d595510/src/Core/AdminConsole/Models/Data/Organizations/Policies/SendOptionsPolicyData.cs#L5


### PR DESCRIPTION
in the new web-vault (https://github.com/dani-garcia/bw_web_builds/pull/221) there will be a new policy that is not hidden behind a feature flag to set the [default URI match detection](https://bitwarden.com/help/policies/#default-uri-match-detection).

I've also documented the other new policies as comments as well which are hidden behind feature flags or not available in the open source version. `AutotypeDefaultSetting` should be a client-side policy as well, while `AutoConfirm` will need server-side changes (at least [this new endpoint](https://github.com/bitwarden/clients/blob/2a3e13b9b35928a1999a7709a0d43fcb1b00d22d/libs/admin-console/src/common/organization-user/services/default-organization-user-api.service.ts#L204)).