### PR TITLE
Add wrapped named variants to UserDecryptionOptions

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -173,7 +173,10 @@ async fn sync(data: SyncData, headers: Headers, client_version: Option<ClientVer
                 "memory": headers.user.client_kdf_memory,
                 "parallelism": headers.user.client_kdf_parallelism
             },
+            // This field is named inconsistently and will be removed and replaced by the "wrapped" variant in the apps.
+            // https://github.com/bitwarden/android/blob/release/2025.12-rc41/network/src/main/kotlin/com/bitwarden/network/model/MasterPasswordUnlockDataJson.kt#L22-L26
             "masterKeyEncryptedUserKey": headers.user.akey,
+            "masterKeyWrappedUserKey": headers.user.akey,
             "salt": headers.user.email
         })
     } else {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -472,7 +472,10 @@ async fn authenticated_response(
                 "Memory": user.client_kdf_memory,
                 "Parallelism": user.client_kdf_parallelism
             },
+            // This field is named inconsistently and will be removed and replaced by the "wrapped" variant in the apps.
+            // https://github.com/bitwarden/android/blob/release/2025.12-rc41/network/src/main/kotlin/com/bitwarden/network/model/MasterPasswordUnlockDataJson.kt#L22-L26
             "MasterKeyEncryptedUserKey": user.akey,
+            "MasterKeyWrappedUserKey": user.akey,
             "Salt": user.email
         })
     } else {


### PR DESCRIPTION
The android app indicates that this field has an inconsistent naming and will be renamed in the future to `masterKeyWrappedUserKey`. The apps should handle that change in a backwards compatible way, but we can send both just to be safe. I'll make a note to come back and clean this up in three months or so, when the apps are updated.

Reference: https://github.com/bitwarden/android/blob/release/2025.12-rc41/network/src/main/kotlin/com/bitwarden/network/model/MasterPasswordUnlockDataJson.kt#L22-L26