### PR TITLE
fix(send_invite): invite links

### DIFF
--- a/src/mail.rs
+++ b/src/mail.rs
@@ -302,10 +302,10 @@ pub async fn send_invite(
             .append_pair("organizationUserId", &member_id)
             .append_pair("token", &invite_token);
 
-        if CONFIG.sso_enabled() {
-            query_params.append_pair("orgUserHasExistingUser", "false");
+        if CONFIG.sso_enabled() && CONFIG.sso_only() {
             query_params.append_pair("orgSsoIdentifier", &org_id);
-        } else if user.private_key.is_some() {
+        }
+        if user.private_key.is_some() {
             query_params.append_pair("orgUserHasExistingUser", "true");
         }
     }


### PR DESCRIPTION
Only include `orgSsoIdentifier` when the server is running in SSO-only mode, ensuring invites do not force SSO when password login is still allowed.

This PR is motivated by #6807

> I’m not deeply familiar with the Vaultwarden codebase yet, so I’d appreciate a review to confirm this change aligns with existing patterns and doesn’t introduce unintended side effects.