### PR TITLE
Fix migration for MariaDB 12.2.2

### DIFF
--- a/migrations/mysql/2024-03-13-170000_sso_users_cascade/up.sql
+++ b/migrations/mysql/2024-03-13-170000_sso_users_cascade/up.sql
@@ -1,15 +1,31 @@
--- Dynamically create DROP FOREIGN KEY
--- Some versions of MySQL or MariaDB might fail if the key doesn't exists
--- This checks if the key exists, and if so, will drop it.
-SET @drop_sso_fk = IF((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-    CONSTRAINT_SCHEMA = DATABASE() AND
-    TABLE_NAME = 'sso_users' AND
-    CONSTRAINT_NAME = 'sso_users_ibfk_1' AND
-    CONSTRAINT_TYPE = 'FOREIGN KEY') = true,
-    'ALTER TABLE sso_users DROP FOREIGN KEY sso_users_ibfk_1',
-    'SELECT 1');
-PREPARE stmt FROM @drop_sso_fk;
-EXECUTE stmt;
-DEALLOCATE PREPARE stmt;
+SELECT if (
+    EXISTS(
+        SELECT CONSTRAINT_NAME FROM information_schema.table_constraints
+            WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'sso_users'
+                AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+                AND CONSTRAINT_NAME = 'sso_users_ibfk_1'
+    )
+    ,'ALTER TABLE sso_users DROP FOREIGN KEY `sso_users_ibfk_1`'
+    ,'SELECT "info: FK sso_users_ibfk_1 does not exist."'
+) INTO @drop_stmt;
+PREPARE drop_stmt FROM @drop_stmt;
+EXECUTE drop_stmt;
+
+SELECT if (
+    EXISTS(
+        SELECT CONSTRAINT_NAME FROM information_schema.table_constraints
+            WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'sso_users'
+                AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+                AND CONSTRAINT_NAME = '1'
+    )
+    ,'ALTER TABLE sso_users DROP FOREIGN KEY `1`'
+    ,'SELECT "info: FK sso_users 1 does not exist."'
+) INTO @drop_stmt;
+PREPARE drop_stmt FROM @drop_stmt;
+EXECUTE drop_stmt;
+
+DEALLOCATE PREPARE drop_stmt;
 
 ALTER TABLE sso_users ADD FOREIGN KEY(user_uuid) REFERENCES users(uuid) ON UPDATE CASCADE ON DELETE CASCADE;

--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -58,7 +58,7 @@ services:
   Mariadb:
     profiles: ["playwright"]
     container_name: playwright_mariadb
-    image: mariadb:11.2.4
+    image: mariadb:12.2.2
     env_file: test.env
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]

--- a/playwright/docker-compose.yml
+++ b/playwright/docker-compose.yml
@@ -61,7 +61,7 @@ services:
   Mariadb:
     profiles: ["playwright"]
     container_name: playwright_mariadb
-    image: mariadb:11.2.4
+    image: mariadb:12.2.2
     env_file: test.env
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]


### PR DESCRIPTION
I had missed the Mariadb fix so encountered the error with latest `mariadb` version.
It appears they changed the naming convention for foreign key :(.

But with the current fix it ends up with a double definition:

```sql
> show create table sso_users
CREATE TABLE `sso_users` (
  `user_uuid` char(36) NOT NULL,
  `identifier` varchar(768) NOT NULL,
  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
  PRIMARY KEY (`user_uuid`),
  UNIQUE KEY `identifier` (`identifier`),
  CONSTRAINT `1` FOREIGN KEY (`user_uuid`) REFERENCES `users` (`uuid`),
  CONSTRAINT `2` FOREIGN KEY (`user_uuid`) REFERENCES `users` (`uuid`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
```

Edit: Wonder if it would make sense to add a new migration to cleanup and add it as a named constraint ?