### PR TITLE
Fix posting cipher with readonly collections

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -322,25 +322,6 @@ async fn post_ciphers_create(
 ) -> JsonResult {
     let mut data: ShareCipherData = data.into_inner();
 
-    // Check if there are one more more collections selected when this cipher is part of an organization.
-    // err if this is not the case before creating an empty cipher.
-    if let Some(org_id) = &data.cipher.organization_id {
-        if data.collection_ids.is_empty() {
-            err!("You must select at least one collection.");
-        } else {
-            for col_id in &data.collection_ids {
-                match Collection::find_by_uuid_and_org(col_id, org_id, &conn).await {
-                    None => err!("Invalid collection ID provided"),
-                    Some(collection) => {
-                        if !collection.is_writable_by_user(&headers.user.uuid, &conn).await {
-                            err!("No rights to modify the collection")
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     // This check is usually only needed in update_cipher_from_data(), but we
     // need it here as well to avoid creating an empty cipher in the call to
     // cipher.save() below.
@@ -358,7 +339,11 @@ async fn post_ciphers_create(
     // or otherwise), we can just ignore this field entirely.
     data.cipher.last_known_revision_date = None;
 
-    share_cipher_by_uuid(&cipher.uuid, data, &headers, &conn, &nt, None).await
+    let res = share_cipher_by_uuid(&cipher.uuid, data, &headers, &conn, &nt, None).await;
+    if res.is_err() {
+        cipher.delete(&conn).await?;
+    }
+    res
 }
 
 /// Called when creating a new user-owned cipher.


### PR DESCRIPTION
This fix will check if a collection is writeable for the user, and if not error out early instead of creating the cipher first and leaving it. It will also save some database transactions.

Fixes #6562