### PR TITLE
fix: add ForcePasswordReset to api key login

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -647,6 +647,7 @@ async fn _user_api_key_login(
         "KdfMemory": user.client_kdf_memory,
         "KdfParallelism": user.client_kdf_parallelism,
         "ResetMasterPassword": false, // TODO: according to official server seems something like: user.password_hash.is_empty(), but would need testing
+        "ForcePasswordReset": false,
         "scope": AuthMethod::UserApiKey.scope(),
         "UserDecryptionOptions": {
             "HasMasterPassword": has_master_password,


### PR DESCRIPTION
**DESCRIPTION** 

This should address #5641 and #5642 if maintainers choose to merge this.

On attempting to use this patch with the [Bitwarden SDK](https://crates.io/crates/bitwarden) this does allow the user api key login flow to work for the login request and response at least.

Noting that full API compatibility may not the be the ultimate goal of Vaultwarden it does allow the official SDK to use this flow at least (there are obviously other missing endpoints like `/api/organizations/<org_id>/secrets` that do not even allow the example snippet provided with the SDK README to complete successfully).

Context: I am trying to write a CLI application - but a few challenges have made me realise I probably shouldn't be trying to leverage the official SDK to do this as I'm realistically targeting Vaultwarden more than Bitwarden proper. 

The official SDK is also _very_ poorly documented.

The offical SDK considers this field mandatory

See https://docs.rs/bitwarden-core/2.0.0/src/bitwarden_core/auth/api/response/identity_success_response.rs.html#33-34