### PR TITLE
Fix Custom Role CSS for new dialog markup

### DIFF
--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -116,8 +116,8 @@ app-security > app-two-factor-setup > form {
 }
 
 /* Hide unsupported Custom Role options */
-bit-dialog div.tw-ml-4:has(bit-form-control input),
-bit-dialog div.tw-col-span-4:has(input[formcontrolname*="access"], input[formcontrolname*="manage"]) {
+:is(bit-dialog, [bit-dialog]) div.tw-ml-4:has(bit-form-control input),
+:is(bit-dialog, [bit-dialog]) div.tw-col-span-4:has(input[formcontrolname*="access"], input[formcontrolname*="manage"]) {
   @extend %vw-hide;
 }
 


### PR DESCRIPTION
Web Vault 2026.6.2 changed the dialog host from `<bit-dialog>` to `[bit-dialog]`.

Match both forms so unsupported Custom Role permissions remain hidden. Tested with the 2026.4.1 and 2026.6.2 markup and Vaultwarden's SCSS compiler.
