### PR TITLE
refactor: improve tooltips in diagnostics page

### DIFF
--- a/src/static/templates/admin/diagnostics.hbs
+++ b/src/static/templates/admin/diagnostics.hbs
@@ -8,7 +8,7 @@
                 <dl class="row">
                     <dt class="col-sm-5">Server Installed
                         <span class="badge bg-success d-none abbr-badge" id="server-success" title="Latest version is installed.">Ok</span>
-                        <span class="badge bg-warning text-dark d-none abbr-badge" id="server-warning" title="There seems to be an update available.">Update</span>
+                        <span class="badge bg-warning text-dark d-none abbr-badge" id="server-warning" title="An update is available.">Update</span>
                         <span class="badge bg-info text-dark d-none abbr-badge" id="server-branch" title="This is a branched version.">Branched</span>
                     </dt>
                     <dd class="col-sm-7">
@@ -23,8 +23,8 @@
                     {{#if page_data.web_vault_enabled}}
                     <dt class="col-sm-5">Web Installed
                         <span class="badge bg-success d-none abbr-badge" id="web-success" title="Latest version is installed.">Ok</span>
-                        <span class="badge bg-warning text-dark d-none abbr-badge" id="web-warning" title="There seems to be an update available.">Update</span>
-                        <span class="badge bg-info text-dark d-none abbr-badge" id="web-prerelease" title="You seem to be using a pre-release version.">Pre-Release</span>
+                        <span class="badge bg-warning text-dark d-none abbr-badge" id="web-warning" title="An update is available.">Update</span>
+                        <span class="badge bg-info text-dark d-none abbr-badge" id="web-prerelease" title="You are using a pre-release version.">Pre-Release</span>
                     </dt>
                     <dd class="col-sm-7">
                         <span id="web-installed">{{page_data.active_web_release}}</span>


### PR DESCRIPTION
The term "seems to" is used too loosely in many of the tooltips, but in these 2 instances it is wrong wording.
An update is either available or not. If there is no update, one could argue that "seems to" is valid, since the Internet could be down to check for a new version. But in this situation the update is availble. It is impossible that an update seems to be available.

P.S.: Oops, I forgot about the pre-release. That is also wrong from a logical perspective. 

----

This is merely a cosmetic change and certainly not important. But when I read the tooltip it made me cringe. Feel free to close it.