### PR TITLE
Fix logout push identifiers and send logout before clearing devices

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -480,13 +480,14 @@ async fn deauth_user(user_id: UserId, _token: AdminToken, conn: DbConn, nt: Noti
 #[post("/users/<user_id>/disable", format = "application/json")]
 async fn disable_user(user_id: UserId, _token: AdminToken, conn: DbConn, nt: Notify<'_>) -> EmptyResult {
     let mut user = get_user_or_404(&user_id, &conn).await?;
-    Device::delete_all_by_user(&user.uuid, &conn).await?;
     user.reset_security_stamp(&conn).await?;
     user.enabled = false;
 
     let save_result = user.save(&conn).await;
 
     nt.send_logout(&user, None, &conn).await;
+
+    Device::delete_all_by_user(&user.uuid, &conn).await?;
 
     save_result
 }

--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -540,7 +540,7 @@ async fn post_password(data: Json<ChangePassData>, headers: Headers, conn: DbCon
     // Prevent logging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
-    nt.send_logout(&user, Some(headers.device.uuid.clone()), &conn).await;
+    nt.send_logout(&user, Some(&headers.device), &conn).await;
 
     save_result
 }
@@ -638,7 +638,7 @@ async fn post_kdf(data: Json<ChangeKdfData>, headers: Headers, conn: DbConn, nt:
     .await?;
     let save_result = user.save(&conn).await;
 
-    nt.send_logout(&user, Some(headers.device.uuid.clone()), &conn).await;
+    nt.send_logout(&user, Some(&headers.device), &conn).await;
 
     save_result
 }
@@ -911,7 +911,7 @@ async fn post_rotatekey(data: Json<KeyData>, headers: Headers, conn: DbConn, nt:
     // Prevent logging out the client where the user requested this endpoint from.
     // If you do logout the user it will causes issues at the client side.
     // Adding the device uuid will prevent this.
-    nt.send_logout(&user, Some(headers.device.uuid.clone()), &conn).await;
+    nt.send_logout(&user, Some(&headers.device), &conn).await;
 
     save_result
 }
@@ -923,11 +923,12 @@ async fn post_sstamp(data: Json<PasswordOrOtpData>, headers: Headers, conn: DbCo
 
     data.validate(&user, true, &conn).await?;
 
-    Device::delete_all_by_user(&user.uuid, &conn).await?;
     user.reset_security_stamp(&conn).await?;
     let save_result = user.save(&conn).await;
 
     nt.send_logout(&user, None, &conn).await;
+
+    Device::delete_all_by_user(&user.uuid, &conn).await?;
 
     save_result
 }

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -358,7 +358,7 @@ impl WebSocketUsers {
         }
     }
 
