### PR TITLE
Return invalid_grant on expired refresh token (#7060)

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -131,7 +131,7 @@ async fn login(
     login_result
 }
 
-// Return Status::Unauthorized to trigger logout
+// Return an OAuth2-compliant invalid_grant error to trigger client logout on refresh failure
 async fn _refresh_login(data: ConnectData, conn: &DbConn, ip: &ClientIp) -> JsonResult {
     // Extract token
     let refresh_token = match data.refresh_token {
@@ -147,7 +147,20 @@ async fn _refresh_login(data: ConnectData, conn: &DbConn, ip: &ClientIp) -> Json
     // let members = Membership::find_confirmed_by_user(&user.uuid, conn).await;
     match auth::refresh_tokens(ip, &refresh_token, data.client_id, conn).await {
         Err(err) => {
-            err_code!(format!("Unable to refresh login credentials: {}", err.message()), Status::Unauthorized.code)
+            // Return an OAuth2-compliant `invalid_grant` error response so that
+            // Bitwarden clients recognize the expired/invalid refresh token and
+            // prompt the user to re-authenticate. See: #7060
+            let msg = format!("Unable to refresh login credentials: {}", err.message());
+            error!("{msg}");
+            let result = json!({
+                "error": "invalid_grant",
+                "error_description": msg,
+                "ErrorModel": {
+                    "Message": msg,
+                    "Object": "error"
+                }
+            });
+            return Err(("invalid_grant", result).into());
         }
         Ok((mut device, auth_tokens)) => {
             // Save to update `device.updated_at` to track usage and toggle new status


### PR DESCRIPTION
# Summary

Fixes #7060

When a client's `refresh_token` expires, the server returns a response that Bitwarden clients don't recognize as a session expiration, causing them to silently fail instead of prompting the user to re-authenticate.

# Root Cause

Bitwarden clients detect expired sessions by checking the token refresh response for:
- HTTP status `400 Bad Request`
- JSON body with `"error": "invalid_grant"`

([Reference: api.service.ts#L1799-L1810](https://github.com/bitwarden/clients/blob/69f9c7d30dd4e013101667ac7f79f0e68e6bd122/libs/common/src/services/api.service.ts#L1799-L1810))

```typescript
if (response.status === HttpStatusCode.BadRequest && responseJson?.error === "invalid_grant") {
    await this.logoutCallback("sessionExpired");
}
```

However, Vaultwarden was returning `401 Unauthorized` with a standard error body where `"error"` is an empty string — none of the client's checks matched, so the client never triggered re-authentication.

# Changes

**`src/api/identity.rs`** — `_refresh_login()`:

Changed the error response for failed refresh token exchanges to return an OAuth2-compliant `invalid_grant` error:

| | Before | After |
|---|---|---|
| HTTP Status | `401 Unauthorized` | `400 Bad Request` |
| `error` field | `""` (empty) | `"invalid_grant"` |
| `error_description` | `""` (empty) | Descriptive message |

This follows the same pattern already used for 2FA errors in the codebase (see `_json_err_twofactor`), and aligns with [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) which specifies `invalid_grant` for expired/revoked tokens.

# Testing

1. Log in on a Bitwarden client (desktop or browser extension)
2. Wait for the refresh token to expire (or force expiration)
3. Trigger a sync or vault edit on the client
4. **Before fix:** Client shows cryptic errors, never prompts re-login
5. **After fix:** Client detects `invalid_grant`, triggers `sessionExpired` logout callback, and prompts user to re-authenticate


