### PR TITLE
ci: add daily scheduled RustSec advisory scan

### DIFF
--- a/.github/workflows/cargo-deny-scheduled.yml
+++ b/.github/workflows/cargo-deny-scheduled.yml
@@ -1,0 +1,41 @@
+name: Scheduled Advisory Scan
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Daily at 11:17 UTC — offset from Trivy (11:08) to spread advisory DB load.
+    - cron: '17 11 * * *'
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cargo-deny-advisories:
+    name: cargo deny advisories
+    # Only run on the upstream repo, not forks — avoids hammering the RustSec DB.
+    if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Run only the advisories check so duplicate/license noise doesn't obscure
+      # newly published CVEs. The full `cargo deny check` runs in build.yml on
+      # every push/PR; this job exists solely to catch new advisories between pushes.
+      - name: Run cargo deny (advisories only)
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+        with:
+          command: check advisories


### PR DESCRIPTION
cargo deny check advisories runs daily at 11:17 UTC (offset from Trivy
at 11:08 to spread DB load). This catches new CVEs published against
Cargo dependencies between code pushes, matching the coverage Trivy
provides for container vulnerabilities.

Runs advisories-only so duplicate/license warnings don't obscure newly
published CVEs - the full cargo deny check already runs in build.yml on
every push/PR. Guarded to the upstream repo to avoid fork hammering the
RustSec DB. Supports workflow_dispatch for manual triggering.