### PR TITLE
apply policies only to confirmed members

### DIFF
--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -269,7 +269,7 @@ impl OrgPolicy {
                 continue;
             }
 
-            if let Some(user) = Membership::find_by_user_and_org(user_uuid, &policy.org_uuid, conn).await {
+            if let Some(user) = Membership::find_confirmed_by_user_and_org(user_uuid, &policy.org_uuid, conn).await {
                 if user.atype < MembershipType::Admin {
                     return true;
                 }


### PR DESCRIPTION
I've noticed that my account was affected by the `DisableSend` policy from an organization I have not been confirmed yet.