### PR TITLE
Dummy identifier need to pass for a guid

### DIFF
--- a/src/sso.rs
+++ b/src/sso.rs
@@ -17,7 +17,7 @@ use crate::{
     CONFIG,
 };
 
-pub static FAKE_SSO_IDENTIFIER: &str = "vaultwarden-dummy-oidc-identifier";
+pub static FAKE_SSO_IDENTIFIER: &str = "00000000-01DC-01DC-01DC-000000000000";
 
 static SSO_JWT_ISSUER: LazyLock<String> = LazyLock::new(|| format!("{}|sso", CONFIG.domain_origin()));
 


### PR DESCRIPTION
Since client version `2026-3.1` the `organizationId` need to pass the `isId` check [cf](https://github.com/bitwarden/clients/blob/web-v2026.3.1/apps/web/src/app/auth/organization-invite/accept-organization.component.ts#L137)
Which mean passing `guidRegex = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i`