### PR TITLE
Empty AccountKeys when no private key

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -482,14 +482,18 @@ async fn authenticated_response(
         Value::Null
     };
 
-    let account_keys = json!({
-        "publicKeyEncryptionKeyPair": {
-            "wrappedPrivateKey": user.private_key,
-            "publicKey": user.public_key,
-            "Object": "publicKeyEncryptionKeyPair"
-        },
-        "Object": "privateKeys"
-    });
+    let account_keys = if user.private_key.is_some() {
+        json!({
+            "publicKeyEncryptionKeyPair": {
+                "wrappedPrivateKey": user.private_key,
+                "publicKey": user.public_key,
+                "Object": "publicKeyEncryptionKeyPair"
+            },
+            "Object": "privateKeys"
+        })
+    } else {
+        Value::Null
+    };
 
     let mut result = json!({
         "access_token": auth_tokens.access_token(),


### PR DESCRIPTION
When creating a user using SSO the user key is not initialized, returning the object with `null` values break the onboarding with an error `Response must contain a valid publicKey`.

