### PR TITLE
Add support for Fill Assist

### DIFF
--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -220,6 +220,7 @@ fn config() -> Json<Value> {
         &FeatureFlagFilter::ValidOnly,
     );
     feature_states.insert("pm-19148-innovation-archive".to_owned(), true);
+    feature_states.insert("fill-assist-targeting-rules".to_owned(), true);
 
     Json(json!({
         // Note: The clients use this version to handle backwards compatibility concerns

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -245,6 +245,9 @@ fn config() -> Json<Value> {
           "notifications": format!("{domain}/notifications"),
           "sso": "",
           "cloudRegion": null,
+          // fillAssistRules as returned by the Bitwarden server (https://github.com/bitwarden/server @ 045113a),
+          // and hardcoded in the Bitwarden clients (https://github.com/bitwarden/clients @ 2581be6)
+          "fillAssistRules": "https://github.com/bitwarden/map-the-web/releases/latest/download",
         },
         // Bitwarden uses this for the self-hosted servers to indicate the default push technology
         "push": {


### PR DESCRIPTION
See #7428 and https://bitwarden.com/blog/fill-assist-improving-autofill-every-time-for-everyone/

Since this feature is only client-side and is opt-in on the client anyway, I feel like it can just be added as a static always-enabled feature flag. But it could also be added as a supported experimental flag.