### PR TITLE
Hide email field on login page when SSO_ONLY is enabled

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -89,6 +89,16 @@ app-root ng-component > form > div:nth-child(1) > div:nth-child(3) > div:nth-chi
 }
 {{/if}}
 
+/* When SSO is the only login option, also hide the email input field and the
+   `Remember email` checkbox: the email is not required to start the SSO flow
+   in vaultwarden (single-tenant, FAKE_SSO_IDENTIFIER is used server-side). */
+{{#if sso_only}}
+.vw-email-form-field,
+.vw-remember-email {
+  @extend %vw-hide;
+}
+{{/if}}
+
 /* Hide Two-Factor menu in Organization settings */
 bit-nav-item[route="settings/two-factor"],
 a[href$="/settings/two-factor"] {


### PR DESCRIPTION
Two new SCSS rules in `src/static/templates/scss/vaultwarden.scss.hbs` that hide `.vw-email-form-field` and `.vw-remember-email` when `sso_only=true`.

## Why
When `SSO_ENABLED=true && SSO_ONLY=true` the email entered on the login page is ignored by the backend (single-tenant SSO uses `FAKE_SSO_IDENTIFIER`), but the page still asks for it and forces the user to type something. Hiding the input simplifies the UX to a single "Continue with SSO" button.

## How
Following the existing pattern used for `.vw-or-text` / `.vw-other-login` (already conditional on `sso_only`), this PR adds an analogous block for the email form-field and the Remember-email checkbox.

## Depends on
The classes `.vw-email-form-field` and `.vw-remember-email` are added by a companion patch in vw_web_builds: [view PR](https://github.com/vaultwarden/vw_web_builds/pull/24). Without that patch the new rules simply do not match anything.