### PR TITLE
hide password hints via CSS

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -60,11 +60,12 @@ fn vaultwarden_css() -> Cached<Css<String>> {
         "mail_2fa_enabled": CONFIG._enable_email_2fa(),
         "mail_enabled": CONFIG.mail_enabled(),
         "sends_allowed": CONFIG.sends_allowed(),
+        "password_hints_allowed": CONFIG.password_hints_allowed(),
         "signup_disabled": CONFIG.is_signup_disabled(),
         "sso_enabled": CONFIG.sso_enabled(),
         "sso_only": CONFIG.sso_enabled() && CONFIG.sso_only(),
-        "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),
         "webauthn_2fa_supported": CONFIG.is_webauthn_2fa_supported(),
+        "yubico_enabled": CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some(),
     });
 
     let scss = match CONFIG.render_template("scss/vaultwarden.scss", &css_options) {

--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -192,6 +192,19 @@ bit-nav-item[route="sends"] {
   @extend %vw-hide;
 }
 {{/unless}}
+
+{{#unless password_hints_allowed}}
+/* Hide password hints if not allowed */
+a[routerlink="/hint"],
+{{#if (webver "<2025.12.2")}}
+app-change-password > form > .form-group:nth-child(5),
+auth-input-password > form > bit-form-field:nth-child(4) {
+{{else}}
+.vw-password-hint {
+{{/if}}
+  @extend %vw-hide;
+}
+{{/unless}}
 /**** End Dynamic Vaultwarden Changes ****/
 /**** Include a special user stylesheet for custom changes ****/
 {{#if load_user_scss}}


### PR DESCRIPTION
implements the suggestion to hide password hints https://github.com/dani-garcia/vaultwarden/discussions/6719 without requiring the new patched web-vault v2025.12.2 https://github.com/vaultwarden/vw_web_builds/pull/23 (while this is probably not backwards compatible for older web-vault versions due to the css being position dependent it should work at least with v2025.12.1).