### PR TITLE
Add SSO_SIGNUPS_ALLOWED

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -494,6 +494,9 @@
 ## Prevent users from logging in directly without going through SSO
 # SSO_ONLY=false
 
+## Allow SSO flow to create account. You probably want to disable it when using a public provider.
+# SSO_SIGNUPS_ALLOWED=true
+
 ## On SSO Signup if a user with a matching email already exists make the association
 # SSO_SIGNUPS_MATCH_EMAIL=true
 

--- a/.env.template
+++ b/.env.template
@@ -518,6 +518,9 @@
 ## Prevent users from logging in directly without going through SSO
 # SSO_ONLY=false
 
+## Allow SSO flow to create account. You probably want to disable it when using a public provider.
+# SSO_SIGNUPS_ALLOWED=true
+
 ## On SSO Signup if a user with a matching email already exists make the association
 # SSO_SIGNUPS_MATCH_EMAIL=true
 

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -285,7 +285,7 @@ async fn sso_login(
     // Will trigger 2FA flow if needed
     let (user, mut device, twofactor_token, sso_user) = match user_with_sso {
         None => {
-            if !CONFIG.sso_signups_allowed() {
+            if !CONFIG.is_sso_signup_allowed(&user_infos.email) {
                 if CONFIG.signups_domains_whitelist().is_empty() {
                     err!(
                         "Signups are disabled. You will need an invitation",
@@ -293,14 +293,13 @@ async fn sso_login(
                             event: EventType::UserFailedLogIn
                         }
                     );
-                } else if !CONFIG.is_email_domain_allowed(&user_infos.email) {
-                    err!(
-                        "Email domain not allowed",
-                        ErrorEvent {
-                            event: EventType::UserFailedLogIn
-                        }
-                    );
                 }
+                err!(
+                    "Email domain not allowed",
+                    ErrorEvent {
+                        event: EventType::UserFailedLogIn
+                    }
+                );
             }
 
             match user_infos.email_verified {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -220,6 +220,24 @@ async fn sso_login(
                     }
                 )
             }
+            Some((user, None))
+                if user.private_key.is_none()
+                    && !CONFIG.sso_signups_allowed()
+                    && !CONFIG.is_email_domain_allowed(&user.email)
+                    && !CONFIG.mail_enabled()
+                    && Invitation::find_by_mail(&user.email, conn).await.is_none() =>
+            {
+                error!(
+                    "Login failure ({}), no invitation with email ({}) was found",
+                    user_infos.identifier, user.email
+                );
+                err_silent!(
+                    "Missing invitation",
+                    ErrorEvent {
+                        event: EventType::UserFailedLogIn
+                    }
+                )
+            }
             Some((user, None)) if user.private_key.is_some() && !CONFIG.sso_signups_match_email() => {
                 error!(
                     "Login failure ({}), existing non SSO user ({}) with same email ({}) and association is disabled",
@@ -267,13 +285,22 @@ async fn sso_login(
     // Will trigger 2FA flow if needed
     let (user, mut device, twofactor_token, sso_user) = match user_with_sso {
         None => {
-            if !CONFIG.is_email_domain_allowed(&user_infos.email) {
-                err!(
-                    "Email domain not allowed",
-                    ErrorEvent {
-                        event: EventType::UserFailedLogIn
-                    }
-                );
+            if !CONFIG.sso_signups_allowed() {
+                if CONFIG.signups_domains_whitelist().is_empty() {
+                    err!(
+                        "Signups are disabled. You will need an invitation",
+                        ErrorEvent {
+                            event: EventType::UserFailedLogIn
+                        }
+                    );
+                } else if !CONFIG.is_email_domain_allowed(&user_infos.email) {
+                    err!(
+                        "Email domain not allowed",
+                        ErrorEvent {
+                            event: EventType::UserFailedLogIn
+                        }
+                    );
+                }
             }
 
             match user_infos.email_verified {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -299,7 +299,7 @@ async fn sso_login(
     // Will trigger 2FA flow if needed
     let (user, mut device, twofactor_token, sso_user) = match user_with_sso {
         None => {
-            if !CONFIG.sso_signups_allowed() {
+            if !CONFIG.is_sso_signup_allowed(&user_infos.email) {
                 if CONFIG.signups_domains_whitelist().is_empty() {
                     err!(
                         "Signups are disabled. You will need an invitation",
@@ -307,14 +307,13 @@ async fn sso_login(
                             event: EventType::UserFailedLogIn
                         }
                     );
-                } else if !CONFIG.is_email_domain_allowed(&user_infos.email) {
-                    err!(
-                        "Email domain not allowed",
-                        ErrorEvent {
-                            event: EventType::UserFailedLogIn
-                        }
-                    );
                 }
+                err!(
+                    "Email domain not allowed",
+                    ErrorEvent {
+                        event: EventType::UserFailedLogIn
+                    }
+                );
             }
 
             match user_infos.email_verified {

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -234,6 +234,24 @@ async fn sso_login(
                     }
                 )
             }
+            Some((user, None))
+                if user.private_key.is_none()
+                    && !CONFIG.sso_signups_allowed()
+                    && !CONFIG.is_email_domain_allowed(&user.email)
+                    && !CONFIG.mail_enabled()
+                    && Invitation::find_by_mail(&user.email, conn).await.is_none() =>
+            {
+                error!(
+                    "Login failure ({}), no invitation with email ({}) was found",
+                    user_infos.identifier, user.email
+                );
+                err_silent!(
+                    "Missing invitation",
+                    ErrorEvent {
+                        event: EventType::UserFailedLogIn
+                    }
+                )
+            }
             Some((user, None)) if user.private_key.is_some() && !CONFIG.sso_signups_match_email() => {
                 error!(
                     "Login failure ({}), existing non SSO user ({}) with same email ({}) and association is disabled",
@@ -281,13 +299,22 @@ async fn sso_login(
     // Will trigger 2FA flow if needed
     let (user, mut device, twofactor_token, sso_user) = match user_with_sso {
         None => {
-            if !CONFIG.is_email_domain_allowed(&user_infos.email) {
-                err!(
-                    "Email domain not allowed",
-                    ErrorEvent {
-                        event: EventType::UserFailedLogIn
-                    }
-                );
+            if !CONFIG.sso_signups_allowed() {
+                if CONFIG.signups_domains_whitelist().is_empty() {
+                    err!(
+                        "Signups are disabled. You will need an invitation",
+                        ErrorEvent {
+                            event: EventType::UserFailedLogIn
+                        }
+                    );
+                } else if !CONFIG.is_email_domain_allowed(&user_infos.email) {
+                    err!(
+                        "Email domain not allowed",
+                        ErrorEvent {
+                            event: EventType::UserFailedLogIn
+                        }
+                    );
+                }
             }
 
             match user_infos.email_verified {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1517,6 +1517,17 @@ impl Config {
         }
     }
 
+    /// Tests whether SSO signup is allowed for an email address, taking into
+    /// account the sso_signups_allowed and signups_domains_whitelist settings.
+    pub fn is_sso_signup_allowed(&self, email: &str) -> bool {
+        if self.signups_domains_whitelist().is_empty() {
+            self.sso_signups_allowed()
+        } else {
+            // The whitelist setting overrides the signups_allowed setting.
+            self.is_email_domain_allowed(email)
+        }
+    }
+
     // The registration link should be hidden if
     //  - Signup is not allowed and email whitelist is empty unless mail is disabled and invitations are allowed
     //  - The SSO is activated and password login is disabled.

--- a/src/config.rs
+++ b/src/config.rs
@@ -801,6 +801,8 @@ make_config! {
         sso_enabled:                    bool,   true,   def,    false;
         /// Only SSO login |> Disable Email+Master Password login
         sso_only:                       bool,   true,   def,    false;
+        /// Allow SSO flow to create account |> You probably want to disable it when using a public provider
+        sso_signups_allowed:            bool,   true,   def,    true;
         /// Allow email association |> Associate existing non-SSO user based on email
         sso_signups_match_email:        bool,   true,   def,    true;
         /// Allow unknown email verification status |> Allowing this with `SSO_SIGNUPS_MATCH_EMAIL=true` open potential account takeover.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1546,6 +1546,17 @@ impl Config {
         }
     }
 
+    /// Tests whether SSO signup is allowed for an email address, taking into
+    /// account the sso_signups_allowed and signups_domains_whitelist settings.
+    pub fn is_sso_signup_allowed(&self, email: &str) -> bool {
+        if self.signups_domains_whitelist().is_empty() {
+            self.sso_signups_allowed()
+        } else {
+            // The whitelist setting overrides the signups_allowed setting.
+            self.is_email_domain_allowed(email)
+        }
+    }
+
     // The registration link should be hidden if
     //  - Signup is not allowed and email whitelist is empty unless mail is disabled and invitations are allowed
     //  - The SSO is activated and password login is disabled.

--- a/src/config.rs
+++ b/src/config.rs
@@ -817,6 +817,8 @@ make_config! {
         sso_enabled:                    bool,   true,   def,    false;
         /// Only SSO login |> Disable Email+Master Password login
         sso_only:                       bool,   true,   def,    false;
+        /// Allow SSO flow to create account |> You probably want to disable it when using a public provider
+        sso_signups_allowed:            bool,   true,   def,    true;
         /// Allow email association |> Associate existing non-SSO user based on email
         sso_signups_match_email:        bool,   true,   def,    true;
         /// Allow unknown email verification status |> Allowing this with `SSO_SIGNUPS_MATCH_EMAIL=true` open potential account takeover.


### PR DESCRIPTION
Add configuration to disable SSO signups, useful when using a public provider.

Discussed in https://github.com/dani-garcia/vaultwarden/issues/7050

There is a bit of an issue with Organization invitation, if the invitation is deleted then the stub account will still be present and there is no way to know it when processing the login.

Could reuse the `Invitation` logic used when email are disabled but didn't want to make more change without discussion.