### PR TITLE
Bump rustls-webpki 0.103.11 to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,7 +4485,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -4533,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
This PR updates `rustls-webpki` from 0.103.11 to 0.103.12 in
`Cargo.lock` to address two advisories published on 2026-04-15:

- **RUSTSEC-2026-0098** / GHSA-965h-392x-2mh5: URI name constraints
  were silently accepted instead of rejected.
- **RUSTSEC-2026-0099** / GHSA-xgp8-3hg3-c2mh: permitted-subtree
  DNS name constraints were accepted for certificates asserting a
  wildcard name.

Both bugs are reachable only after signature verification and require
misissuance to exploit. Defense-in-depth fix.

The change was produced with `cargo update -p rustls-webpki@0.103.11`
and only `Cargo.lock` is modified. No other dependencies move.

### Note on the second `rustls-webpki` copy

`cargo audit` also flags a second copy of `rustls-webpki` at 0.101.7,
pulled transitively via `rocket 0.5.1` -> `rustls 0.21.x`. That copy
is **not** addressed here; resolving it requires a Rocket release
against a newer rustls tree, which is outside the scope of this PR.

### References

- https://rustsec.org/advisories/RUSTSEC-2026-0098.html
- https://rustsec.org/advisories/RUSTSEC-2026-0099.html
- https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5
- https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh