### PR TITLE
Support new desktop origin on CORS

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -153,9 +153,11 @@ impl Cors {
     fn get_allowed_origin(headers: &HeaderMap<'_>) -> Option<String> {
         let origin = Cors::get_header(headers, "Origin");
         let safari_extension_origin = "file://";
+        let desktop_custom_file_origin = "bw-desktop-file://bundle";
 
         if origin == CONFIG.domain_origin()
             || origin == safari_extension_origin
+            || origin == desktop_custom_file_origin
             || (CONFIG.sso_enabled() && origin == CONFIG.sso_authority())
         {
             Some(origin)


### PR DESCRIPTION
The desktop app is moving to a new custom file scheme in a couple of versions, following [electron's security guidance](https://www.electronjs.org/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols).

To ensure the app keeps working, the server needs to be properly configured to support CORS, here's [the upstream change](https://github.com/bitwarden/server/blob/4732d7fcd2910ead8427e514b307b8ed6cd38a4b/src/Core/Utilities/CoreHelpers.cs#L651).

The desktop app change is still not ready, but I want to make sure that we have this ready so that the app doesn't break.