### PR TITLE
Add option to specify backup path

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -790,7 +790,7 @@ async fn delete_config(_token: AdminToken) -> EmptyResult {
 #[post("/config/backup_db", format = "application/json")]
 fn backup_db(_token: AdminToken) -> ApiResult<String> {
     if *CAN_BACKUP {
-        match backup_sqlite() {
+        match backup_sqlite(None) {
             Ok(f) => Ok(format!("Backup to '{f}' was successful")),
             Err(e) => err!(format!("Backup was unsuccessful {e}")),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ FLAGS:
 
 COMMAND:
     hash [--preset {bitwarden|owasp}]  Generate an Argon2id PHC ADMIN_TOKEN
-    backup                             Create a backup of the SQLite database
+    backup [--path]                    Create a backup of the SQLite database
                                        You can also send the USR1 signal to trigger a backup
 
 PRESETS:                  m=         t=          p=
@@ -187,7 +187,9 @@ fn parse_args() {
                 exit(1);
             }
         } else if command == "backup" {
-            match db::backup_sqlite() {
+            let backup_path: Option<String> = pargs.opt_value_from_str(["-p", "--path"]).unwrap_or_default();
+
+            match db::backup_sqlite(backup_path) {
                 Ok(f) => {
                     println!("Backup to '{f}' was successful");
                     exit(0);
@@ -606,7 +608,7 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
                     // If we need more signals to act upon, we might want to use select! here.
                     // With only one item to listen for this is enough.
                     let _ = signal_user1.recv().await;
-                    match db::backup_sqlite() {
+                    match db::backup_sqlite(None) {
                         Ok(f) => info!("Backup to '{f}' was successful"),
                         Err(e) => error!("Backup failed. {e:?}"),
                     }


### PR DESCRIPTION
The current backup comannd will store the backup file in the same folder as the db itself. This MR gives the user the option to store backup files in a different folder (e.g. to an different SMB share).