### PR TITLE
fix: Correct invalid comment syntax in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
-// Ignore everything
+# Ignore everything
 *
 
-// Allow what is needed
+# Allow what is needed
 !.git
 !docker/healthcheck.sh
 !docker/start.sh


### PR DESCRIPTION
Docker only recognizes `#` as a valid comment indicator in .dockerignore files.  Using `//` causes the lines to be incorrectly parsed as glob patterns rather than comments.  While this may not cause fatal errors if no matching files exist, it is syntactically invalid and could lead to unexpected behavior. Corrected the syntax to use `#`.