### PR TITLE
Switch to `xx-cargo`

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -57,7 +57,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Debian Trixie uses libpq v17
     PQ_LIB_DIR="/usr/local/musl/pq17/lib"
 
-
 # Create CARGO_HOME folder and don't download rust docs
 RUN mkdir -pv "${CARGO_HOME}" && \
     rustup set profile minimal

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -51,7 +51,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TERM=xterm-256color \
     CARGO_HOME="/root/.cargo" \
     USER="root"
-# Install clang to get `xx-cargo` working
+# Install clang && xx-c-essentials to get `xx-cargo` working
 # Install pkg-config to allow amd64 builds to find all libraries
 # Install git so build.rs can determine the correct version
 # Install the libc cross packages based upon the debian-arch
@@ -59,19 +59,16 @@ RUN apt-get update && \
     apt-get install -y \
         --no-install-recommends \
         clang \
-        pkg-config \
-        git \
-        "libc6-$(xx-info debian-arch)-cross" \
-        "libc6-dev-$(xx-info debian-arch)-cross" \
-        "linux-libc-dev-$(xx-info debian-arch)-cross" && \
+        git && \
     xx-apt-get install -y \
         --no-install-recommends \
-        gcc \
         libpq-dev \
         libpq5 \
         libssl-dev \
         libmariadb-dev \
-        zlib1g-dev && \
+        pkg-config \
+        zlib1g-dev \
+        xx-c-essentials && \
     # Run xx-cargo early, since it sometimes seems to break when run at a later stage
     echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
 
@@ -82,29 +79,6 @@ RUN mkdir -pv "${CARGO_HOME}" && \
 # Creates a dummy project used to grab dependencies
 RUN USER=root cargo new --bin /app
 WORKDIR /app
-
-# Environment variables for Cargo on Debian based builds
-ARG TARGET_PKG_CONFIG_PATH
-
-RUN source /env-cargo && \
-    if xx-info is-cross ; then \
-        # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
-        # Because of this we generate the needed environment variables here which we can load in the needed steps.
-        echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export CARGO_TARGET_$(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export CROSS_COMPILE=1" >> /env-cargo && \
-        echo "export PKG_CONFIG_ALLOW_CROSS=1" >> /env-cargo && \
-        # For some architectures `xx-info` returns a triple which doesn't matches the path on disk
-        # In those cases you can override this by setting the `TARGET_PKG_CONFIG_PATH` build-arg
-        if [[ -n "${TARGET_PKG_CONFIG_PATH}" ]]; then \
-            echo "export TARGET_PKG_CONFIG_PATH=${TARGET_PKG_CONFIG_PATH}" >> /env-cargo ; \
-        else \
-            echo "export PKG_CONFIG_PATH=/usr/lib/$(xx-info)/pkgconfig" >> /env-cargo ; \
-        fi && \
-        echo "# End of env-cargo" >> /env-cargo ; \
-    fi && \
-    # Output the current contents of the file
-    cat /env-cargo
 
 RUN source /env-cargo && \
     rustup target add "${CARGO_TARGET}"
@@ -122,7 +96,9 @@ ARG DB=sqlite,mysql,postgresql
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
 RUN source /env-cargo && \
-    cargo build --features ${DB} --profile "${CARGO_PROFILE}" --target="${CARGO_TARGET}" && \
+    # Workaround for xx related build issues
+    # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -137,7 +113,9 @@ RUN source /env-cargo && \
     # Also do this for build.rs to ensure the version is rechecked
     touch build.rs src/main.rs && \
     # Create a symlink to the binary target folder to easy copy the binary in the final stage
-    cargo build --features ${DB} --profile "${CARGO_PROFILE}" --target="${CARGO_TARGET}" && \
+    # Workaround for xx related build issues
+    # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     if [[ "${CARGO_PROFILE}" == "dev" ]] ; then \
         ln -vfsr "/app/target/${CARGO_TARGET}/debug" /app/target/final ; \
     else \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -27,6 +27,11 @@
 #     $ docker image inspect --format "{{ '{{' }}.RepoTags}}" docker.io/vaultwarden/web-vault@{{ vault_image_digest }}
 #     [docker.io/vaultwarden/web-vault:{{ vault_version }}]
 #
+{% macro xx_cargo_config() -%}
+# Workaround for xx related build issues
+    # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}"
+{%- endmacro %}
 FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_digest }} AS vault
 
 {% if base == "debian" %}
@@ -66,10 +71,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Use PostgreSQL v17 during Alpine/MUSL builds instead of the default v16
     # Debian Trixie uses libpq v17
     PQ_LIB_DIR="/usr/local/musl/pq17/lib"
-{% endif %}
+{%- endif %}
 
 {% if base == "debian" %}
