### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
   docker-build:
     name: Build Vaultwarden containers
     if: ${{ github.repository == 'dani-garcia/vaultwarden' }}
-    environment: 
+    environment: &environment
       name: release
       deployment: false
     permissions:
@@ -54,7 +54,8 @@ jobs:
     strategy:
       matrix:
         arch: ["amd64", "arm64", "arm/v7", "arm/v6"]
-        base_image: ["debian","alpine"]
+        base_image: &base-image
+          ["debian","alpine"]
 
     steps:
       - name: Initialize QEMU binfmt support
@@ -105,14 +106,16 @@ jobs:
           fi
 
       # Login to Docker Hub
-      - name: Login to Docker Hub
+      - &dockerhub-login
+        name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         if: ${{ vars.DOCKERHUB_REPO != '' }}
 
-      - name: Add registry for DockerHub
+      - &dockerhub-registry
+        name: Add registry for DockerHub
         if: ${{ vars.DOCKERHUB_REPO != '' }}
         env:
           DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
@@ -120,7 +123,8 @@ jobs:
           echo "CONTAINER_REGISTRIES=${DOCKERHUB_REPO}" | tee -a "${GITHUB_ENV}"
 
       # Login to GitHub Container Registry
-      - name: Login to GitHub Container Registry
+      - &gchr-login
+        name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -128,7 +132,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ vars.GHCR_REPO != '' }}
 
-      - name: Add registry for ghcr.io
+      - &ghcr-registry
+        name: Add registry for ghcr.io
         if: ${{ vars.GHCR_REPO != '' }}
         env:
           GHCR_REPO: ${{ vars.GHCR_REPO }}
@@ -136,7 +141,8 @@ jobs:
           echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${GHCR_REPO}" | tee -a "${GITHUB_ENV}"
 
       # Login to Quay.io
-      - name: Login to Quay.io
+      - &quay-login
+        name: Login to Quay.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: quay.io
@@ -144,7 +150,8 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
         if: ${{ vars.QUAY_REPO != '' }}
 
-      - name: Add registry for Quay.io
+      - &quay-registry
+        name: Add registry for Quay.io
         if: ${{ vars.QUAY_REPO != '' }}
         env:
           QUAY_REPO: ${{ vars.QUAY_REPO }}
@@ -187,7 +194,6 @@ jobs:
         id: bake_vw
         uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0
         env:
-          BASE_TAGS: "${{ steps.determine-version.outputs.BASE_TAGS }}"
           SOURCE_COMMIT: "${{ env.SOURCE_COMMIT }}"
           SOURCE_VERSION: "${{ env.SOURCE_VERSION }}"
           SOURCE_REPOSITORY_URL: "${{ env.SOURCE_REPOSITORY_URL }}"
@@ -251,16 +257,14 @@ jobs:
     name: Merge manifests
     runs-on: ubuntu-latest
     needs: docker-build
-    environment: 
-      name: release
-      deployment: false
+    environment: *environment
     permissions:
       packages: write # Needed to upload packages and artifacts
       attestations: write # Needed to generate an artifact attestation for a build
       id-token: write # Needed to mint the OIDC token necessary to request a Sigstore signing certificate
     strategy:
       matrix:
-        base_image: ["debian","alpine"]
+        base_image: *base-image
 
     steps:
       - name: Download digests
@@ -270,52 +274,17 @@ jobs:
           pattern: digests-*-${{ matrix.base_image }}
           merge-multiple: true
 
-      # Login to Docker Hub
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: ${{ vars.DOCKERHUB_REPO != '' }}
+      - *dockerhub-login
 
-      - name: Add registry for DockerHub
-        if: ${{ vars.DOCKERHUB_REPO != '' }}
-        env:
-          DOCKERHUB_REPO: ${{ vars.DOCKERHUB_REPO }}
-        run: |
-          echo "CONTAINER_REGISTRIES=${DOCKERHUB_REPO}" | tee -a "${GITHUB_ENV}"
+      - *dockerhub-registry
 
-      # Login to GitHub Container Registry
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ vars.GHCR_REPO != '' }}
+      - *gchr-login
 
-      - name: Add registry for ghcr.io
-        if: ${{ vars.GHCR_REPO != '' }}
-        env:
-          GHCR_REPO: ${{ vars.GHCR_REPO }}
-        run: |
-          echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${GHCR_REPO}" | tee -a "${GITHUB_ENV}"
+      - *ghcr-registry
 
-      # Login to Quay.io
-      - name: Login to Quay.io
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-        if: ${{ vars.QUAY_REPO != '' }}
+      - *quay-login
 
-      - name: Add registry for Quay.io
-        if: ${{ vars.QUAY_REPO != '' }}
-        env:
-          QUAY_REPO: ${{ vars.QUAY_REPO }}
-        run: |
-          echo "CONTAINER_REGISTRIES=${CONTAINER_REGISTRIES:+${CONTAINER_REGISTRIES},}${QUAY_REPO}" | tee -a "${GITHUB_ENV}"
+      - *quay-registry
 
       # Determine Base Tags
       - name: Determine Base Tags


### PR DESCRIPTION
- use YAML anchors to remove duplicated steps (https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases)
- cleanup unused `BASE_TAGS` from 1st job
- remove leftover whitespace from a previous commit

The empty lines between the aliases in the 2nd job could be removed if needed. (not sure if I like how the empty space looks)
Also open to more suggestions for furher anchor usage in the workflow.