### PR TITLE
Update docker cli example to match docker compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can replace `docker` with `podman` if you prefer to use podman.
 docker pull vaultwarden/server:latest
 docker run --detach --name vaultwarden \
   --env DOMAIN="https://vw.domain.tld" \
-  --volume /vw-data/:/data/ \
+  --volume ./vw-data/:/data/ \
   --restart unless-stopped \
   --publish 127.0.0.1:8000:80 \
   vaultwarden/server:latest


### PR DESCRIPTION
Little PR

Adding a '.' to the docker cli example in README.md make it match with the docker-compose example right below it.  
It may also help people that simply copy-paste the command for tests purposes to not try to write to a directory at the root of their FS