### PR TITLE
Add `pm-26340-linux-biometrics-v2` feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -378,6 +378,7 @@
 ## - "ssh-agent-v2": Enable newer SSH agent support. (Desktop >= 2026.2.1)
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Clients >= 2024.12.0)
 ## - "pm-25373-windows-biometrics-v2": Enable the new implementation of biometrics on Windows. (Desktop >= 2025.11.0)
+## - "pm-26340-linux-biometrics-v2": Enable the new implementation of biometrics on Linux. (Desktop >= 2025.11.0)
 ## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Android >= 2025.3.0, iOS >= 2025.4.0)
 ## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Android >= 2025.3.0, iOS >= 2025.4.0)
 ## - "mutual-tls": Enable the use of mutual TLS on Android (Clients >= 2025.2.0)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1404,6 +1404,7 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     // Key Management Team
     "ssh-key-vault-item",
     "pm-25373-windows-biometrics-v2",
+    "pm-26340-linux-biometrics-v2",
     // Mobile Team
     "anon-addy-self-host-alias",
     "simple-login-self-host-alias",


### PR DESCRIPTION
Adds the `pm-26340-linux-biometrics-v2` feature flag to the supported client feature flags allowlist.

Bitwarden's desktop client rewrote Linux biometric (polkit) unlock as a v2 implementation gated behind the `pm-26340-linux-biometrics-v2` LaunchDarkly flag (client constant `LinuxBiometricsV2` in `libs/common/src/enums/feature-flag.enum.ts`; introduced in bitwarden/clients PRs #16660 / #16661). On recent desktop builds the "Unlock with biometrics" option is hidden on Linux unless the server advertises this flag via `/api/config`, so self-hosted users can no longer enable fingerprint/polkit unlock.

This mirrors the Windows equivalent added in #6468 (`pm-25373-windows-biometrics-v2`): a one-line addition to `SUPPORTED_FEATURE_FLAGS` plus the matching `.env.template` documentation. After this, setting `EXPERIMENTAL_CLIENT_FEATURE_FLAGS=pm-26340-linux-biometrics-v2` lets the Linux desktop client expose biometric unlock again.

Available since Desktop 2025.11.0.