### PR TITLE
don't auto-enable signup via allowed domain list

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -269,8 +269,10 @@
 ## email will be re-sent upon an attempted login.
 # SIGNUPS_VERIFY_RESEND_LIMIT=6
 
-## Controls if new users from a list of comma-separated domains can register
-## even if SIGNUPS_ALLOWED is set to false
+## Restrict email addresses to this list of comma-separated domains
+## This allow list affects signups, invitations and email address changes.
+## By default this allow list is empty, meaning no restrictions apply.
+## NOTE: You can circumvent this restriction if you invite someone via the `/admin` panel.
 # SIGNUPS_DOMAINS_WHITELIST=example.com,example.net,example.org
 
 ## Controls whether event logging is enabled for organizations

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1062,7 +1062,7 @@ async fn send_invite(
             && data.permissions.get("deleteAnyCollection") == Some(&json!(true))
             && data.permissions.get("createNewCollections") == Some(&json!(true)));
 
-    let mut user_created: bool = false;
+    let mut user_created: bool;
     for email in &data.emails {
         let mut member_status = MembershipStatus::Invited as i32;
         let user = match User::find_by_mail(email, &conn).await {
@@ -1093,6 +1093,7 @@ async fn send_invite(
                 if !CONFIG.mail_enabled() && !user.password_hash.is_empty() {
                     member_status = MembershipStatus::Accepted as i32;
                 }
+                user_created = false;
                 user
             }
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -623,7 +623,7 @@ make_config! {
         signups_verify_resend_time: u64, true,  def,    3_600;
         /// If signups require email verification, limit how many emails are automatically sent when login is attempted (0 means no limit)
         signups_verify_resend_limit: u32, true, def,    6;
-        /// Email domain whitelist |> Allow signups only from this list of comma-separated domains, even when signups are otherwise disabled
+        /// Email domain whitelist |> Restrict email addresses to this list of comma-separated domains
         signups_domains_whitelist: String, true, def,   String::new();
         /// Enable event logging |> Enables event logging for organizations.
         org_events_enabled:     bool,   false,  def,    false;
@@ -1507,21 +1507,14 @@ impl Config {
     /// Tests whether signup is allowed for an email address, taking into
     /// account the signups_allowed and signups_domains_whitelist settings.
     pub fn is_signup_allowed(&self, email: &str) -> bool {
-        if self.signups_domains_whitelist().is_empty() {
-            self.signups_allowed()
-        } else {
-            // The whitelist setting overrides the signups_allowed setting.
-            self.is_email_domain_allowed(email)
-        }
+        self.signups_allowed() && self.is_email_domain_allowed(email)
     }
 
     // The registration link should be hidden if
-    //  - Signup is not allowed and email whitelist is empty unless mail is disabled and invitations are allowed
+    //  - Signup is not allowed unless mail is disabled and invitations are allowed
     //  - The SSO is activated and password login is disabled.
     pub fn is_signup_disabled(&self) -> bool {
-        (!self.signups_allowed()
-            && self.signups_domains_whitelist().is_empty()
-            && (self.mail_enabled() || !self.invitations_allowed()))
+        (!self.signups_allowed() && (self.mail_enabled() || !self.invitations_allowed()))
             || (self.sso_enabled() && self.sso_only())
     }
 


### PR DESCRIPTION
As discussed in #7272 I think the default behavior for registration should be changed to be less confusing.

Restricting the allowed domains via the allow list should not override whether signups are allowed.
Since this would be a breaking change, this should be explicitly mentioned in the next release notes.