### PR TITLE
Add UserDecryption on /sync too

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -74,11 +74,11 @@ const GLOBAL_DOMAINS: &str = include_str!("../../static/global_domains.json");
 
 #[get("/settings/domains")]
 fn get_eq_domains(headers: Headers) -> Json<Value> {
-    _get_eq_domains(headers, false)
+    _get_eq_domains(&headers, false)
 }
 
-fn _get_eq_domains(headers: Headers, no_excluded: bool) -> Json<Value> {
-    let user = headers.user;
+fn _get_eq_domains(headers: &Headers, no_excluded: bool) -> Json<Value> {
+    let user = &headers.user;
     use serde_json::from_str;
 
     let equivalent_domains: Vec<Vec<String>> = from_str(&user.equivalent_domains).unwrap();


### PR DESCRIPTION
The UserDecryption values are not only returned on the authentication response, but also on calls to /sync, which I've missed on #6572.

Yes, it's also using different casing 😿, but that's the behavior from upstream, so I'd rather copy it to avoid problems