### PR TITLE
Fix favicon fetching to check all icon links instead of just the first one

### DIFF
--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -534,7 +534,9 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
 
     use data_url::DataUrl;
 
-    for icon in icon_result.iconlist.iter().take(5) {
+    for (i, icon) in icon_result.iconlist.iter().enumerate() {
+        let is_last = i == icon_result.iconlist.iter().count() - 1;
+
         if icon.href.starts_with("data:image") {
             let Ok(datauri) = DataUrl::process(&icon.href) else {
                 continue;
@@ -562,11 +564,23 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
                 _ => debug!("Extracted icon from data:image uri is invalid"),
             };
         } else {
-            let res = get_page_with_referer(&icon.href, &icon_result.referer).await?;
+            debug!("Trying {}", icon.href);
+            // Make sure all icons are checked before returning error
+            let res = match get_page_with_referer(&icon.href, &icon_result.referer).await {
+                Ok(r) => r,
+                Err(e) if is_last => return Err(e.into()),
+                Err(e) if CustomHttpClientError::downcast_ref(&e).is_some() => return Err(e.into()), // If blacklisted stop immediately instead of checking the rest of the icons. see explanation and actual handling inside get_icon()
+                Err(e) => {
+                    warn!("Unable to download icon: {e:?}");
+                    
+                    // Continue to next icon
+                    continue;
+                }
+            };
 
             buffer = stream_to_bytes_limit(res, 5120 * 1024).await?; // 5120KB/5MB for each icon max (Same as icons.bitwarden.net)
 
-            // Check if the icon type is allowed, else try an icon from the list.
+            // Check if the icon type is allowed, else try another icon from the list.
             icon_type = get_icon_type(&buffer);
             if icon_type.is_none() {
                 buffer.clear();

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -534,8 +534,8 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
 
     use data_url::DataUrl;
 
-    for (i, icon) in icon_result.iconlist.iter().enumerate() {
-        let is_last = i == icon_result.iconlist.iter().count() - 1;
+    for (i, icon) in icon_result.iconlist.iter().take(5).enumerate() {
+        let is_last = i == icon_result.iconlist.iter().take(5).count() - 1;
 
         if icon.href.starts_with("data:image") {
             let Ok(datauri) = DataUrl::process(&icon.href) else {

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -567,11 +567,11 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
             // Make sure all icons are checked before returning error
             let res = match get_page_with_referer(&icon.href, &icon_result.referer).await {
                 Ok(r) => r,
-                Err(e) if icons.peek().is_none() => return Err(e.into()),
-                Err(e) if CustomHttpClientError::downcast_ref(&e).is_some() => return Err(e.into()), // If blacklisted stop immediately instead of checking the rest of the icons. see explanation and actual handling inside get_icon()
+                Err(e) if icons.peek().is_none() => return Err(e),
+                Err(e) if CustomHttpClientError::downcast_ref(&e).is_some() => return Err(e), // If blacklisted stop immediately instead of checking the rest of the icons. see explanation and actual handling inside get_icon()
                 Err(e) => {
                     warn!("Unable to download icon: {e:?}");
-                    
+
                     // Continue to next icon
                     continue;
                 }

--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -534,9 +534,8 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
 
     use data_url::DataUrl;
 
-    for (i, icon) in icon_result.iconlist.iter().take(5).enumerate() {
-        let is_last = i == icon_result.iconlist.iter().take(5).count() - 1;
-
+    let mut icons = icon_result.iconlist.iter().take(5).peekable();
+    while let Some(icon) = icons.next() {
         if icon.href.starts_with("data:image") {
             let Ok(datauri) = DataUrl::process(&icon.href) else {
                 continue;
@@ -568,7 +567,7 @@ async fn download_icon(domain: &str) -> Result<(Bytes, Option<&str>), Error> {
             // Make sure all icons are checked before returning error
             let res = match get_page_with_referer(&icon.href, &icon_result.referer).await {
                 Ok(r) => r,
-                Err(e) if is_last => return Err(e.into()),
+                Err(e) if icons.peek().is_none() => return Err(e.into()),
                 Err(e) if CustomHttpClientError::downcast_ref(&e).is_some() => return Err(e.into()), // If blacklisted stop immediately instead of checking the rest of the icons. see explanation and actual handling inside get_icon()
                 Err(e) => {
                     warn!("Unable to download icon: {e:?}");


### PR DESCRIPTION
Fix logic in `download_icon()`, got broken (most likely accidentally) in https://github.com/dani-garcia/vaultwarden/commit/27dc67fadd3d45b9f7d8d37407cef9453b8f5802#diff-c0f730ed83eb02623c5c9bde35b0366115b8961fb596c27f98613140cba6d2a7L714 which caused the downloader to stop after first error

~~Also don't limit max checked icons to 5, allow all icons in the list~~