### PR TITLE
Fix org-details issue

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -929,9 +929,13 @@ struct OrgIdData {
 }
 
 #[get("/ciphers/organization-details?<data..>")]
-async fn get_org_details(data: OrgIdData, headers: OrgMemberHeaders, conn: DbConn) -> JsonResult {
+async fn get_org_details(data: OrgIdData, headers: ManagerHeadersLoose, conn: DbConn) -> JsonResult {
     if data.organization_id != headers.membership.org_uuid {
         err_code!("Resource not found.", "Organization id's do not match", rocket::http::Status::NotFound.code);
+    }
+
+    if !headers.membership.has_full_access() {
+        err_code!("Resource not found.", "User does not have full access", rocket::http::Status::NotFound.code);
     }
 
     Ok(Json(json!({


### PR DESCRIPTION
Fix an issue where it was possible for users who were not eligible to access all org ciphers to be able to download and extract the encrypted contents. Only Managers with full access and Admins and Owners should be able to access this endpoint.

This change will block and prevent access for other users.