### PR TITLE
fix: grant manage permission to Manager on collection creation

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -521,7 +521,7 @@ async fn post_organization_collections(
     }
 
     if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
-        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, false, &conn).await?;
+        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, true, &conn).await?;
     }
 
     Ok(Json(collection.to_json_details(&headers.membership.user_uuid, None, &conn).await))


### PR DESCRIPTION
## Summary

- Fixes a bug where a Manager without `access_all` could create a new collection but was unable to edit it afterward
- The `CollectionUser` record was being saved with `manage=false`, causing the `ManagerHeaders` guard to reject edit requests with "The current user isn't a manager for this collection"
- Changed the `manage` parameter from `false` to `true` when saving the `CollectionUser` for the creating Manager

## Details

In `src/api/core/organizations.rs` (line 524), the collection creation endpoint saves a `CollectionUser` entry for the Manager:

```rust
CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, false, &conn).await?;
```

The last parameter (`manage`) was `false`, so subsequent calls to `Collection::is_coll_manageable_by_user()` via the `ManagerHeaders` guard would fail since:
1. `users_collections.manage` is `false`
2. `access_all` is `false` (condition to enter this code block)
3. The user is a Manager, not Admin/Owner

This was not reproduced when testing with a Manager that had `Manage all collections` enabled, because `access_all=true` bypasses this code path entirely.

## Test plan

- [ ] Create a Manager user **without** `Manage all collections`
- [ ] Grant the Manager permission to create collections
- [ ] Log in as the Manager and create a new collection
- [ ] Verify the Manager can edit the newly created collection
- [ ] Verify the Manager can update permissions on the collection
- [ ] Verify existing collection behavior is unchanged for Admins/Owners

Fixes #6871