### PR TITLE
Fix SSO_ONLY users unable to accept org invites (#7072)

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1102,6 +1102,11 @@ async fn send_invite(
                     if !CONFIG.mail_enabled() && !user.password_hash.is_empty() {
                         member_status = MembershipStatus::Accepted as i32;
                     }
+                    // SSO_ONLY users have no master password and cannot use the email invite
+                    // acceptance flow, so automatically accept them
+                    if CONFIG.sso_enabled() && CONFIG.sso_only() && user.password_hash.is_empty() {
+                        member_status = MembershipStatus::Accepted as i32;
+                    }
                     user
                 }
             }
@@ -1113,7 +1118,10 @@ async fn send_invite(
         new_member.status = member_status;
         new_member.save(&conn).await?;
 
-        if CONFIG.mail_enabled() {
+        // Only send the invite email if the member is still in the Invited state.
+        // SSO_ONLY users are auto-accepted above and should not receive an invite
+        // email with a link they cannot use.
+        if CONFIG.mail_enabled() && member_status == MembershipStatus::Invited as i32 {
             let org_name = match Organization::find_by_uuid(&org_id, &conn).await {
                 Some(org) => org.name,
                 None => err!("Error looking up organization"),
@@ -1249,12 +1257,18 @@ async fn _reinvite_member(
         err!("Invitations are not allowed.")
     }
 
-    let org_name = match Organization::find_by_uuid(org_id, conn).await {
-        Some(org) => org.name,
-        None => err!("Error looking up organization."),
-    };
-
-    if CONFIG.mail_enabled() {
+    if CONFIG.sso_enabled() && CONFIG.sso_only() && user.password_hash.is_empty() {
+        // SSO_ONLY users have no master password and cannot use the email invite
+        // acceptance flow, so automatically accept them
+        Invitation::take(&user.email, conn).await;
+        let mut member = member;
+        member.status = MembershipStatus::Accepted as i32;
+        member.save(conn).await?;
+    } else if CONFIG.mail_enabled() {
+        let org_name = match Organization::find_by_uuid(org_id, conn).await {
+            Some(org) => org.name,
+            None => err!("Error looking up organization."),
+        };
         mail::send_invite(&user, org_id.clone(), member.uuid, &org_name, Some(invited_by_email.to_string())).await?;
     } else if user.password_hash.is_empty() {
         let invitation = Invitation::new(&user.email);


### PR DESCRIPTION
## Summary
Fixes #7072

SSO_ONLY users (users who authenticate via SSO and have no master password) cannot accept organization invites because the invite acceptance flow requires a master password login.

## Changes
- In `send_invite`: Auto-set membership status to `Accepted` for existing SSO_ONLY users when they are invited to an organization
- In `_reinvite_member`: Prioritize SSO_ONLY auto-accept before attempting to send an email invite that the user cannot act on

## How it works
When `SSO_ENABLED=true` and `SSO_ONLY=true`, users who have an empty `password_hash` (indicating they authenticated only via SSO) are automatically moved to `Accepted` status when invited. The admin can then confirm them normally through the admin console.

## Testing
- Tested with SSO_ONLY=true, inviting an SSO-created user to an org
- User membership status correctly set to Accepted (status=1)
- Admin can confirm the user, user can access collections
