### PR TITLE
Serve Apple app site association file

### DIFF
--- a/src/api/web.rs
+++ b/src/api/web.rs
@@ -23,7 +23,15 @@ pub fn routes() -> Vec<Route> {
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log
     let mut routes = routes![attachments, alive, alive_head, static_files];
     if CONFIG.web_vault_enabled() {
-        routes.append(&mut routes![web_index, web_index_direct, web_index_head, app_id, web_files, vaultwarden_css]);
+        routes.append(&mut routes![
+            web_index,
+            web_index_direct,
+            web_index_head,
+            app_id,
+            apple_app_site_association,
+            web_files,
+            vaultwarden_css
+        ]);
     }
 
     #[cfg(debug_assertions)]
@@ -154,6 +162,24 @@ fn app_id() -> Cached<(ContentType, Json<Value>)> {
                     "ios:bundle-id:com.8bit.bitwarden",
                     "android:apk-key-hash:dUGFzUzf3lmHSLBDBIv+WaFyZMI" ]
                 }]
+            })),
+        ),
+        true,
+    )
+}
+
+#[get("/.well-known/apple-app-site-association")]
+fn apple_app_site_association() -> Cached<(ContentType, Json<Value>)> {
+    Cached::long(
+        (
+            ContentType::JSON,
+            Json(json!({
+                "webcredentials": {
+                    "apps": [
+                        "LTZ2PFU5D6.com.8bit.bitwarden",
+                        "LTZ2PFU5D6.com.8bit.bitwarden.beta"
+                    ]
+                }
             })),
         ),
         true,


### PR DESCRIPTION
## Summary

Serve `/.well-known/apple-app-site-association` from vaultwarden.

Right now the request falls through to the web vault catch-all route:

```rust
#[get("/<p..>", rank = 10)]
```

That route takes a `PathBuf`, and Rocket rejects `.well-known` before the static file lookup runs. The result is a `422 Unprocessable Entity` instead of an AASA response.

## Changes

- Add an explicit `GET /.well-known/apple-app-site-association` route before the catch-all web vault route.
- Return JSON with `Content-Type: application/json`.
- Use the current Bitwarden iOS app identifiers:
  - `LTZ2PFU5D6.com.8bit.bitwarden`
  - `LTZ2PFU5D6.com.8bit.bitwarden.beta`

## Notes

I'm keeping this scoped to the server-side endpoint. This fixes the `422` response for the AASA URL, but it does not claim to fully solve every iOS passkey/auth-loop case by itself.

## Verification

I checked the route behavior with a minimal Rocket reproduction using the same catch-all route shape.

Before adding an explicit route:

```text
GET /.well-known/apple-app-site-association
PathBuf guard forwards with BadStart('.')
status: 422 Unprocessable Entity
```

After adding the explicit route:

```text
GET /.well-known/apple-app-site-association
status: 200 OK
content-type: application/json
```

I also ran:

```text
cargo fmt --all -- --check
git diff --check
```

Finally, I ran the repository CI on my fork for commit `399742b`; all checks passed:

- Build and Test / msrv
- Build and Test / rust-toolchain
- Code Spell Checking
- Hadolint
- Check templates
- zizmor

Refs #7186
