### PR TITLE
Update secure context requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A nearly complete implementation of the Bitwarden Client API is provided, includ
 
 > [!IMPORTANT]
 > The web-vault requires the use a secure context for the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API).
-> That means it will only work via `http://localhost:8000` (using the port from the example below) or if you [enable HTTPS](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS).
+> That means it will only work via [HTTPS](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS).
 
 The recommended way to install and use Vaultwarden is via our container images which are published to [ghcr.io](https://github.com/dani-garcia/vaultwarden/pkgs/container/vaultwarden), [docker.io](https://hub.docker.com/r/vaultwarden/server) and [quay.io](https://quay.io/repository/vaultwarden/server).
 See [which container image to use](https://github.com/dani-garcia/vaultwarden/wiki/Which-container-image-to-use) for an explanation of the provided tags.


### PR DESCRIPTION
It is my understanding that most browsers require https to use web crypto apis and these apis wont function over localhost at all. With this in mind, i don't see the need to keep this port 8000 blurb here.