### PR TITLE
fix email 2fa for bw cli

### DIFF
--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -25,7 +25,7 @@ pub fn routes() -> Vec<Route> {
 #[serde(rename_all = "camelCase")]
 struct SendEmailLoginData {
     #[serde(alias = "DeviceIdentifier")]
-    device_identifier: DeviceId,
+    device_identifier: Option<DeviceId>,
     #[serde(alias = "Email")]
     email: Option<String>,
     #[serde(alias = "MasterPasswordHash")]
@@ -91,8 +91,11 @@ async fn send_email_login(data: Json<SendEmailLoginData>, client_headers: Client
 
         user
     } else {
+        let Some(device_identifier) = &data.device_identifier else {
+            err!("No device identifier has been submitted.")
+        };
         // SSO login only sends device id, so we get the user by the most recently used device
-        let Some(user) = User::find_by_device_for_email2fa(&data.device_identifier, &conn).await else {
+        let Some(user) = User::find_by_device_for_email2fa(device_identifier, &conn).await else {
             err!("Username or password is incorrect. Try again.")
         };
 


### PR DESCRIPTION
fixes #7212 by making the device identifier optional.

Note that this means that you can't login using sso if you have enabled email as 2fa because the cli apparently sends neither an email address nor a device id as far as I've tested it...