### PR TITLE
prevent managers from creating collections

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -500,6 +500,10 @@ async fn post_organization_collections(
     let data: FullCollectionData = data.into_inner();
     data.validate(&org_id, &conn).await?;
 
+    if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
+        err!("You don't have permission to create collections")
+    }
+
     let collection = Collection::new(org_id.clone(), data.name, data.external_id);
     collection.save(&conn).await?;
 
@@ -538,10 +542,6 @@ async fn post_organization_collections(
             &conn,
         )
         .await?;
-    }
-
-    if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
-        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, false, &conn).await?;
     }
 
     Ok(Json(collection.to_json_details(&headers.membership.user_uuid, None, &conn).await))

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -514,7 +514,8 @@ impl Membership {
             "familySponsorshipValidUntil": null,
             "familySponsorshipToDelete": null,
             "accessSecretsManager": false,
-            "limitCollectionCreation": self.atype < MembershipType::Manager, // If less then a manager return true, to limit collection creations
+            // limit collection creation to managers with access_all permission to prevent issues
+            "limitCollectionCreation": self.atype < MembershipType::Manager || !self.access_all,
             "limitCollectionDeletion": true,
             "limitItemDeletion": false,
             "allowAdminAccessToAllCollectionItems": true,


### PR DESCRIPTION
managers without the access_all flag should not be able to create collections. the manage all permission consists of three separate custom permission which would need to be properly implemented first for more delegate control.
<img width="232" height="192" alt="image" src="https://github.com/user-attachments/assets/213b1182-4c9d-4813-b138-9c5bf93a6a5c" />

this should fix #6871 for now by both preventing managers from creating collections as well as restricting the api call for managers to the ones that have access to all collections in order to prevent permission errors.