### PR TITLE
Change SQLite backup to use VACUUM INTO query

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -403,6 +403,7 @@ pub fn backup_sqlite() -> Result<String, Error> {
         diesel::sql_query("VACUUM INTO ?")
             .bind::<diesel::sql_types::Text, _>(&backup_file)
             .execute(&mut conn)
+            .map(|_| ())
             .map_res("VACUUM INTO failed")?;
 
         Ok(backup_file)


### PR DESCRIPTION
https://github.com/dani-garcia/vaultwarden/pull/6279 introduced several great improvements, but replaced `VACUUM INTO` with `serialize_database_to_buffer()` which is less efficient and loads the whole DB into RAM. This may be contributing to an increase in OOM errors which I have noticed in small vaultwarden deployments with 256MB RAM.

This PR reverts the `serialize_database_to_buffer()` change back into a `VACUUM INTO` query while keeping the other improvements from that PR. I also used `.bind::<Text, _>(&backup_file)` instead of the previous `format!("VACUUM INTO '{}'", backup_file)` to prevent theoretical SQL injection (even though path is trusted), let me know if you prefer the `format!` approach and I can switch it