### PR TITLE
hide remember 2fa token

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -60,6 +60,7 @@ fn vaultwarden_css() -> Cached<Css<String>> {
         "mail_2fa_enabled": CONFIG._enable_email_2fa(),
         "mail_enabled": CONFIG.mail_enabled(),
         "sends_allowed": CONFIG.sends_allowed(),
+        "remember_2fa_disabled": CONFIG.disable_2fa_remember(),
         "password_hints_allowed": CONFIG.password_hints_allowed(),
         "signup_disabled": CONFIG.is_signup_disabled(),
         "sso_enabled": CONFIG.sso_enabled(),

--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -158,6 +158,13 @@ app-root a[routerlink="/signup"] {
 {{/if}}
 {{/if}}
 
+{{#if remember_2fa_disabled}}
+/* Hide checkbox to remember 2FA token for 30 days */
+app-two-factor-auth > form > bit-form-control {
+  @extend %vw-hide;
+}
+{{/if}}
+
 {{#unless mail_2fa_enabled}}
 /* Hide `Email` 2FA if mail is not enabled */
 .providers-2fa-1 {


### PR DESCRIPTION
when `DISABLE_2FA_REMEMBER=true` there is no reason to show the checkbox to remember the second factor for 30 days as it should not do anything (as discussed in #6849).
<img width="531" height="297" alt="image" src="https://github.com/user-attachments/assets/185166cd-0717-43c6-be00-11f07f0e6bcd" />


I have not checked if this works with all 2FA providers and I plan to also make this position independent in the next web-vault release to make sure that this does not hide the wrong element