### PR TITLE
Force MySQL to use correct name and collation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -97,7 +97,7 @@
 ## This is mainly useful for connection-scoped pragmas.
 ## If empty, a database-specific default is used:
 ## - SQLite: "PRAGMA busy_timeout = 5000; PRAGMA synchronous = NORMAL;"
-## - MySQL: ""
+## - MySQL: "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;"
 ## - PostgreSQL: ""
 # DATABASE_CONN_INIT=""
 


### PR DESCRIPTION
This should force all MySQL/MariaDB connections to use the correct names and collation to be `utf8mb4` and `utf8mb4_unicode_ci`. It will not fix current tables which have the wrong charset or collation, but it should prevent new databases and future additions to use the wrong set.

Also made sure that the init statements are also applied during migrations, which currently did not happen.

Should prevent / resolve #6611 like issues in the future.