### PR TITLE
Add authType field to Send API responses

### DIFF
--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -131,6 +131,9 @@ impl Send {
             data["size"] = Value::String(size.to_string());
         }
 
+        // Determine authType based on Bitwarden's AuthType enum: Email=0, Password=1, None=2
+        let auth_type = if self.password_hash.is_some() { 1 } else { 2 };
+
         json!({
             "id": self.uuid,
             "accessId": BASE64URL_NOPAD.encode(Uuid::parse_str(&self.uuid).unwrap_or_default().as_bytes()),
@@ -145,6 +148,7 @@ impl Send {
             "maxAccessCount": self.max_access_count,
             "accessCount": self.access_count,
             "password": self.password_hash.as_deref().map(|h| BASE64URL_NOPAD.encode(h)),
+            "authType": auth_type,
             "disabled": self.disabled,
             "hideEmail": self.hide_email,
 


### PR DESCRIPTION
Fixes #6976

## Problem
All Sends were displaying as password-protected in the web vault regardless of their actual protection status.

## Root Cause
The web-vault changed how it determines Send protection status in bitwarden/clients@9f74178. It now checks `authType !== AuthType.None` instead of checking for the presence of the `password` field, but Vaultwarden wasn't returning `authType` in its API responses.

## Fix
Add `authType` to `Send.to_json()` using Bitwarden's `AuthType` enum:
- `0` = Email (future email OTP support)
- `1` = Password protected
- `2` = None (no authentication required)