### PR TITLE
allow MasterPasswordHash for Android

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -47,6 +47,7 @@ pub type EmptyResult = ApiResult<()>;
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PasswordOrOtpData {
+    #[serde(alias = "MasterPasswordHash")]
     master_password_hash: Option<String>,
     otp: Option<String>,
 }


### PR DESCRIPTION
If you try to delete your account in the Android app this currently fails with `No validation provided`.

```
[2026-01-06 13:16:25.721][request][INFO] DELETE /api/accounts
[2026-01-06 13:16:25.725][vaultwarden::api][ERROR] No validation provided
[2026-01-06 13:16:25.725][response][INFO] (delete_account) DELETE /api/accounts => 400 Bad Request
```

To replicate:
1. Go to "Settings" > "Account security"
2. Scroll down to "Delete account" and click on it
3. Click again on the red "Delete account" button that pops up. 
4. Enter your password to verify and click "Submit".

<img width="720" height="1600" alt="Screenshot_20260106-131520" src="https://github.com/user-attachments/assets/6121a54a-b563-40f6-98f6-61902e7c8897" />

As far as I've looked into it this is because the request is using [`MasterPasswordHash`](https://github.com/bitwarden/android/blob/f02b374e989600a8458d2884abd2526244241c8a/network/src/main/kotlin/com/bitwarden/network/model/DeleteAccountRequestJson.kt#L14) and not `masterPasswordHash`.