### PR TITLE
Add Google S2 icon cache fallback for favicon fetching

### DIFF
--- a/src/api/icons.rs
+++ b/src/api/icons.rs
@@ -425,6 +425,9 @@ async fn get_icon_url(domain: &str) -> Result<IconUrlResult, Error> {
         iconlist.push(Icon::new(40, format!("{httpdomain}/apple-touch-icon.png")));
     }
 
+    // Add Google S2 icon cache fallback
+    iconlist.push(Icon::new(255, format!("https://www.google.com/s2/favicons?sz=32&domain={domain}")));
+
     // Sort the iconlist by priority
     iconlist.sort_by_key(|x| x.priority);
 


### PR DESCRIPTION
**LATER EDIT: ignore the request but see the comments below**

In case the favicon download fails due to anti-bot/anti-crawler techniques (most likely HTTP code 403 or even 444) fallback to Google icon cache which is almost sure to have the favicon cached.

While it may seem a bad idea to hardcode links like this, an increasingly amount of sites started using such techniques, especially aggressive Cloudflare-protected sites, causing Vaultwarden to fail in fetching favicons

P.S.: For this pull request to work, https://github.com/dani-garcia/vaultwarden/pull/6880 also needs to be accepted/merged