### PR TITLE
Add Webauthn related origins flag to known flags.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1046,6 +1046,8 @@ fn validate_config(cfg: &ConfigItems) -> Result<(), Error> {
         "anon-addy-self-host-alias",
         "simple-login-self-host-alias",
         "mutual-tls",
+        // Webauthn Related Origins
+        "pm-30529-webauthn-related-origins",
     ];
     let configured_flags = parse_experimental_client_feature_flags(&cfg.experimental_client_feature_flags);
     let invalid_flags: Vec<_> = configured_flags.keys().filter(|flag| !KNOWN_FLAGS.contains(&flag.as_str())).collect();


### PR DESCRIPTION
support pm-30529-webauthn-related-origins flag