### PR TITLE
fix(sends): emit hideEmail as non-null boolean in sync response

### DIFF
--- a/src/db/models/send.rs
+++ b/src/db/models/send.rs
@@ -161,7 +161,7 @@ impl Send {
             "password": self.password_hash.as_deref().map(|h| BASE64URL_NOPAD.encode(h)),
             "authType": if self.password_hash.is_some() { SendAuthType::Password as i32 } else { SendAuthType::None as i32 },
             "disabled": self.disabled,
-            "hideEmail": self.hide_email,
+            "hideEmail": self.hide_email.unwrap_or(false),
 
             "revisionDate": format_date(&self.revision_date),
             "expirationDate": self.expiration_date.as_ref().map(format_date),


### PR DESCRIPTION
### Problem

`GET /api/sync` returns `"hideEmail": null` for Sends whose `hide_email` column is NULL. The `sends.hide_email` column is `Nullable<Bool>` with no default (added in migration `2021-05-11-205202_add_hide_email`), so it is NULL for older Sends and any code path that leaves it unset.

The Bitwarden Android client deserializes `SyncResponseJson.Send.hideEmail` as a non-null Kotlin `Boolean` and throws a `JsonDecodingException`, aborting the **entire** sync. Web, desktop and CLI clients coerce null to `false`, so only accounts with at least one Send are affected, and only on Android.

The official Bitwarden server treats `hideEmail` as non-nullable.

### Fix

Default `None` to `false` at the serialization boundary in `Send::to_json()`:

```rust
"hideEmail": self.hide_email.unwrap_or(false),
```

The field stays `Option<bool>` internally. No DB migration is required, and this fixes both existing NULL rows and any future NULLs.