-# Install clang to get `xx-cargo` working
+# Install clang && xx-c-essentials to get `xx-cargo` working
 # Install pkg-config to allow amd64 builds to find all libraries
 # Install git so build.rs can determine the correct version
 # Install the libc cross packages based upon the debian-arch
@@ -77,19 +82,16 @@ RUN apt-get update && \
     apt-get install -y \
         --no-install-recommends \
         clang \
-        pkg-config \
-        git \
-        "libc6-$(xx-info debian-arch)-cross" \
-        "libc6-dev-$(xx-info debian-arch)-cross" \
-        "linux-libc-dev-$(xx-info debian-arch)-cross" && \
+        git && \
     xx-apt-get install -y \
         --no-install-recommends \
-        gcc \
         libpq-dev \
         libpq5 \
         libssl-dev \
         libmariadb-dev \
-        zlib1g-dev && \
+        pkg-config \
+        zlib1g-dev \
+        xx-c-essentials && \
     # Run xx-cargo early, since it sometimes seems to break when run at a later stage
     echo "export CARGO_TARGET=$(xx-cargo --print-target-triple)" >> /env-cargo
 {% endif %}
@@ -102,31 +104,7 @@ RUN mkdir -pv "${CARGO_HOME}" && \
 RUN USER=root cargo new --bin /app
 WORKDIR /app
 
-{% if base == "debian" %}
-# Environment variables for Cargo on Debian based builds
-ARG TARGET_PKG_CONFIG_PATH
-
-RUN source /env-cargo && \
-    if xx-info is-cross ; then \
-        # We can't use xx-cargo since that uses clang, which doesn't work for our libraries.
-        # Because of this we generate the needed environment variables here which we can load in the needed steps.
-        echo "export CC_$(echo "${CARGO_TARGET}" | tr '[:upper:]' '[:lower:]' | tr - _)=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export CARGO_TARGET_$(echo "${CARGO_TARGET}" | tr '[:lower:]' '[:upper:]' | tr - _)_LINKER=/usr/bin/$(xx-info)-gcc" >> /env-cargo && \
-        echo "export CROSS_COMPILE=1" >> /env-cargo && \
-        echo "export PKG_CONFIG_ALLOW_CROSS=1" >> /env-cargo && \
-        # For some architectures `xx-info` returns a triple which doesn't matches the path on disk
-        # In those cases you can override this by setting the `TARGET_PKG_CONFIG_PATH` build-arg
-        if [[ -n "${TARGET_PKG_CONFIG_PATH}" ]]; then \
-            echo "export TARGET_PKG_CONFIG_PATH=${TARGET_PKG_CONFIG_PATH}" >> /env-cargo ; \
-        else \
-            echo "export PKG_CONFIG_PATH=/usr/lib/$(xx-info)/pkgconfig" >> /env-cargo ; \
-        fi && \
-        echo "# End of env-cargo" >> /env-cargo ; \
-    fi && \
-    # Output the current contents of the file
-    cat /env-cargo
-
-{% elif base == "alpine" %}
+{% if base == "alpine" %}
 # Environment variables for Cargo on Alpine based builds
 RUN echo "export CARGO_TARGET=${RUST_MUSL_CROSS_TARGET}" >> /env-cargo && \
     # Output the current contents of the file
@@ -154,7 +132,11 @@ ARG DB=sqlite,mysql,postgresql,enable_mimalloc
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
 RUN source /env-cargo && \
+{% if base == "debian" %}
+    {{ xx_cargo_config() }} && \
+{% elif base == "alpine" %}
     cargo build --features ${DB} --profile "${CARGO_PROFILE}" --target="${CARGO_TARGET}" && \
+{% endif %}
     find . -not -path "./target*" -delete
 
 # Copies the complete project
@@ -169,7 +151,11 @@ RUN source /env-cargo && \
     # Also do this for build.rs to ensure the version is rechecked
     touch build.rs src/main.rs && \
     # Create a symlink to the binary target folder to easy copy the binary in the final stage
+{% if base == "debian" %}
+    {{ xx_cargo_config() }} && \
+{% elif base == "alpine" %}
     cargo build --features ${DB} --profile "${CARGO_PROFILE}" --target="${CARGO_TARGET}" && \
+{% endif %}
     if [[ "${CARGO_PROFILE}" == "dev" ]] ; then \
         ln -vfsr "/app/target/${CARGO_TARGET}/debug" /app/target/final ; \
     else \


### PR DESCRIPTION
- removes a lot of additional configuration lines from the Dockerfile
- includes the workaround for the `openssl-sys` build issues with improper `pkg-config` setup
- for reference: https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977

Could also switch to use `lld` as the linker if wanted.