### PR TITLE
SSO config to skip 2FA on login

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -275,7 +275,11 @@ async fn _sso_login(
         Some((mut user, sso_user)) => {
             let mut device = get_device(&data, conn, &user).await?;
 
-            let twofactor_token = twofactor_auth(&mut user, &data, &mut device, ip, client_version, conn).await?;
+            let twofactor_token = if CONFIG.sso_skip_2fa() {
+                None
+            } else {
+                twofactor_auth(&mut user, &data, &mut device, ip, client_version, conn).await?
+            };
 
             if user.private_key.is_none() {
                 // User was invited a stub was created

--- a/src/config.rs
+++ b/src/config.rs
@@ -827,6 +827,8 @@ make_config! {
         sso_auth_only_not_session:      bool,   true,   def,    false;
         /// Client cache for discovery endpoint. |> Duration in seconds (0 or less to disable). More details: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect#client-cache
         sso_client_cache_expiration:    u64,    true,   def,    0;
+        /// Skip 2FA for SSO login |> Disable two-factor authentication requirement for SSO login
+        sso_skip_2fa:                   bool,   true,   def,    false;
         /// Log all tokens |> `LOG_LEVEL=debug` or `LOG_LEVEL=info,vaultwarden::sso=debug` is required
         sso_debug_tokens:               bool,   true,   def,    false;
     },


### PR DESCRIPTION
Allow users to skip 2FA on SSO, userful when an external IdP has already multiple 2FA options.

Tested on Web Vault, Chrome Extension and Android app.