### PR TITLE
Add Vaultwarden OIDC Post

### DIFF
--- a/src/sso_client.rs
+++ b/src/sso_client.rs
@@ -114,7 +114,8 @@ impl Client {
             Ok(metadata) => metadata,
         };
 
-        let base_client = CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret));
+        let base_client = CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
+            .set_auth_type(openidconnect::AuthType::RequestBody);
 
         let token_uri = if let Some(uri) = base_client.token_uri() {
             uri.clone()


### PR DESCRIPTION
## Problem

Vaultwarden SSO uses the `openidconnect` crate which defaults to HTTP Basic Auth (`client_id:client_secret` in the `Authorization` header) for token endpoint requests.

[Stalwart Mail Server](https://stalw.art)'s OIDC provider only accepts client credentials as `client_id` and `client_secret` POST body parameters — it does not support the Basic Auth header method. This causes the token exchange to fail when using Stalwart as the OIDC identity provider for Vaultwarden SSO.

## Fix

Set `.set_auth_type(openidconnect::AuthType::RequestBody)` on the client, so credentials are sent as `application/x-www-form-urlencoded` POST body parameters instead of in the `Authorization` header.

This is consistent with RFC 6749 Section 2.3.1 which says clients using the "client password" authentication method may include credentials in the request body. The `openidconnect` crate supports both methods — the fix simply selects the one that Stalwart (and other providers that follow the body-only convention) expects.

## Testing

Tested with Stalwart OIDC as the identity provider. Token exchange succeeds after this change where it previously failed with an authentication error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
