### PR TITLE
Fix web-vault version check and update web-vault

### DIFF
--- a/docker/DockerSettings.yaml
+++ b/docker/DockerSettings.yaml
@@ -1,6 +1,6 @@
 ---
-vault_version: "v2025.12.1.1"
-vault_image_digest: "sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457"
+vault_version: "v2025.12.1+build.3"
+vault_image_digest: "sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42"
 # Cross Compile Docker Helper Scripts v1.9.0
 # We use the linux/amd64 platform shell scripts since there is no difference between the different platform scripts
 # https://github.com/tonistiigi/xx | https://hub.docker.com/r/tonistiigi/xx/tags

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -19,15 +19,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2025.12.1.1
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2025.12.1.1
-#     [docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2025.12.1_build.3
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2025.12.1_build.3
+#     [docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457
-#     [docker.io/vaultwarden/web-vault:v2025.12.1.1]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42
+#     [docker.io/vaultwarden/web-vault:v2025.12.1_build.3]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457 AS vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42 AS vault
 
 ########################## ALPINE BUILD IMAGES ##########################
 ## NOTE: The Alpine Base Images do not support other platforms then linux/amd64 and linux/arm64

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -19,15 +19,15 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:v2025.12.1.1
-#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2025.12.1.1
-#     [docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457]
+#     $ docker pull docker.io/vaultwarden/web-vault:v2025.12.1_build.3
+#     $ docker image inspect --format "{{.RepoDigests}}" docker.io/vaultwarden/web-vault:v2025.12.1_build.3
+#     [docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42]
 #
 # - Conversely, to get the tag name from the digest:
-#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457
-#     [docker.io/vaultwarden/web-vault:v2025.12.1.1]
+#     $ docker image inspect --format "{{.RepoTags}}" docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42
+#     [docker.io/vaultwarden/web-vault:v2025.12.1_build.3]
 #
-FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:90261e5d5438b67a00cb12d8615cf3f130a65e81f33a3f5ff190c6202bf0e457 AS vault
+FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@sha256:bf5aa55dc7bcb99f85d2a88ff44d32cdc832e934a0603fe28e5c3f92904bad42 AS vault
 
 ########################## Cross Compile Docker Helper Scripts ##########################
 ## We use the linux/amd64 no matter which Build Platform, since these are all bash scripts

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -19,13 +19,13 @@
 # - From https://hub.docker.com/r/vaultwarden/web-vault/tags,
 #   click the tag name to view the digest of the image it currently points to.
 # - From the command line:
-#     $ docker pull docker.io/vaultwarden/web-vault:{{ vault_version }}
-#     $ docker image inspect --format "{{ '{{' }}.RepoDigests}}" docker.io/vaultwarden/web-vault:{{ vault_version }}
+#     $ docker pull docker.io/vaultwarden/web-vault:{{ vault_version | replace('+', '_') }}
+#     $ docker image inspect --format "{{ '{{' }}.RepoDigests}}" docker.io/vaultwarden/web-vault:{{ vault_version | replace('+', '_') }}
 #     [docker.io/vaultwarden/web-vault@{{ vault_image_digest }}]
 #
 # - Conversely, to get the tag name from the digest:
 #     $ docker image inspect --format "{{ '{{' }}.RepoTags}}" docker.io/vaultwarden/web-vault@{{ vault_image_digest }}
