### PR TITLE
add a config experimental_client_feature_flags_skip_validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -383,6 +383,11 @@
 ## - "mutual-tls": Enable the use of mutual TLS on Android (Client >= 2025.2.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=fido2-vault-credentials
 
+## Skip validation of experimental client feature flags.
+## If set to true, Vaultwarden will not check if the flags in EXPERIMENTAL_CLIENT_FEATURE_FLAGS are known.
+## Use this at your own risk!
+# EXPERIMENTAL_CLIENT_FEATURE_FLAGS_SKIP_VALIDATION=false
+
 ## Require new device emails. When a user logs in an email is required to be sent.
 ## If sending the email fails the login attempt will fail!!
 # REQUIRE_DEVICE_EMAIL=false

--- a/src/config.rs
+++ b/src/config.rs
@@ -712,6 +712,9 @@ make_config! {
 
         /// Customize the enabled feature flags on the clients |> This is a comma separated list of feature flags to enable.
         experimental_client_feature_flags: String, false, def, String::new();
+        /// Skip validation of experimental client feature flags |> If this is set to true, the experimental client feature flags will not be validated. This is useful for testing.
+        /// Use this at your own risk!
+        experimental_client_feature_flags_skip_validation: bool, false, def, false;
 
         /// Require new device emails |> When a user logs in an email is required to be sent.
         /// If sending the email fails the login attempt will fail.
@@ -1047,12 +1050,15 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "simple-login-self-host-alias",
         "mutual-tls",
     ];
-    let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
-    let invalid_flags: Vec<_> = configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();
-    if !invalid_flags.is_empty() {
-        err!(format!("Unrecognized experimental client feature flags: {invalid_flags:?}.\n\n\
-                     Please ensure all feature flags are spelled correctly and that they are supported in this version.\n\
-                     Supported flags: {KNOWN_FLAGS:?}"));
+    if !cfg.experimental_client_feature_flags_skip_validation {
+        let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
+        let invalid_flags: Vec<_> =
+            configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();
+        if !invalid_flags.is_empty() {
+            err!(format!("Unrecognized experimental client feature flags: {invalid_flags:?}.\n\n\
+                         Please ensure all feature flags are spelled correctly and that they are supported in this version.\n\
+                         Supported flags: {KNOWN_FLAGS:?}"));
+        }
     }
 
     const MAX_FILESIZE_KB: i64 = i64::MAX >> 10;


### PR DESCRIPTION
add a config experimental_client_feature_flags_skip_validation, that, when set, passes through all feature flags verbatim without validation. 

This is useful for testing and early adopters to test it out in their docker spaces, without waiting for an official binary change.

verified that this achieves the desired behavior:
https://gist.github.com/phoeagon/6e599a40001f452837ece1f967ae8e77

```
phoeagon@Zhes-Mac-mini vaultwarden % cargo run --features sqlite   
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/vaultwarden`
/--------------------------------------------------------------------\
|                        Starting Vaultwarden                        |
|--------------------------------------------------------------------|
| This is an *unofficial* Bitwarden implementation, DO NOT use the   |
| official channels to report bugs/features, regardless of client.   |
| Send usage/configuration questions or feature requests to:         |
|   https://github.com/dani-garcia/vaultwarden/discussions or        |
|   https://vaultwarden.discourse.group/                             |
| Report suspected bugs/issues in the software itself at:            |
|   https://github.com/dani-garcia/vaultwarden/issues/new            |
\--------------------------------------------------------------------/

[2026-02-20 20:31:46.550][start][INFO] Rocket has launched from http://127.0.0.1:8000
[2026-02-20 20:32:02.571][request][INFO] GET /api
[2026-02-20 20:32:02.571][response][INFO] 404 Not Found
^C[2026-02-20 20:32:48.560][vaultwarden][INFO] Exiting Vaultwarden!
[2026-02-20 20:32:48.560][rocket::server][WARN] Received SIGINT. Requesting shutdown.
^C[2026-02-20 20:32:50.455][rocket::server][WARN] Received SIGINT. Shutdown already in progress.
[2026-02-20 20:32:50.564][vaultwarden][INFO] Vaultwarden process exited!
phoeagon@Zhes-Mac-mini vaultwarden % export EXPERIMENTAL_CLIENT_FEATURE_FLAGS=non-exist
phoeagon@Zhes-Mac-mini vaultwarden % cargo run --features sqlite
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/vaultwarden`
/--------------------------------------------------------------------\
|                        Starting Vaultwarden                        |
|--------------------------------------------------------------------|
| This is an *unofficial* Bitwarden implementation, DO NOT use the   |
| official channels to report bugs/features, regardless of client.   |
| Send usage/configuration questions or feature requests to:         |
|   https://github.com/dani-garcia/vaultwarden/discussions or        |
|   https://vaultwarden.discourse.group/                             |
| Report suspected bugs/issues in the software itself at:            |
|   https://github.com/dani-garcia/vaultwarden/issues/new            |
\--------------------------------------------------------------------/

Error loading config:
  Unrecognized experimental client feature flags: ["non-exist"].

Please ensure all feature flags are spelled correctly and that they are supported in this version.
Supported flags: ["inline-menu-positioning-improvements", "inline-menu-totp", "ssh-agent", "ssh-key-vault-item", "pm-25373-windows-biometrics-v2", "export-attachments", "anon-addy-self-host-alias", "simple-login-self-host-alias", "mutual-tls"]

phoeagon@Zhes-Mac-mini vaultwarden % export EXPERIMENTAL_CLIENT_FEATURE_FLAGS_SKIP_VALIDATION=true
phoeagon@Zhes-Mac-mini vaultwarden % cargo run --features sqlite
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/vaultwarden`
/--------------------------------------------------------------------\
|                        Starting Vaultwarden                        |
|--------------------------------------------------------------------|
| This is an *unofficial* Bitwarden implementation, DO NOT use the   |
| official channels to report bugs/features, regardless of client.   |
| Send usage/configuration questions or feature requests to:         |
|   https://github.com/dani-garcia/vaultwarden/discussions or        |
|   https://vaultwarden.discourse.group/                             |
| Report suspected bugs/issues in the software itself at:            |
|   https://github.com/dani-garcia/vaultwarden/issues/new            |
\--------------------------------------------------------------------/

[2026-02-20 20:33:56.619][start][INFO] Rocket has launched from http://127.0.0.1:8000
```