### PR TITLE
return no content with status code 204

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -919,6 +919,7 @@ struct RegisterVerificationData {
 
 #[derive(rocket::Responder)]
 enum RegisterVerificationResponse {
+    #[response(status = 204)]
     NoContent(()),
     Token(Json<String>),
 }


### PR DESCRIPTION
As discussed in https://github.com/dani-garcia/vaultwarden/issues/6592#issuecomment-3709484614 the Bitwarden android app expects the status code to be `204 No Content` for this endpoint if the response is empty. (Cf. [AccountsController.cs#L124](https://github.com/bitwarden/server/blob/68702611916668660521c9657ad5b317fd9ebca4/src/Identity/Controllers/AccountsController.cs#L124)). With the default `200` it tries to convert it to JSON which fails. ```kotlinx.serialization.json.internal.JsonDecodingException: Cannot read Json element because of unexpected end of the input at path: $```

(To test you need to configure both mail and set `SIGNUPS_VERIFY=true` otherwise you can just choose a password.)