### PR TITLE
Fix invalid refresh token response

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -2,7 +2,6 @@ use chrono::Utc;
 use num_traits::FromPrimitive;
 use rocket::{
     form::{Form, FromForm},
-    http::Status,
     response::Redirect,
     serde::json::Json,
     Route,
@@ -131,12 +130,14 @@ async fn login(
     login_result
 }
 
-// Return Status::Unauthorized to trigger logout
 async fn _refresh_login(data: ConnectData, conn: &DbConn, ip: &ClientIp) -> JsonResult {
-    // Extract token
-    let refresh_token = match data.refresh_token {
-        Some(token) => token,
-        None => err_code!("Missing refresh_token", Status::Unauthorized.code),
+    // When a refresh token is invalid or missing we need to respond with an HTTP BadRequest (400)
+    // It also needs to return a json which holds at least a key `error` with the value `invalid_grant`
+    // See the link below for details
+    // https://github.com/bitwarden/clients/blob/2ee158e720a5e7dbe3641caf80b569e97a1dd91b/libs/common/src/services/api.service.ts#L1786-L1797
+
+    let Some(refresh_token) = data.refresh_token else {
+        err_json!(json!({"error": "invalid_grant"}), "Missing refresh_token")
     };
 
     // ---
@@ -147,7 +148,10 @@ async fn _refresh_login(data: ConnectData, conn: &DbConn, ip: &ClientIp) -> Json
     // let members = Membership::find_confirmed_by_user(&user.uuid, conn).await;
     match auth::refresh_tokens(ip, &refresh_token, data.client_id, conn).await {
         Err(err) => {
-            err_code!(format!("Unable to refresh login credentials: {}", err.message()), Status::Unauthorized.code)
+            err_json!(
+                json!({"error": "invalid_grant"}),
+                format!("Unable to refresh login credentials: {}", err.message())
+            )
         }
         Ok((mut device, auth_tokens)) => {
             // Save to update `device.updated_at` to track usage and toggle new status


### PR DESCRIPTION
If the refresh token is invalid or expired we need to return a specific JSON and HTTP Status, else the clients will not logout.

Fixes #7060
Closes #7080