### PR TITLE
Add aria-label to token field on admin login page

### DIFF
--- a/src/static/templates/admin/login.hbs
+++ b/src/static/templates/admin/login.hbs
@@ -13,7 +13,7 @@
             <small>Please provide it below:</small>
 
             <form class="form-inline" method="post" action="{{urlpath}}/admin">
-                <input type="password" autocomplete="password" class="form-control w-50 mr-2" name="token" placeholder="Enter admin token" autofocus="autofocus">
+                <input type="password" autocomplete="password" class="form-control w-50 mr-2" name="token" aria-label="Admin token" placeholder="Enter admin token" autofocus="autofocus">
                 {{#if redirect}}
                 <input type="hidden" id="redirect" name="redirect" value="/{{redirect}}">
                 {{/if}}


### PR DESCRIPTION
This makes it possible for Bitwarden to autofill admin token by using a Custom Field [1] named "Admin token". Autofill for custom fields works by matching a form element's id, name, aria-label, or placeholder [2].

Currently, autofill can be configured using a custom field named "Token", which is somewhat generic and may be confused with other credentials such as an API token.

[1] https://bitwarden.com/help/custom-fields/
[2] https://bitwarden.com/help/auto-fill-custom-fields/