### PR TITLE
Don't fail login when push device registration fails

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -493,7 +493,12 @@ async fn authenticated_response(
 
     // register push device
     if !device.is_new() {
-        register_push_device(device, conn).await?;
+        // Registering the device for push is best-effort: a failure talking to the
+        // push relay/identity server must not turn a successful authentication into
+        // an error (see #7371). This mirrors the new-device email handling above.
+        if let Err(e) = register_push_device(device, conn).await {
+            error!("An error occurred while registering the device for push notifications: {e}");
+        }
     }
 
     // Save to update `device.updated_at` to track usage and toggle new status


### PR DESCRIPTION
## Problem

With `PUSH_ENABLED=true`, re-authenticating an existing device (e.g. after the session expires or a forced re-login) fails: `POST /identity/connect/token` returns `400`, with this in the log:

```
[vaultwarden::api::push][ERROR] Unexpected push token received from bitwarden server: error decoding response body
POST /identity/connect/token => 400 Bad Request
```

The initial login succeeds; only a later re-login fails. Reported in #7371 (iOS + OIDC SSO, but it isn't SSO-specific).

## Cause

In `authenticated_response` (`src/api/identity.rs`), push registration runs only for already-known devices and its error is propagated with `?`:

```rust
if !device.is_new() {
    register_push_device(device, conn).await?;
}
```

`register_push_device` calls `get_auth_api_token()`, which returns `Err` when the push identity server's response can't be deserialized (`src/api/push.rs`, `err!("Unexpected push token received from bitwarden server: …")`). The `?` propagates that out of `authenticated_response`, so it becomes the token endpoint's `400`. The `!device.is_new()` gate is why only re-authentication is affected — the very first login takes the `is_new()` path and skips registration.

## Fix

Handle the registration best-effort: log the error and continue, mirroring the new-device login email a few lines above (also a non-essential side effect of login). The device is still saved right after, so push keeps working once the relay/identity endpoint recovers, and authentication no longer fails when it misbehaves.

## Verification

`cargo fmt --all -- --check` and `cargo clippy --features sqlite -- -D warnings` both pass on the change.

Fixes #7371
