### PR TITLE
Org membership delete remove Invitation

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1089,9 +1089,13 @@ async fn send_invite(
                     err!(format!("User already in organization: {email}"))
                 }
 
-                // automatically accept existing users if mail is disabled
-                if !CONFIG.mail_enabled() && !user.password_hash.is_empty() {
-                    member_status = MembershipStatus::Accepted as i32;
+                if !CONFIG.mail_enabled() {
+                    if user.password_hash.is_empty() {
+                        Invitation::new(email).save(&conn).await?;
+                    } else {
+                        // automatically accept existing users if mail is disabled
+                        member_status = MembershipStatus::Accepted as i32;
+                    }
                 }
                 user
             }
@@ -1713,6 +1717,15 @@ async fn delete_member_impl(
 
     if let Some(user) = User::find_by_uuid(&member_to_delete.user_uuid, conn).await {
         nt.send_user_update(UpdateType::SyncOrgKeys, &user, headers.device.push_uuid.as_ref(), conn).await;
+
+        if !CONFIG.mail_enabled()
+            && !Membership::find_invited_by_user(&user.uuid, conn)
+                .await
+                .into_iter()
+                .any(|m| m.uuid != member_to_delete.uuid)
+        {
+            Invitation::take(&user.email, conn).await;
+        }
     }
 
     member_to_delete.delete(conn).await


### PR DESCRIPTION
While discussing https://github.com/dani-garcia/vaultwarden/pull/7272 realized that the `Invitiation` is not deleted when the membership is deleted through the Orgnaization membership.

And while testing I realized that if the user stub is already present then the `Invitation` is not created again.

Additionally, I wonder if the invitations check should not be done again when the user stub is present ? cf:

```rust 
                if !CONFIG.invitations_allowed() {
                    err!(format!("User does not exist: {email}"))
                }
                if !CONFIG.is_email_domain_allowed(email) {
                    err!("Email domain not eligible for invitations")
                }
``` 

And realized that the revoked flow does not handle the `Invitations`  creation/deletion nor check again the invitation/domain is still allowed on restoration.

Wanted some feedback before making more modifcations.