### PR TITLE
Pin Debian MariaDB client library snapshot

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -51,6 +51,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TERM=xterm-256color \
     CARGO_HOME="/root/.cargo" \
     USER="root"
+
+# Force the install of an older MariaDB client library to prevent Diesel from
+# misreading result sets with affected MariaDB Connector/C releases.
+# See https://github.com/dani-garcia/vaultwarden/issues/6416
+# See https://github.com/dani-garcia/vaultwarden/issues/7268
+RUN echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
+    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot
 # Install clang && xx-c-essentials to get `xx-cargo` working
 # Install pkg-config to allow amd64 builds to find all libraries
 # Install git so build.rs can determine the correct version
@@ -148,6 +158,15 @@ ENV ROCKET_PROFILE="release" \
 
 # Create data folder and Install needed libraries
 RUN mkdir /data && \
+    # Force the install of an older MariaDB client library to prevent Diesel from
+    # misreading result sets with affected MariaDB Connector/C releases.
+    # See https://github.com/dani-garcia/vaultwarden/issues/6416
+    # See https://github.com/dani-garcia/vaultwarden/issues/7268
+    echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
+    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot && \
     apt-get update && apt-get install -y \
         --no-install-recommends \
         ca-certificates \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -52,15 +52,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_HOME="/root/.cargo" \
     USER="root"
 
-# Force the install of an older MariaDB client library to prevent Diesel from
-# misreading result sets with affected MariaDB Connector/C releases.
+# Pin MariaDB Connector/C to the latest known-working Trixie build before
+# 11.8.7 started breaking Diesel migration metadata/result handling.
 # See https://github.com/dani-garcia/vaultwarden/issues/6416
 # See https://github.com/dani-garcia/vaultwarden/issues/7268
-RUN echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+RUN echo "deb http://snapshot.debian.org/archive/debian/20260617T000000Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
     echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
-    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Package: libmariadb* mariadb-common' > /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot
+
 # Install clang && xx-c-essentials to get `xx-cargo` working
 # Install pkg-config to allow amd64 builds to find all libraries
 # Install git so build.rs can determine the correct version
@@ -158,13 +159,13 @@ ENV ROCKET_PROFILE="release" \
 
 # Create data folder and Install needed libraries
 RUN mkdir /data && \
-    # Force the install of an older MariaDB client library to prevent Diesel from
-    # misreading result sets with affected MariaDB Connector/C releases.
+    # Pin MariaDB Connector/C to the latest known-working Trixie build before
+    # 11.8.7 started breaking Diesel migration metadata/result handling.
     # See https://github.com/dani-garcia/vaultwarden/issues/6416
     # See https://github.com/dani-garcia/vaultwarden/issues/7268
-    echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "deb http://snapshot.debian.org/archive/debian/20260617T000000Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
     echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
-    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Package: libmariadb* mariadb-common' > /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot && \
     apt-get update && apt-get install -y \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -72,15 +72,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Debian Trixie uses libpq v17
     PQ_LIB_DIR="/usr/local/musl/pq17/lib"
 {%- endif %}
+
 {% if base == "debian" %}
 
-# Force the install of an older MariaDB client library to prevent Diesel from
-# misreading result sets with affected MariaDB Connector/C releases.
+# Pin MariaDB Connector/C to the latest known-working Trixie build before
+# 11.8.7 started breaking Diesel migration metadata/result handling.
 # See https://github.com/dani-garcia/vaultwarden/issues/6416
 # See https://github.com/dani-garcia/vaultwarden/issues/7268
-RUN echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+RUN echo "deb http://snapshot.debian.org/archive/debian/20260617T000000Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
     echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
-    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Package: libmariadb* mariadb-common' > /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot
 
@@ -203,13 +204,13 @@ ENV ROCKET_PROFILE="release" \
 # Create data folder and Install needed libraries
 RUN mkdir /data && \
 {% if base == "debian" %}
-    # Force the install of an older MariaDB client library to prevent Diesel from
-    # misreading result sets with affected MariaDB Connector/C releases.
+    # Pin MariaDB Connector/C to the latest known-working Trixie build before
+    # 11.8.7 started breaking Diesel migration metadata/result handling.
     # See https://github.com/dani-garcia/vaultwarden/issues/6416
     # See https://github.com/dani-garcia/vaultwarden/issues/7268
-    echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "deb http://snapshot.debian.org/archive/debian/20260617T000000Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
     echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
-    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Package: libmariadb* mariadb-common' > /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
     echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot && \
     apt-get update && apt-get install -y \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -72,8 +72,18 @@ ENV DEBIAN_FRONTEND=noninteractive \
     # Debian Trixie uses libpq v17
     PQ_LIB_DIR="/usr/local/musl/pq17/lib"
 {%- endif %}
-
 {% if base == "debian" %}
+
+# Force the install of an older MariaDB client library to prevent Diesel from
+# misreading result sets with affected MariaDB Connector/C releases.
+# See https://github.com/dani-garcia/vaultwarden/issues/6416
+# See https://github.com/dani-garcia/vaultwarden/issues/7268
+RUN echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
+    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot
+
 # Install clang && xx-c-essentials to get `xx-cargo` working
 # Install pkg-config to allow amd64 builds to find all libraries
 # Install git so build.rs can determine the correct version
@@ -193,6 +203,15 @@ ENV ROCKET_PROFILE="release" \
 # Create data folder and Install needed libraries
 RUN mkdir /data && \
 {% if base == "debian" %}
+    # Force the install of an older MariaDB client library to prevent Diesel from
+    # misreading result sets with affected MariaDB Connector/C releases.
+    # See https://github.com/dani-garcia/vaultwarden/issues/6416
+    # See https://github.com/dani-garcia/vaultwarden/issues/7268
+    echo "deb http://snapshot.debian.org/archive/debian/20250707T084701Z/ trixie main" > /etc/apt/sources.list.d/mariadb-snapshot.list && \
+    echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/allow-snapshot && \
+    echo 'Package: libmariadb* mariadb*' > /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin: origin "snapshot.debian.org"' >> /etc/apt/preferences.d/mariadb-snapshot && \
+    echo 'Pin-Priority: 1001' >> /etc/apt/preferences.d/mariadb-snapshot && \
     apt-get update && apt-get install -y \
         --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
## Summary

- pin Debian image builds to the 2025-07-07 Debian Trixie snapshot for `libmariadb*`/`mariadb*`
- apply the same pin in the runtime image so the shipped Debian image uses the known-good MariaDB Connector/C package set
- keep the generated `Dockerfile.debian` in sync with `Dockerfile.j2`

## Context

Recent MariaDB Connector/C releases can make Diesel misread result sets. In #7268 this shows up as Diesel not seeing existing `__diesel_schema_migrations` rows, then replaying migrations and failing on duplicate columns. This is the same class of MariaDB client-library issue previously tracked in #6416.

The pinned snapshot contains `libmariadb3`/`libmariadb-dev` `1:11.8.1-4`; current Trixie provides `1:11.8.6-0+deb13u1`.

Refs #6416
Refs #7268

## Verification

- `git diff --check`
- static check that both `docker/Dockerfile.j2` and generated `docker/Dockerfile.debian` contain the snapshot pin and #7268 reference
- checked Debian snapshot package metadata for `libmariadb3`, `libmariadb-dev`, and `libmariadb-dev-compat` at `1:11.8.1-4`

Note: `make -C docker` could not run in this local environment because Python modules `yaml`/`jinja2` are not installed, so `Dockerfile.debian` was updated to match the template change manually.
