### PR TITLE
Do not display unavailable 2FA options

### DIFF
--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -56,7 +56,7 @@ pub fn is_twofactor_provider_usable(provider_type: i32, provider_data: Option<&s
         x if x == TwoFactorType::YubiKey as i32 => {
             CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some()
         }
-        x if x == TwoFactorType::Webauthn as i32 => CONFIG.domain_set(),
+        x if x == TwoFactorType::Webauthn as i32 => CONFIG.is_webauthn_2fa_supported(),
         x if x == TwoFactorType::Remember as i32 => !CONFIG.disable_2fa_remember(),
         x if x == TwoFactorType::RecoveryCode as i32 => true,
         _ => false,

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -2,6 +2,7 @@ use chrono::{TimeDelta, Utc};
 use data_encoding::BASE32;
 use rocket::serde::json::Json;
 use rocket::Route;
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
@@ -14,7 +15,7 @@ use crate::{
     db::{
         models::{
             DeviceType, EventType, Membership, MembershipType, OrgPolicyType, Organization, OrganizationId, TwoFactor,
-            TwoFactorIncomplete, User, UserId,
+            TwoFactorIncomplete, TwoFactorType, User, UserId,
         },
         DbConn, DbPool,
     },
@@ -30,6 +31,37 @@ pub mod email;
 pub mod protected_actions;
 pub mod webauthn;
 pub mod yubikey;
+
+fn has_global_duo_credentials() -> bool {
+    CONFIG._enable_duo() && CONFIG.duo_host().is_some() && CONFIG.duo_ikey().is_some() && CONFIG.duo_skey().is_some()
+}
+
+pub fn is_twofactor_provider_usable(provider_type: i32, provider_data: Option<&str>) -> bool {
+    #[derive(Deserialize)]
+    struct DuoProviderData {
+        host: String,
+        ik: String,
+        sk: String,
+    }
+
+    match provider_type {
+        x if x == TwoFactorType::Authenticator as i32 => true,
+        x if x == TwoFactorType::Email as i32 => CONFIG._enable_email_2fa(),
+        x if x == TwoFactorType::Duo as i32 || x == TwoFactorType::OrganizationDuo as i32 => {
+            provider_data
+                .and_then(|raw| serde_json::from_str::<DuoProviderData>(raw).ok())
+                .is_some_and(|duo| !duo.host.is_empty() && !duo.ik.is_empty() && !duo.sk.is_empty())
+                || has_global_duo_credentials()
+        }
+        x if x == TwoFactorType::YubiKey as i32 => {
+            CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some()
+        }
+        x if x == TwoFactorType::Webauthn as i32 => CONFIG.domain_set(),
+        x if x == TwoFactorType::Remember as i32 => !CONFIG.disable_2fa_remember(),
+        x if x == TwoFactorType::RecoveryCode as i32 => true,
+        _ => false,
+    }
+}
 
 pub fn routes() -> Vec<Route> {
     let mut routes = routes![
@@ -53,7 +85,11 @@ pub fn routes() -> Vec<Route> {
 #[get("/two-factor")]
 async fn get_twofactor(headers: Headers, conn: DbConn) -> Json<Value> {
     let twofactors = TwoFactor::find_by_user(&headers.user.uuid, &conn).await;
-    let twofactors_json: Vec<Value> = twofactors.iter().map(TwoFactor::to_json_provider).collect();
+    let twofactors_json: Vec<Value> = twofactors
+        .iter()
+        .filter(|tf| is_twofactor_provider_usable(tf.atype, Some(&tf.data)))
+        .map(TwoFactor::to_json_provider)
+        .collect();
 
     Json(json!({
         "data": twofactors_json,

--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -1,5 +1,6 @@
 use chrono::{TimeDelta, Utc};
 use data_encoding::BASE32;
+use num_traits::FromPrimitive;
 use rocket::serde::json::Json;
 use rocket::Route;
 use serde::Deserialize;
@@ -36,7 +37,7 @@ fn has_global_duo_credentials() -> bool {
     CONFIG._enable_duo() && CONFIG.duo_host().is_some() && CONFIG.duo_ikey().is_some() && CONFIG.duo_skey().is_some()
 }
 
-pub fn is_twofactor_provider_usable(provider_type: i32, provider_data: Option<&str>) -> bool {
+pub fn is_twofactor_provider_usable(provider_type: TwoFactorType, provider_data: Option<&str>) -> bool {
     #[derive(Deserialize)]
     struct DuoProviderData {
         host: String,
@@ -45,21 +46,27 @@ pub fn is_twofactor_provider_usable(provider_type: i32, provider_data: Option<&s
     }
 
     match provider_type {
-        x if x == TwoFactorType::Authenticator as i32 => true,
-        x if x == TwoFactorType::Email as i32 => CONFIG._enable_email_2fa(),
-        x if x == TwoFactorType::Duo as i32 || x == TwoFactorType::OrganizationDuo as i32 => {
+        TwoFactorType::Authenticator => true,
+        TwoFactorType::Email => CONFIG._enable_email_2fa(),
+        TwoFactorType::Duo | TwoFactorType::OrganizationDuo => {
             provider_data
                 .and_then(|raw| serde_json::from_str::<DuoProviderData>(raw).ok())
                 .is_some_and(|duo| !duo.host.is_empty() && !duo.ik.is_empty() && !duo.sk.is_empty())
                 || has_global_duo_credentials()
         }
-        x if x == TwoFactorType::YubiKey as i32 => {
+        TwoFactorType::YubiKey => {
             CONFIG._enable_yubico() && CONFIG.yubico_client_id().is_some() && CONFIG.yubico_secret_key().is_some()
         }
-        x if x == TwoFactorType::Webauthn as i32 => CONFIG.is_webauthn_2fa_supported(),
-        x if x == TwoFactorType::Remember as i32 => !CONFIG.disable_2fa_remember(),
-        x if x == TwoFactorType::RecoveryCode as i32 => true,
-        _ => false,
+        TwoFactorType::Webauthn => CONFIG.is_webauthn_2fa_supported(),
+        TwoFactorType::Remember => !CONFIG.disable_2fa_remember(),
+        TwoFactorType::RecoveryCode => true,
+        TwoFactorType::U2f
+        | TwoFactorType::U2fRegisterChallenge
+        | TwoFactorType::U2fLoginChallenge
+        | TwoFactorType::EmailVerificationChallenge
+        | TwoFactorType::WebauthnRegisterChallenge
+        | TwoFactorType::WebauthnLoginChallenge
+        | TwoFactorType::ProtectedActions => false,
     }
 }
 
@@ -87,8 +94,10 @@ async fn get_twofactor(headers: Headers, conn: DbConn) -> Json<Value> {
     let twofactors = TwoFactor::find_by_user(&headers.user.uuid, &conn).await;
     let twofactors_json: Vec<Value> = twofactors
         .iter()
-        .filter(|tf| is_twofactor_provider_usable(tf.atype, Some(&tf.data)))
-        .map(TwoFactor::to_json_provider)
+        .filter_map(|tf| {
+            let provider_type = TwoFactorType::from_i32(tf.atype)?;
+            is_twofactor_provider_usable(provider_type, Some(&tf.data)).then(|| TwoFactor::to_json_provider(tf))
+        })
         .collect();
 
     Json(json!({

--- a/src/api/core/two_factor/webauthn.rs
+++ b/src/api/core/two_factor/webauthn.rs
@@ -108,8 +108,8 @@ impl WebauthnRegistration {
 
 #[post("/two-factor/get-webauthn", data = "<data>")]
 async fn get_webauthn(data: Json<PasswordOrOtpData>, headers: Headers, conn: DbConn) -> JsonResult {
-    if !CONFIG.domain_set() {
-        err!("`DOMAIN` environment variable is not set. Webauthn disabled")
+    if !CONFIG.is_webauthn_2fa_supported() {
+        err!("Configured `DOMAIN` is not compatible with Webauthn")
     }
 
     let data: PasswordOrOtpData = data.into_inner();

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -887,7 +887,7 @@ async fn _json_err_twofactor(
         match TwoFactorType::from_i32(*provider) {
             Some(TwoFactorType::Authenticator) => { /* Nothing to do for TOTP */ }
 
-            Some(TwoFactorType::Webauthn) if CONFIG.domain_set() => {
+            Some(TwoFactorType::Webauthn) if CONFIG.is_webauthn_2fa_supported() => {
                 let request = webauthn::generate_webauthn_login(user_id, conn).await?;
                 result["TwoFactorProviders2"][provider.to_string()] = request.0;
             }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -15,7 +15,8 @@ use crate::{
             accounts::{PreloginData, RegisterData, _prelogin, _register, kdf_upgrade},
             log_user_event,
             two_factor::{
-                authenticator, duo, duo_oidc, email, enforce_2fa_policy, is_twofactor_provider_usable, webauthn, yubikey,
+                authenticator, duo, duo_oidc, email, enforce_2fa_policy, is_twofactor_provider_usable, webauthn,
+                yubikey,
             },
         },
         master_password_policy,
@@ -743,8 +744,10 @@ async fn twofactor_auth(
 
     let twofactor_ids: Vec<_> = twofactors
         .iter()
-        .filter(|tf| tf.enabled && is_twofactor_provider_usable(tf.atype, Some(&tf.data)))
-        .map(|tf| tf.atype)
+        .filter_map(|tf| {
+            let provider_type = TwoFactorType::from_i32(tf.atype)?;
+            (tf.enabled && is_twofactor_provider_usable(provider_type, Some(&tf.data))).then_some(tf.atype)
+        })
         .collect();
     if twofactor_ids.is_empty() {
         err!("No enabled and usable two factor providers are available for this account")

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -14,7 +14,9 @@ use crate::{
         core::{
             accounts::{PreloginData, RegisterData, _prelogin, _register, kdf_upgrade},
             log_user_event,
-            two_factor::{authenticator, duo, duo_oidc, email, enforce_2fa_policy, webauthn, yubikey},
+            two_factor::{
+                authenticator, duo, duo_oidc, email, enforce_2fa_policy, is_twofactor_provider_usable, webauthn, yubikey,
+            },
         },
         master_password_policy,
         push::register_push_device,
@@ -739,8 +741,22 @@ async fn twofactor_auth(
 
     TwoFactorIncomplete::mark_incomplete(&user.uuid, &device.uuid, &device.name, device.atype, ip, conn).await?;
 
-    let twofactor_ids: Vec<_> = twofactors.iter().map(|tf| tf.atype).collect();
+    let twofactor_ids: Vec<_> = twofactors
+        .iter()
+        .filter(|tf| tf.enabled && is_twofactor_provider_usable(tf.atype, Some(&tf.data)))
+        .map(|tf| tf.atype)
+        .collect();
+    if twofactor_ids.is_empty() {
+        err!("No enabled and usable two factor providers are available for this account")
+    }
+
     let selected_id = data.two_factor_provider.unwrap_or(twofactor_ids[0]); // If we aren't given a two factor provider, assume the first one
+    if !twofactor_ids.contains(&selected_id) {
+        err_json!(
+            _json_err_twofactor(&twofactor_ids, &user.uuid, data, client_version, conn).await?,
+            "Invalid two factor provider"
+        )
+    }
 
     let twofactor_code = match data.two_factor_token {
         Some(ref code) => code,


### PR DESCRIPTION
- Prevent YubiKey option availability if Yubico credentials are not configured; 
- Prevent Duo option availability if there is no valid per-user data or fully configured global Duo keys; 
- Prevent WebAuthn if domain does not match one that generates challenge payload; 
- Prevent E-mail option if email 2FA is disabled by admin.