### PR TITLE
Fix apikey login

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -633,6 +633,19 @@ async fn _user_api_key_login(
         Value::Null
     };
 
+    let account_keys = if user.private_key.is_some() {
+        json!({
+            "publicKeyEncryptionKeyPair": {
+                "wrappedPrivateKey": user.private_key,
+                "publicKey": user.public_key,
+                "Object": "publicKeyEncryptionKeyPair"
+            },
+            "Object": "privateKeys"
+        })
+    } else {
+        Value::Null
+    };
+
     // Note: No refresh_token is returned. The CLI just repeats the
     // client_credentials login flow when the existing token expires.
     let result = json!({
@@ -649,6 +662,7 @@ async fn _user_api_key_login(
         "ResetMasterPassword": false, // TODO: according to official server seems something like: user.password_hash.is_empty(), but would need testing
         "ForcePasswordReset": false,
         "scope": AuthMethod::UserApiKey.scope(),
+        "AccountKeys": account_keys,
         "UserDecryptionOptions": {
             "HasMasterPassword": has_master_password,
             "MasterPasswordUnlock": master_password_unlock,


### PR DESCRIPTION
The API Key login needs some extra JSON return key's, same as password login.

Fixes #6912
