### PR TITLE
improve sso callback path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1325,7 +1325,9 @@ fn generate_smtp_img_src(embed_images: bool, domain: &str) -> String {
     if embed_images {
         "cid:".to_string()
     } else {
-        format!("{domain}/vw_static/")
+        // normalize base_url
+        let base_url = domain.trim_end_matches('/');
+        format!("{base_url}/vw_static/")
     }
 }
 


### PR DESCRIPTION
Currently we remove a trailing slash after making the config:
https://github.com/dani-garcia/vaultwarden/blob/9f1df422595cdfb04b8aea6968ae52a434887abc/src/config.rs#L309

This means that the generated `sso_callback_path` is not yet normalized, which leads to some issues (e.g. https://github.com/dani-garcia/vaultwarden/issues/6180 or https://github.com/dani-garcia/vaultwarden/issues/6601).

This change would fix that by applying the same normalization to the generated URL.