### PR TITLE
Make available toggling webauthn allow_subdomains

### DIFF
--- a/src/api/core/two_factor/webauthn.rs
+++ b/src/api/core/two_factor/webauthn.rs
@@ -32,12 +32,17 @@ use webauthn_rs_proto::{
 static WEBAUTHN: LazyLock<Webauthn> = LazyLock::new(|| {
     let domain = CONFIG.domain();
     let domain_origin = CONFIG.domain_origin();
-    let rp_id = Url::parse(&domain).map(|u| u.domain().map(str::to_owned)).ok().flatten().unwrap_or_default();
-    let rp_origin = Url::parse(&domain_origin).unwrap();
+    let rp_id = Url::parse(&domain)
+        .map(|u| u.domain().map(str::to_owned))
+        .ok()
+        .flatten()
+        .expect("Invalid domain part for rp_id");
+    let rp_origin = Url::parse(&domain_origin).expect("Invalid domain_origin for rp_origin");
 
     let webauthn = WebauthnBuilder::new(&rp_id, &rp_origin)
         .expect("Creating WebauthnBuilder failed")
         .rp_name(&domain)
+        .allow_subdomains(CONFIG.webauthn_allow_subdomains())
         .timeout(Duration::from_millis(60000));
 
     webauthn.build().expect("Building Webauthn failed")

--- a/src/config.rs
+++ b/src/config.rs
@@ -793,6 +793,9 @@ make_config! {
         /// Prefer IPv6 (AAAA) resolving |> This settings configures the DNS resolver to resolve IPv6 first, and if not available try IPv4
         /// This could be useful in IPv6 only environments.
         dns_prefer_ipv6: bool, true, def, false;
+
+        /// Accept passkeys bound to subdomains |> This setting controls if passkeys bound to sub-domains of <Domain URL> are accepted for authentication.
+        webauthn_allow_subdomains: bool, false, def, false;
     },
 
     /// OpenID Connect SSO settings


### PR DESCRIPTION
This patch makes it possible to have DNS records for subdomains of DOMAIN_URL to point to vaultwarden instances with working webauthn keys.

I verified this code works by running patched vaultwarden instances. This change is foolproof, allow_subdomains might as well have been set to true by default but opted for defensive approach.

Related discussion; https://github.com/dani-garcia/vaultwarden/discussions/6567

Before;

DOMAIN_URL = passwords.my.domain

1. RESET
1. Navigate to URL passwords.my.domain and login
2. Generate webauthn key and save
3. Attempt login and webauthn validation = OK
4. Navigate to URL \<anything>.passwords.my.domain and login
5. Attempt webauthn validation => FAILURE

Before;

DOMAIN_URL = passwords.my.domain

1. RESET
1. Navigate to URL \<anything>.passwords.my.domain and login
2. Generate webauthn key and save => FAILURE

=> webauthn_rs fails on the browser URL passed into auth_requests when doing stuff from hostname zone.passwords.my.domain

#
After;

DOMAIN_URL = passwords.my.domain
WEBAUTHN_ALLOW_SUBDOMAINS = true

* Generating webauthn keys from browser URL \<anything>.passwords.my.domain works
* Validating webauthn keys from browser URL \<anything>.passwords.my.domain works