### PR TITLE
Disable deployments for release env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
   docker-build:
     name: Build Vaultwarden containers
     if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
-    environment: release
+    environment: 
+      name: release
+      deployment: false
     permissions:
       packages: write # Needed to upload packages and artifacts
       contents: read
@@ -249,7 +251,9 @@ jobs:
     name: Merge manifests
     runs-on: ubuntu-latest
     needs: docker-build
-    environment: release
+    environment: 
+      name: release
+      deployment: false
     permissions:
       packages: write # Needed to upload packages and artifacts
       attestations: write # Needed to generate an artifact attestation for a build


### PR DESCRIPTION
As according to the docs:
https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments

> This is useful when you want to use environments for:
> 
> Organizing secrets—group related secrets under an environment name without creating deployment records.
> Access control—restrict which branches can use certain secrets via environment branch policies, without deployment tracking.
> CI and testing jobs—reference an environment for its configuration without adding noise to the deployment history.