-#     [docker.io/vaultwarden/web-vault:{{ vault_version }}]
+#     [docker.io/vaultwarden/web-vault:{{ vault_version | replace('+', '_') }}]
 #
 FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_digest }} AS vault
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
 
 use crate::{
     error::Error,
-    util::{get_env, get_env_bool, get_web_vault_version, is_valid_email, parse_experimental_client_feature_flags},
+    util::{get_active_web_release, get_env, get_env_bool, is_valid_email, parse_experimental_client_feature_flags},
 };
 
 static CONFIG_FILE: LazyLock<String> = LazyLock::new(|| {
@@ -1849,7 +1849,7 @@ fn to_json<'reg, 'rc>(
 // Configure the web-vault version as an integer so it can be used as a comparison smaller or greater then.
 // The default is based upon the version since this feature is added.
 static WEB_VAULT_VERSION: LazyLock<semver::Version> = LazyLock::new(|| {
-    let vault_version = get_web_vault_version();
+    let vault_version = get_active_web_release();
     // Use a single regex capture to extract version components
     let re = regex::Regex::new(r"(\d{4})\.(\d{1,2})\.(\d{1,2})").unwrap();
     re.captures(&vault_version)

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn parse_args() {
         exit(0);
     } else if pargs.contains(["-v", "--version"]) {
         config::SKIP_CONFIG_VALIDATION.store(true, Ordering::Relaxed);
-        let web_vault_version = util::get_web_vault_version();
+        let web_vault_version = util::get_active_web_release();
         println!("Vaultwarden {version}");
         println!("Web-Vault {web_vault_version}");
         exit(0);

--- a/src/static/scripts/admin_diagnostics.js
+++ b/src/static/scripts/admin_diagnostics.js
@@ -29,7 +29,7 @@ function isValidIp(ip) {
     return ipv4Regex.test(ip) || ipv6Regex.test(ip);
 }
 
-function checkVersions(platform, installed, latest, commit=null, pre_release=false) {
+function checkVersions(platform, installed, latest, commit=null, compare_order=0) {
     if (installed === "-" || latest === "-") {
         document.getElementById(`${platform}-failed`).classList.remove("d-none");
         return;
@@ -37,7 +37,7 @@ function checkVersions(platform, installed, latest, commit=null, pre_release=fal
 
     // Only check basic versions, no commit revisions
     if (commit === null || installed.indexOf("-") === -1) {
-        if (platform === "web" && pre_release === true) {
+        if (platform === "web" && compare_order === 1) {
             document.getElementById(`${platform}-prerelease`).classList.remove("d-none");
         } else if (installed == latest) {
             document.getElementById(`${platform}-success`).classList.remove("d-none");
@@ -83,7 +83,7 @@ async function generateSupportString(event, dj) {
     let supportString = "### Your environment (Generated via diagnostics page)\n\n";
 
     supportString += `* Vaultwarden version: v${dj.current_release}\n`;
-    supportString += `* Web-vault version: v${dj.web_vault_version}\n`;
+    supportString += `* Web-vault version: v${dj.active_web_release}\n`;
     supportString += `* OS/Arch: ${dj.host_os}/${dj.host_arch}\n`;
     supportString += `* Running within a container: ${dj.running_within_container} (Base: ${dj.container_base_image})\n`;
     supportString += `* Database type: ${dj.db_type}\n`;
@@ -208,9 +208,9 @@ function initVersionCheck(dj) {
     }
     checkVersions("server", serverInstalled, serverLatest, serverLatestCommit);
 
-    const webInstalled = dj.web_vault_version;
-    const webLatest = dj.latest_web_build;
-    checkVersions("web", webInstalled, webLatest, null, dj.web_vault_pre_release);
+    const webInstalled = dj.active_web_release;
+    const webLatest = dj.latest_web_release;
+    checkVersions("web", webInstalled, webLatest, null, dj.web_vault_compare);
 }
 
 function checkDns(dns_resolved) {

--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -27,13 +27,13 @@
                         <span class="badge bg-info text-dark d-none abbr-badge" id="web-prerelease" title="You seem to be using a pre-release version.">Pre-Release</span>
                     </dt>
                     <dd class="col-sm-7">
-                        <span id="web-installed">{{page_data.web_vault_version}}</span>
+                        <span id="web-installed">{{page_data.active_web_release}}</span>
                     </dd>
                     <dt class="col-sm-5">Web Latest
                         <span class="badge bg-secondary d-none abbr-badge" id="web-failed" title="Unable to determine latest version.">Unknown</span>
                     </dt>
                     <dd class="col-sm-7">
-                        <span id="web-latest">{{page_data.latest_web_build}}</span>
+                        <span id="web-latest">{{page_data.latest_web_release}}</span>
                     </dd>
                     {{/if}}
                     {{#unless page_data.web_vault_enabled}}

--- a/src/util.rs
+++ b/src/util.rs
@@ -531,7 +531,7 @@ struct WebVaultVersion {
     version: String,
 }
 
-pub fn get_web_vault_version() -> String {
+pub fn get_active_web_release() -> String {
     let version_files = [
         format!("{}/vw-version.json", CONFIG.web_vault_folder()),
         format!("{}/version.json", CONFIG.web_vault_folder()),


### PR DESCRIPTION
Adjust the version checking for the web-vault to work with the `+build.n` schema.
Also adjusted some variable and function names to be more clear.
Added a test to validate and verify the version matching.