### PR TITLE
add Zenith Hosting badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ services:
 
 <br>
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/vaultwarden?ref=gh)
+
 ## Get in touch
 
 Have a question, suggestion or need help? Join our community on [Matrix](https://matrix.to/#/#vaultwarden:matrix.org), [GitHub Discussions](https://github.com/dani-garcia/vaultwarden/discussions) or [Discourse Forums](https://vaultwarden.discourse.group/).


### PR DESCRIPTION
Hey, i'm part of a startup called Zenith Hosting; where we frequently use Vaultwarden to help safeguard our creds. We wanted to make it easier for other people who don't want to use heavyweight/non-free password managers, so we added Vaultwarden as a one-click deploy on our platform. 

this PR simply adds a small deploy badge to the README; which links to https://zenith.hosting/host/vaultwarden where people can just spin up a fresh vw instance with persistent storage and auto backups without the hassle of setting up Docker or a reverse proxy/ufw themselves.