### PR TITLE
Fix duplicate AuthRequestResponse notification on approving device

### DIFF
--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -515,15 +515,11 @@ impl WebSocketUsers {
         if *NOTIFICATIONS_DISABLED {
             return;
         }
-        let data = create_update(
-            vec![("Id".into(), auth_request_id.to_string().into()), ("UserId".into(), user_id.to_string().into())],
-            UpdateType::AuthRequestResponse,
-            Some(device.uuid.clone()),
-        );
-        if CONFIG.enable_websocket() {
-            self.send_update(user_id, &data).await;
-        }
-
+        // AuthRequestResponse should not be sent through the authenticated WebSocket hub,
+        // as that broadcasts to all user devices including the approving device, causing
+        // a duplicate notification. The anonymous hub already delivers the response to the
+        // requesting device. Only the push relay is needed here as a fallback for devices
+        // not connected via WebSocket.
         if CONFIG.push_enabled() {
             push_auth_response(user_id, auth_request_id, device, conn).await;
         }


### PR DESCRIPTION
## Summary

When approving a login-with-device request, `nt.send_auth_response()` broadcasts an `AuthRequestResponse` (type 16) through the **authenticated** WebSocket hub to all user devices — including the approving device itself. This causes a duplicate auth request notification on Android.

### Root cause

In `put_auth_request`, two notification calls are made after approval:

```rust
ant.send_auth_response(...) // anonymous hub → correct, reaches only Device A
nt.send_auth_response(...)  // authenticated hub + push relay → broadcasts to ALL devices
```

The authenticated WebSocket hub (`self.send_update(user_id, &data)`) sends to every connected device of the user, including Device B (the approving device), which should not receive `AuthRequestResponse` at all.

### How the official Bitwarden server handles this

Per the official server code (`HubHelpers.cs`), `AuthRequestResponse` (type 16) is sent **only** through `_anonymousHubContext` to `Group(AuthRequest.Id)`. It is **not** sent through the authenticated `_hubContext`. This is the key difference from `AuthRequest` (type 15), which uses `_hubContext.Clients.User()`.

### Fix

Remove the authenticated WebSocket broadcast from `send_auth_response()`, keeping only the push relay call as a fallback for devices not connected via WebSocket. The anonymous hub (`ant.send_auth_response`) already handles WebSocket delivery to the requesting device.

## Test plan

- [ ] On Device A (browser), choose "Log in with device"
- [ ] On Device B (Android), approve the login request
- [ ] Verify Device B does **not** show a duplicate notification after approving
- [ ] Verify Device A still receives the approval and completes login

Fixes #6788