-    pub async fn send_logout(&self, user: &User, device: Option<&Device>, conn: &DbConn) {
+    pub async fn send_logout(&self, user: &User, acting_device: Option<&Device>, conn: &DbConn) {
         // Skip any processing if both WebSockets and Push are not active
         if *NOTIFICATIONS_DISABLED {
             return;

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -363,7 +363,7 @@ impl WebSocketUsers {
         if *NOTIFICATIONS_DISABLED {
             return;
         }
-        let acting_device_id = device.map(|d| d.uuid.clone());
+        let acting_device_id = acting_device.map(|d| d.uuid.clone());
         let data = create_update(
             vec![("UserId".into(), user.uuid.to_string().into()), ("Date".into(), serialize_date(user.updated_at))],
             UpdateType::LogOut,
@@ -375,7 +375,7 @@ impl WebSocketUsers {
         }
 
         if CONFIG.push_enabled() {
-            push_logout(user, device, conn).await;
+            push_logout(user, acting_device, conn).await;
         }
     }
 

--- a/src/api/notifications.rs
+++ b/src/api/notifications.rs
@@ -358,15 +358,16 @@ impl WebSocketUsers {
         }
     }
 
-    pub async fn send_logout(&self, user: &User, acting_device_id: Option<DeviceId>, conn: &DbConn) {
+    pub async fn send_logout(&self, user: &User, device: Option<&Device>, conn: &DbConn) {
         // Skip any processing if both WebSockets and Push are not active
         if *NOTIFICATIONS_DISABLED {
             return;
         }
+        let acting_device_id = device.map(|d| d.uuid.clone());
         let data = create_update(
             vec![("UserId".into(), user.uuid.to_string().into()), ("Date".into(), serialize_date(user.updated_at))],
             UpdateType::LogOut,
-            acting_device_id.clone(),
+            acting_device_id,
         );
 
         if CONFIG.enable_websocket() {
@@ -374,7 +375,7 @@ impl WebSocketUsers {
         }
 
         if CONFIG.push_enabled() {
-            push_logout(user, acting_device_id.clone(), conn).await;
+            push_logout(user, device, conn).await;
         }
     }
 

--- a/src/api/push.rs
+++ b/src/api/push.rs
@@ -193,8 +193,8 @@ pub async fn push_logout(user: &User, acting_device: Option<&Device>, conn: &DbC
         tokio::task::spawn(send_to_push_relay(json!({
             "userId": user.uuid,
             "organizationId": (),
-            "deviceId": device.and_then(|d| d.push_uuid.as_ref()),
-            "identifier": device.map(|d| &d.uuid),
+            "deviceId": acting_device.and_then(|d| d.push_uuid.as_ref()),
+            "identifier": acting_device.map(|d| &d.uuid),
             "type": UpdateType::LogOut as i32,
             "payload": {
                 "userId": user.uuid,

--- a/src/api/push.rs
+++ b/src/api/push.rs
@@ -188,7 +188,7 @@ pub async fn push_cipher_update(ut: UpdateType, cipher: &Cipher, device: &Device
     }
 }
 
-pub async fn push_logout(user: &User, device: Option<&Device>, conn: &DbConn) {
+pub async fn push_logout(user: &User, acting_device: Option<&Device>, conn: &DbConn) {
     if Device::check_user_has_push_device(&user.uuid, conn).await {
         tokio::task::spawn(send_to_push_relay(json!({
             "userId": user.uuid,

--- a/src/api/push.rs
+++ b/src/api/push.rs
@@ -13,7 +13,7 @@ use tokio::sync::RwLock;
 use crate::{
     api::{ApiResult, EmptyResult, UpdateType},
     db::{
-        models::{AuthRequestId, Cipher, Device, DeviceId, Folder, PushId, Send, User, UserId},
+        models::{AuthRequestId, Cipher, Device, Folder, PushId, Send, User, UserId},
         DbConn,
     },
     http_client::make_http_request,
@@ -188,15 +188,13 @@ pub async fn push_cipher_update(ut: UpdateType, cipher: &Cipher, device: &Device
     }
 }
 
-pub async fn push_logout(user: &User, acting_device_id: Option<DeviceId>, conn: &DbConn) {
-    let acting_device_id: Value = acting_device_id.map(|v| v.to_string().into()).unwrap_or_else(|| Value::Null);
-
+pub async fn push_logout(user: &User, device: Option<&Device>, conn: &DbConn) {
     if Device::check_user_has_push_device(&user.uuid, conn).await {
         tokio::task::spawn(send_to_push_relay(json!({
             "userId": user.uuid,
             "organizationId": (),
-            "deviceId": acting_device_id,
-            "identifier": acting_device_id,
+            "deviceId": device.and_then(|d| d.push_uuid.as_ref()),
+            "identifier": device.map(|d| &d.uuid),
             "type": UpdateType::LogOut as i32,
             "payload": {
                 "userId": user.uuid,


### PR DESCRIPTION
This fixes two issues in the logout push flow.

1. `push_logout()` currently sends the acting device UUID in both `deviceId` and `identifier`. That does not match the other push entry points, where `deviceId` is the push UUID and `identifier` is the device UUID.

2. `post_sstamp()` and `disable_user()` delete all devices **before** calling `send_logout()`. Since `check_user_has_push_device()` filter was introduced in #3578, those flows will always skip the push because the device lookup returns `false` after the delete.

This patch:

- passes the acting `Device` through `send_logout()` into `push_logout()`
- sends logout pushes with `deviceId = device.push_uuid` and `identifier = device.uuid`
- moves `Device::delete_all_by_user()` in `post_sstamp()` and `disable_user()` to after logout sending
- leaves `deauth_user()` unchanged, because it already sends the logout notification before deleting devices