### PR TITLE
Fixed Manager Assignment

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -521,7 +521,7 @@ async fn post_organization_collections(
     }
 
     if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
-        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, false, &conn).await?;
+        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, true, &conn).await?;
     }
 
     Ok(Json(collection.to_json_details(&headers.membership.user_uuid, None, &conn).await))


### PR DESCRIPTION
When creating a Collection, the manager cannot Edit the Permissions afterwards, this should not be intended. Simplest fix would be to give the Creator of a Collection permissions to Edit it.