### PR TITLE
SCIM v2 provisioning for Entra ID (invite + deprovision, E2EE-aware)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3047,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e333fe507b738576d6da5bb3f1a7d7a1c80307ed9ef31624c057d844c19c93e9"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5351,6 +5373,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-support"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5955,6 +5984,7 @@ dependencies = [
  "subtle",
  "svg-hush",
  "syslog",
+ "test-support",
  "time",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/dani-garcia/vaultwarden"
 publish = false
 
 [workspace]
-members = ["macros"]
+members = ["macros", "test-support"]
 
 [package]
 name = "vaultwarden"
@@ -397,3 +397,6 @@ missing_panics_doc = "allow"
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+test-support = { path = "test-support" }

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,134 @@
+# TODOS
+
+## SCIM
+
+### Config-gated denial tests (SCIM_ENABLED=false, ORG_GROUPS_ENABLED=false)
+
+**What:** Test the two config master switches from the denied side: a valid token
+against `SCIM_ENABLED=false` must get the uniform 401, and any Groups route with
+`ORG_GROUPS_ENABLED=false` must get the SCIM-enveloped 501.
+
+**Why:** These are the primary kill switches for the whole surface and the one
+authz-matrix case the build plan promised that is still missing.
+
+**Context:** `CONFIG` is a process-global `LazyLock` pinned by the `test-support`
+`#[ctor]` before main, so the disabled states cannot be tested in the same
+process as the enabled suite. Needs either a second test binary with its own
+ctor env, or an injectable check in `guard.rs` / `groups.rs`. See the
+`plan-delivery-gap-scim-disabled-authz-case` learning.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** None
+
+### Live Entra ID tenant validation
+
+**What:** Run the full lifecycle against a throwaway Entra tenant: Test
+Connection, assign user, create/update/deprovision/restore, group sync, token
+rotation. Follow docs/scim/README.md as written and fix any doc drift found.
+
+**Why:** Everything is verified against RFC 7643/7644 and observed Entra
+behaviour, but no real Entra sync has run against this build yet.
+
+**Context:** User-driven (needs a tenant). Never production. The rate limiter
+keys on `IP_HEADER` (`X-Real-IP`) - the deployment in front must set it.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** Branch pushed and deployed somewhere TLS-fronted
+
+### Mail-enabled invite failure path, end to end
+
+**What:** An integration test that runs `post_user` with mail enabled and a
+failing SMTP target, asserting the 500 plus the rollback outcome.
+
+**Why:** The rollback decision logic is unit-tested
+(`provisioning_rollback_spares_preexisting_users`), but the branch that calls it
+(send_invite failure inside `post_user`) still never executes under test.
+
+**Context:** Needs mail enabled in `CONFIG` (same process-global constraint as
+above) plus a fast-failing SMTP endpoint; naive versions are slow or flaky.
+Consider folding into the same second test binary as the config-gated tests.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Config-gated denial tests (shared harness)
+
+### Coverage: error-envelope edges and manage HTTP surface
+
+**What:** Tests for the remaining actionable gaps from the ship coverage audit
+(82%): malformed-body 400 / oversized-body 413 envelopes, HTTP-level 429
+envelope, POST /Users missing/invalid email 400s, policy-blocked restore 400,
+GroupPatch path-less object form (Entra sends this shape), externalId HTTP
+filters, POST /Groups blank-name 400 and dup-externalId 409, and the manage
+endpoints driven over HTTP with AdminHeaders.
+
+**Why:** These are the branches where a regression would surface to Entra as a
+wrong status code or envelope, currently proven only by adjacent coverage.
+
+**Context:** All testable in the existing Rocket-local harness except the
+manage endpoints, which need an AdminHeaders fixture. Coverage map in the
+2026-07-19 ship PR body has the full gap list.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None
+
+### Performance backlog for large orgs
+
+**What:** SQL-side pagination for /Users and /Groups lists, batched group
+member writes (resolve via `eq_any`, diff instead of delete-all+reinsert on
+PUT), and secondary indexes on `users_organizations(org_uuid, external_id)` and
+`groups(organizations_uuid, external_id)`.
+
+**Why:** Current implementation loads full member/group sets per list request
+and issues ~4N queries for an N-member group write. Fine at self-host scale
+(hundreds of members); wasteful for thousands.
+
+**Context:** Indexes diverge from upstream's no-secondary-index convention -
+decide deliberately. Review findings from 2026-07-19 have the details.
+
+**Effort:** L
+**Priority:** P3
+**Depends on:** None
+
+### Harden SCIM write edges surfaced by adversarial review
+
+**What:** Three lower-severity robustness gaps from the 2026-07-19 adversarial
+pass: (1) externalId uniqueness is check-then-set with no backing DB unique
+index, so concurrent writes could duplicate the correlation key; (2) a Group
+displayName > 100 chars or externalId > 300 chars from Entra hits the MySQL
+column limit and returns a 500 instead of a 400 invalidValue; (3) `scim_status`
+returns key metadata behind only an AdminHeaders session with no password/OTP
+re-auth, unlike generate/delete.
+
+**Why:** None are exploitable today (single Entra sync engine; strict-mode MySQL
+only; admin session required), but each is an unenforced invariant or an
+inconsistent guard that a future change could turn into a real bug.
+
+**Why not now:** (1) wants a migration adding a partial unique index across three
+dialects - real schema work, deferrable; (2) wants length validation in the
+Group handlers; (3) is a one-line guard tightening. Bundle them.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None
+
+## Upstream hygiene
+
+### ip_constant clippy lints in http_client.rs tests
+
+**What:** 9 pre-existing `clippy::ip_constant` errors in upstream
+`src/http_client.rs` test code under `--all-targets` with the 1.96 toolchain.
+
+**Why:** Blocks running `cargo clippy --all-targets` clean locally; will bite
+if CI ever lints test targets.
+
+**Context:** Upstream code, untouched per branch discipline. Fix as a separate
+commit or PR upstream (`Ipv4Addr::LOCALHOST` instead of hand-coded addresses).
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** None
+
+## Completed

--- a/docs/scim/README.md
+++ b/docs/scim/README.md
@@ -23,10 +23,16 @@ Entra ID is the tested IdP. Design details and diagrams: [design.md](design.md).
 
    ```ini
    SCIM_ENABLED=true
+   # strongly recommended: without it, SCIM changes leave no audit trail
+   ORG_EVENTS_ENABLED=true
    # optional tuning
    SCIM_RATELIMIT_SECONDS=1
    SCIM_RATELIMIT_MAX_BURST=60
    ```
+
+   The server prints a startup warning if `SCIM_ENABLED` is set while
+   `ORG_EVENTS_ENABLED` is not, because every SCIM change would then be
+   invisible in the org event log.
 
 2. Generate the per-organization SCIM token (requires an org admin session;
    re-authenticates with your master password like API key rotation):
@@ -93,8 +99,24 @@ Entra ID is the tested IdP. Design details and diagrams: [design.md](design.md).
   rather than erroring the sync.
 - **SCIM user id** is the org membership id, not the account id. The same
   person in two orgs has two SCIM ids: SCIM is org-scoped by construction.
+- **externalId is unique per org** for both Users and Groups, on every write
+  path (create, PUT, PATCH). A write that would duplicate one is a 409
+  `uniqueness` conflict and changes nothing; re-asserting a resource's own
+  externalId succeeds.
+- **A Group PUT that omits `members` leaves the member set unchanged.** Only
+  an explicit `"members": []` clears the group, so a sparse non-Entra client
+  cannot wipe membership by accident (Entra always sends the full list).
+- **Deprovision from the IdP, not just the vault.** Because restore is lossless,
+  a member you revoke in the web vault is silently re-activated on the next sync
+  if the IdP still shows them active - `active: true` reinstates a previously
+  confirmed member to full access with no re-confirmation. To offboard someone,
+  unassign or disable them in Entra. Rotate the org's SCIM token if it may have
+  leaked: it can reinstate any member the org previously confirmed, not only
+  invite and deprovision.
 - Every SCIM change is written to the org event log (admin-visible) with the
-  synthetic actor `vaultwarden-scim-...` when `ORG_EVENTS_ENABLED=true`.
+  synthetic actor `vaultwarden-scim-...` when `ORG_EVENTS_ENABLED=true`. Token
+  generation, rotation, and deletion are logged too, under the acting admin's
+  own identity.
 
 ## Operational lifecycle
 

--- a/docs/scim/README.md
+++ b/docs/scim/README.md
@@ -1,0 +1,108 @@
+# SCIM v2 provisioning
+
+This fork adds a SCIM v2 provisioning server (RFC 7643 / RFC 7644) so
+organization membership can be driven from an identity provider. Microsoft
+Entra ID is the tested IdP. Design details and diagrams: [design.md](design.md).
+
+## What it does, honestly
+
+- **Automated invite**: assigning a user in the IdP creates the Vaultwarden
+  account (if needed) and org membership, and sends the invite email.
+- **Automated deprovision**: removing a user (or setting `active: false`)
+  revokes org access immediately. Restore is lossless.
+- **Group sync**: group existence and membership, when `ORG_GROUPS_ENABLED=true`.
+- **Not automated**: the final *Confirm* step. End-to-end encryption means the
+  org key must be wrapped for each member by an admin's client; no server can
+  do it. Provisioned users wait in *Invited* / *Accepted* until an admin
+  confirms them in the web vault. See design.md for why this is a property of
+  the encryption model, not a missing feature.
+
+## Server setup
+
+1. Enable SCIM in the server config (default is off):
+
+   ```ini
+   SCIM_ENABLED=true
+   # optional tuning
+   SCIM_RATELIMIT_SECONDS=1
+   SCIM_RATELIMIT_MAX_BURST=60
+   ```
+
+2. Generate the per-organization SCIM token (requires an org admin session;
+   re-authenticates with your master password like API key rotation):
+
+   ```bash
+   curl -s -X POST "$DOMAIN/api/organizations/$ORG_ID/scim/api-key" \
+     -H "Authorization: Bearer $ADMIN_SESSION_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"masterPasswordHash": "..."}'
+   ```
+
+   The response contains the token (`scim_v1.<org>.<secret>`) and the tenant
+   URL. **The token is shown exactly once**; only its sha256 digest is stored.
+   POST again to rotate (the old token stops working immediately), DELETE the
+   same path to disable SCIM for the org, GET `/scim/status` to inspect.
+
+3. TLS is required in front of the server (Entra refuses plain http). If a
+   reverse proxy sets client IPs, make sure it overwrites the `IP_HEADER`
+   header (default `X-Real-IP`); the SCIM rate limiter keys on that value.
+
+## Entra ID setup
+
+1. Entra admin center: **Enterprise applications > New application > Create
+   your own application** (non-gallery).
+2. **Provisioning > Automatic**:
+   - Tenant URL: `https://<your-domain>/scim/v2/<org_id>`
+   - Secret Token: the `scim_v1...` value from step 2 above.
+   - Test Connection, then Save.
+3. **Attribute mappings** (Users):
+
+   | Entra attribute | SCIM attribute | Vaultwarden |
+   |---|---|---|
+   | userPrincipalName (or mail) | `userName` | account email (lowercased) |
+   | objectId | `externalId` | membership external id |
+   | Switch([IsSoftDeleted], , "False", "True", "True", "False") | `active` | revoke / restore |
+   | displayName | `displayName` | account name (set at creation only) |
+
+   Map `userName` from **mail** rather than userPrincipalName if your UPNs
+   are not routable mailboxes: the value must be a deliverable email address,
+   because it becomes the Vaultwarden login and receives the invite.
+
+   Recommended: delete the default mappings this server does not sync
+   (`roles`, `preferredLanguage`, `title`, addresses, phones). They are
+   accepted and ignored, but trimming them keeps the Entra sync log clean.
+
+4. Groups: map `displayName` and `objectId` to `externalId`. Members sync as
+   diffs. Assign users before (or together with) their groups; a group member
+   who is not yet provisioned as a user is rejected until the user sync runs.
+5. Assign users/groups to the app and start provisioning. Entra's initial
+   cycle lists existing users first (`userName eq` filters), then creates.
+
+## Behaviour notes and deviations
+
+- **DELETE = revoke.** Both Entra soft delete (`active: false`) and hard
+  DELETE revoke the membership. The row and its keys survive, so restoring a
+  returning user needs no re-confirmation. No destructive operation is
+  exposed to the IdP at all. This is a deliberate deviation from RFC 7644.
+- **Roles are not synced.** Everyone provisions as the User role;
+  promote people in the web vault. Vaultwarden's Custom role cannot round-trip
+  through SCIM.
+- **userName / displayName changes are not synced after creation.** The email
+  is the login identity; the display name belongs to the person globally, not
+  to one org's directory. Renames in Entra succeed (accepted and ignored)
+  rather than erroring the sync.
+- **SCIM user id** is the org membership id, not the account id. The same
+  person in two orgs has two SCIM ids: SCIM is org-scoped by construction.
+- Every SCIM change is written to the org event log (admin-visible) with the
+  synthetic actor `vaultwarden-scim-...` when `ORG_EVENTS_ENABLED=true`.
+
+## Operational lifecycle
+
+1. Entra assigns user, SCIM creates membership at *Invited*, invite mail sent.
+2. User clicks the invite, creates or logs into their account (*Accepted*).
+3. An org admin confirms the member in the web vault (*Confirmed*). This is
+   the manual step; the admin's client wraps the org key for the member.
+4. Entra unassigns or soft deletes, SCIM revokes immediately. Vault access
+   stops on the member's next sync.
+5. Re-assignment restores the membership exactly as it was, including the
+   confirmed state, with no new invite or confirmation needed.

--- a/docs/scim/design.md
+++ b/docs/scim/design.md
@@ -1,0 +1,217 @@
+# SCIM v2 design
+
+Architecture and security model for the SCIM implementation in this fork.
+Operator instructions live in [README.md](README.md).
+
+## Provision and deprovision flows
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Entra as Entra ID
+    participant Guard as ScimToken guard
+    participant H as SCIM handlers
+    participant DB as Database
+    participant Mail as SMTP
+
+    Note over Entra,Mail: Provision (assign user in Entra)
+    Entra->>Guard: GET /Users?filter=userName eq "a@x.com" (Bearer scim_v1...)
+    Guard->>DB: verify org key digest (ct_eq)
+    Guard-->>H: ScimToken{org}
+    H->>DB: find user + membership
+    H-->>Entra: 200 ListResponse (totalResults 0)
+    Entra->>Guard: POST /Users {userName, externalId, active}
+    Guard-->>H: ScimToken{org}
+    H->>DB: create shell User (if new), Membership status=Invited(0)
+    H->>Mail: send invite (rollback membership on failure)
+    H->>DB: log event (SCIM actor)
+    H-->>Entra: 201 Created {id = membership uuid}
+
+    Note over Entra,Mail: Deprovision (unassign / soft delete)
+    Entra->>Guard: PATCH /Users/{id} {op replace, active false}
+    Guard-->>H: ScimToken{org}
+    H->>DB: last-confirmed-owner check
+    H->>DB: status -= 128 (revoke, akey kept)
+    H->>DB: log event (SCIM actor)
+    H-->>Entra: 200 {active: false}
+```
+
+## Membership state machine
+
+The revocation encoding is the one non-obvious invariant in the whole
+integration: revoked is a stored **offset** (`status - 128`), and the enum
+value `Revoked = -1` never reaches the database. Every active/inactive
+decision in the SCIM code funnels through one helper that tests
+`status <= -1`.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Invited0: SCIM POST /Users
+    Invited0: Invited (0)
+    Accepted1: Accepted (1)
+    Confirmed2: Confirmed (2)
+    RevokedI: Revoked Invited (-128)
+    RevokedA: Revoked Accepted (-127)
+    RevokedC: Revoked Confirmed (-126)
+
+    Invited0 --> Accepted1: user accepts invite (own session)
+    Accepted1 --> Confirmed2: admin confirms (client wraps org key)
+
+    Invited0 --> RevokedI: SCIM active false / DELETE
+    Accepted1 --> RevokedA: SCIM active false / DELETE
+    Confirmed2 --> RevokedC: SCIM active false / DELETE
+    RevokedI --> Invited0: SCIM active true (restore, +128)
+    RevokedA --> Accepted1: SCIM active true
+    RevokedC --> Confirmed2: SCIM active true (akey intact, no re-confirm)
+
+    note right of Confirmed2
+        Vault access exists only here.
+        The wrap happens in the admin's
+        client. No server-side path can
+        produce Membership.akey.
+    end note
+```
+
+Why confirm cannot be automated server-side, verified against source:
+
+- `Organization.private_key` is stored encrypted under the org symmetric key;
+  the server cannot decrypt it.
+- `confirm_invite_impl` only stores an opaque client-computed blob into
+  `Membership.akey`.
+- Account Recovery cannot substitute: enrollment is self-service and needs
+  the user's master password, and `recover_account` requires the member to
+  already be Confirmed. It is gated behind the state it would need to reach.
+
+A future companion *confirm-worker* (a headless client holding an admin
+account, wrapping keys client-side and posting `bulk_confirm_invite`) could
+automate step three without weakening zero-knowledge. It is deliberately not
+part of the server.
+
+## Authentication
+
+The credential is a per-organization static bearer token,
+`scim_v1.<org_uuid>.<secret>`, because Entra's provisioning client sends a
+fixed Secret Token and cannot run an OAuth flow (which rules out reusing the
+one-hour organization api-key JWT that `/api/public` uses).
+
+- The secret is 32 random bytes (256 bits). At rest it exists only as a
+  sha256 hex digest in the `scim_api_key` table.
+- sha256 instead of argon2 is deliberate: argon2's cost is protection for
+  low-entropy human passwords. This secret is machine-generated at full
+  entropy, so digest inversion is infeasible, while per-request argon2 on an
+  unauthenticated endpoint would be a denial-of-service amplifier during
+  Entra's sync bursts.
+- Verification uses a constant-time compare, with a dummy compare when no
+  key row exists. The dominant timing signal is still the database lookup;
+  the dummy compare is hygiene, not a timing-proof guarantee.
+- An active `scim_api_key` row is also the per-org enable switch; the global
+  `SCIM_ENABLED` config is the master gate. Both must hold.
+- Generation and rotation require an interactive org admin session plus
+  master-password or OTP re-authentication. Rotation replaces the row, so
+  the previous token dies instantly. The plaintext is returned exactly once
+  and never logged.
+
+```mermaid
+flowchart TD
+    A[Request to /scim/v2/org_id/...] --> B{Rate limit by client IP}
+    B -- exceeded --> R429[429 SCIM error]
+    B --> C{SCIM_ENABLED}
+    C -- no --> R401
+    C --> D{Bearer parses as scim_v1.org.secret}
+    D -- no --> R401
+    D --> E{token org == path org}
+    E -- no --> R401
+    E --> F{active scim_api_key row for org}
+    F -- "no (dummy ct_eq burned)" --> R401
+    F --> G{ct_eq sha256 of secret vs stored digest}
+    G -- no --> R401
+    G --> H[ScimToken org_uuid to handler]
+    H --> I[Handler scopes every query to token org]
+
+    R401[Uniform 401 SCIM error body]
+
+    style R401 fill:#7a1f1f,color:#fff
+    style R429 fill:#7a5a1f,color:#fff
+    style H fill:#1f5c2e,color:#fff
+```
+
+Every 401 leaving the mount is byte-identical regardless of which check
+failed (asserted by test); causes are logged server-side only. Misses on
+filters return empty lists and unknown ids return the same 404 as another
+org's ids, so the surface does not confirm what exists.
+
+## Module layout
+
+```mermaid
+flowchart LR
+    subgraph scim [src/api/scim]
+        guard[guard.rs\nScimToken]
+        errm[error.rs\nSCIM envelope + catchers]
+        filter[filter.rs\neq filter parser]
+        patchm[patch.rs\nPatchOp user/group]
+        modelsm[models.rs\nserde requests]
+        usersm[users.rs\n/Users handlers]
+        groupsm[groups.rs\n/Groups handlers]
+        disc[discovery.rs\nSPConfig/ResourceTypes/Schemas]
+        manage[manage.rs\ntoken mgmt under /api]
+    end
+
+    subgraph core [existing Vaultwarden]
+        ratelimit[ratelimit.rs]
+        cryptom[crypto.rs ct_eq/sha256]
+        events[core/events.rs log_event]
+        models[db/models Membership/Group/ScimApiKey]
+    end
+
+    guard --> ratelimit
+    guard --> cryptom
+    guard --> models
+    usersm --> patchm
+    usersm --> filter
+    usersm --> modelsm
+    groupsm --> patchm
+    groupsm --> filter
+    usersm --> events
+    groupsm --> events
+    usersm --> models
+    groupsm --> models
+    manage --> models
+    usersm --> errm
+    groupsm --> errm
+    disc --> guard
+```
+
+The `/scim` mount carries its own catchers so every error, including ones
+Rocket generates before a handler runs, is a SCIM `Error` envelope. Token
+management deliberately lives under `/api` with `AdminHeaders`: the SCIM
+surface itself can never mint or rotate its own credential.
+
+## Semantics that differ from a naive SCIM reading
+
+| Topic | Choice | Reason |
+|---|---|---|
+| DELETE /Users | revoke, not delete | preserves `akey`; restore is lossless; compromised token cannot destroy state |
+| Roles | not synced (always User) | `Custom` collapses to Manager in `MembershipType::from_str`; no honest round-trip |
+| userName/displayName updates | accepted, ignored | email is login identity; `user.name` is global to the person; erroring would fail every directory rename sync |
+| Group DELETE | real delete | groups carry no E2EE state |
+| Group members | diff add/remove; replace only on PUT/replace | Entra PATCHes diffs, including `members[value eq "..."]` removal paths |
+| Groups when disabled | loud 501 | `ldap_import` silently skips; silence hides misconfiguration in the IdP |
+| Filter misses | empty 200 list | Entra Test Connection probes a random user; distinguishable misses enable enumeration |
+
+## Test strategy
+
+All tests are inline (bin-only crate). The integration harness runs the real
+Rocket router with a temporary sqlite database. A `#[ctor]` constructor in
+the `test-support` workspace crate rewrites the process environment before
+`main`, because `CONFIG` is a process-global that reads `.env` at first
+touch: without this, tests would inherit the developer's live configuration.
+The main crate forbids `unsafe`, so the `set_var` calls live in
+`test-support`. Integration tests serialize on a mutex and share one
+never-dropped pool (sqlite WAL locking).
+
+Covered end to end: the full provision / deprovision / restore lifecycle at
+every status offset (`-126`, `-127`, `-128`), duplicate and last-owner
+conflicts, uniform-401 byte-equality, enumeration shape, Entra PATCH quirks
+(op casing, string booleans, path-less values, filter-path member removal),
+pagination edges, and the rate limiter.

--- a/docs/scim/design.md
+++ b/docs/scim/design.md
@@ -23,7 +23,7 @@ sequenceDiagram
     Entra->>Guard: POST /Users {userName, externalId, active}
     Guard-->>H: ScimToken{org}
     H->>DB: create shell User (if new), Membership status=Invited(0)
-    H->>Mail: send invite (rollback membership on failure)
+    H->>Mail: send invite (on failure roll back: new user removed entirely, existing user keeps account, membership goes)
     H->>DB: log event (SCIM actor)
     H-->>Entra: 201 Created {id = membership uuid}
 
@@ -146,6 +146,7 @@ org's ids, so the surface does not confirm what exists.
 ```mermaid
 flowchart LR
     subgraph scim [src/api/scim]
+        modm[mod.rs\nScimJson body guard, pagination,\nlist/location helpers, SCIM actor consts]
         guard[guard.rs\nScimToken]
         errm[error.rs\nSCIM envelope + catchers]
         filter[filter.rs\neq filter parser]
@@ -167,6 +168,9 @@ flowchart LR
     guard --> ratelimit
     guard --> cryptom
     guard --> models
+    usersm --> modm
+    groupsm --> modm
+    disc --> modm
     usersm --> patchm
     usersm --> filter
     usersm --> modelsm
@@ -191,13 +195,34 @@ surface itself can never mint or rotate its own credential.
 
 | Topic | Choice | Reason |
 |---|---|---|
-| DELETE /Users | revoke, not delete | preserves `akey`; restore is lossless; compromised token cannot destroy state |
+| DELETE /Users | revoke, not delete | preserves `akey`; restore is lossless; compromised token cannot destroy state (but see the reinstatement note below) |
 | Roles | not synced (always User) | `Custom` collapses to Manager in `MembershipType::from_str`; no honest round-trip |
 | userName/displayName updates | accepted, ignored | email is login identity; `user.name` is global to the person; erroring would fail every directory rename sync |
 | Group DELETE | real delete | groups carry no E2EE state |
 | Group members | diff add/remove; replace only on PUT/replace | Entra PATCHes diffs, including `members[value eq "..."]` removal paths |
+| Group PUT without `members` | member set unchanged | RFC 7644 permits either reading; keeping membership means a sparse client cannot wipe a group by accident. Explicit `[]` still clears |
+| externalId | unique per org, on every write path | it is the IdP correlation key; a duplicate would make filter lookups and later syncs target an arbitrary group. Users and Groups both 409 on conflict, self re-assertion allowed |
 | Groups when disabled | loud 501 | `ldap_import` silently skips; silence hides misconfiguration in the IdP |
 | Filter misses | empty 200 list | Entra Test Connection probes a random user; distinguishable misses enable enumeration |
+
+### Revocation is IdP-authoritative, in both directions
+
+Because restore is lossless, `active: true` is not just an onboarding signal - it
+**reinstates a revoked member to exactly the state they were revoked from**,
+including `Confirmed` with the wrapped org key intact and no re-confirmation. That
+is the intended deprovision/reprovision behaviour, but it has a consequence worth
+stating plainly:
+
+- **A member revoked in the web vault will be silently re-activated on the next
+  sync if the IdP still shows them active.** SCIM cannot tell a security-motivated
+  admin revocation apart from an Entra-driven one; the IdP is the source of truth.
+  Offboarding must therefore be driven from the IdP (unassign or disable the user
+  there), not only by revoking in the vault.
+- The revoke-only DELETE means a leaked SCIM token cannot *destroy* memberships,
+  but the same token **can reinstate** any member the org previously confirmed and
+  later revoked, gated only by organization policy. Treat the per-org token as an
+  access-reinstatement credential, not merely an invite/deprovision one, when
+  scoping its exposure. Rotate it (management endpoint) if it may have leaked.
 
 ## Test strategy
 
@@ -212,6 +237,14 @@ never-dropped pool (sqlite WAL locking).
 
 Covered end to end: the full provision / deprovision / restore lifecycle at
 every status offset (`-126`, `-127`, `-128`), duplicate and last-owner
-conflicts, uniform-401 byte-equality, enumeration shape, Entra PATCH quirks
-(op casing, string booleans, path-less values, filter-path member removal),
-pagination edges, and the rate limiter.
+conflicts, uniform-401 byte-equality (including a disabled key row with the
+correct secret), enumeration shape, Entra PATCH quirks (op casing, string
+booleans, path-less values, filter-path member removal), pagination edges,
+the rate limiter, group externalId uniqueness on PUT and PATCH, and the
+omitted-versus-empty `members` distinction on group PUT. Token minting is
+exercised through the real management path: the tests mint via
+`manage::mint_scim_token` (the same function the endpoint calls), assert the
+round-trip through the guard, and assert rotation kills the previous token.
+The provisioning rollback rules are pinned directly: a pre-existing account
+survives a failed provision (only the new membership is removed), while a
+shell account created by the failed request is removed entirely.

--- a/migrations/mysql/2026-07-19-000000_add_scim_api_key/down.sql
+++ b/migrations/mysql/2026-07-19-000000_add_scim_api_key/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE scim_api_key;

--- a/migrations/mysql/2026-07-19-000000_add_scim_api_key/up.sql
+++ b/migrations/mysql/2026-07-19-000000_add_scim_api_key/up.sql
@@ -1,8 +1,12 @@
+-- org_uuid is VARCHAR(40) to match organizations.uuid exactly; the FOREIGN KEY
+-- must be a table-level clause because MySQL silently ignores inline
+-- column-level REFERENCES.
 CREATE TABLE scim_api_key (
 	uuid            CHAR(36) NOT NULL PRIMARY KEY,
-	org_uuid        CHAR(36) NOT NULL UNIQUE REFERENCES organizations(uuid),
+	org_uuid        VARCHAR(40) NOT NULL UNIQUE,
 	key_hash        VARCHAR(255) NOT NULL,
 	enabled         BOOLEAN NOT NULL DEFAULT TRUE,
 	created_at      DATETIME NOT NULL,
-	revision_date   DATETIME NOT NULL
+	revision_date   DATETIME NOT NULL,
+	FOREIGN KEY(org_uuid) REFERENCES organizations(uuid)
 );

--- a/migrations/mysql/2026-07-19-000000_add_scim_api_key/up.sql
+++ b/migrations/mysql/2026-07-19-000000_add_scim_api_key/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE scim_api_key (
+	uuid            CHAR(36) NOT NULL PRIMARY KEY,
+	org_uuid        CHAR(36) NOT NULL UNIQUE REFERENCES organizations(uuid),
+	key_hash        VARCHAR(255) NOT NULL,
+	enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+	created_at      DATETIME NOT NULL,
+	revision_date   DATETIME NOT NULL
+);

--- a/migrations/postgresql/2026-07-19-000000_add_scim_api_key/down.sql
+++ b/migrations/postgresql/2026-07-19-000000_add_scim_api_key/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE scim_api_key;

--- a/migrations/postgresql/2026-07-19-000000_add_scim_api_key/up.sql
+++ b/migrations/postgresql/2026-07-19-000000_add_scim_api_key/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE scim_api_key (
+	uuid            CHAR(36) NOT NULL PRIMARY KEY,
+	org_uuid        CHAR(36) NOT NULL UNIQUE REFERENCES organizations(uuid),
+	key_hash        TEXT NOT NULL,
+	enabled         BOOLEAN NOT NULL DEFAULT true,
+	created_at      TIMESTAMP NOT NULL,
+	revision_date   TIMESTAMP NOT NULL
+);

--- a/migrations/sqlite/2026-07-19-000000_add_scim_api_key/down.sql
+++ b/migrations/sqlite/2026-07-19-000000_add_scim_api_key/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE scim_api_key;

--- a/migrations/sqlite/2026-07-19-000000_add_scim_api_key/up.sql
+++ b/migrations/sqlite/2026-07-19-000000_add_scim_api_key/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE scim_api_key (
+	uuid            TEXT NOT NULL PRIMARY KEY,
+	org_uuid        TEXT NOT NULL UNIQUE,
+	key_hash        TEXT NOT NULL,
+	enabled         BOOLEAN NOT NULL DEFAULT 1,
+	created_at      DATETIME NOT NULL,
+	revision_date   DATETIME NOT NULL,
+	FOREIGN KEY(org_uuid) REFERENCES organizations(uuid)
+);

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -47,6 +47,7 @@ pub fn routes() -> Vec<Route> {
     routes.append(&mut two_factor::routes());
     routes.append(&mut sends::routes());
     routes.append(&mut public::routes());
+    routes.append(&mut crate::api::scim::manage_routes());
     routes.append(&mut eq_domains_routes);
     routes.append(&mut hibp_routes);
     routes.append(&mut meta_routes);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,7 @@ mod icons;
 mod identity;
 mod notifications;
 mod push;
+pub mod scim;
 mod web;
 
 use rocket::serde::json::Json;
@@ -28,6 +29,8 @@ pub use crate::api::{
         push_cipher_update, push_folder_update, push_logout, push_send_update, push_user_update, register_push_device,
         unregister_push_device,
     },
+    scim::catchers as scim_catchers,
+    scim::routes as scim_routes,
     web::catchers as web_catchers,
     web::routes as web_routes,
     web::static_files,

--- a/src/api/scim/discovery.rs
+++ b/src/api/scim/discovery.rs
@@ -1,0 +1,109 @@
+//
+// SCIM discovery endpoints, RFC 7643 section 5 and RFC 7644 section 4.
+//
+// Static metadata, served behind the ScimToken guard like everything else
+// under /scim. Entra ID does not require these for Test Connection (that only
+// needs a 200 ListResponse on a userName filter), but other SCIM clients read
+// them, and they are cheap.
+//
+use rocket::Route;
+use serde_json::Value;
+
+use crate::{
+    CONFIG,
+    api::scim::{ScimResponse, guard::ScimToken},
+    db::models::OrganizationId,
+};
+
+pub fn routes() -> Vec<Route> {
+    routes![service_provider_config, resource_types, schemas]
+}
+
+const LIST_RESPONSE_URN: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+pub const USER_SCHEMA_URN: &str = "urn:ietf:params:scim:schemas:core:2.0:User";
+pub const GROUP_SCHEMA_URN: &str = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
+fn scim_base(org_id: &OrganizationId) -> String {
+    format!("{}/scim/v2/{org_id}", CONFIG.domain())
+}
+
+fn list_response(resources: &[Value]) -> Value {
+    json!({
+        "schemas": [LIST_RESPONSE_URN],
+        "totalResults": resources.len(),
+        "itemsPerPage": resources.len(),
+        "startIndex": 1,
+        "Resources": resources,
+    })
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "Rocket request guards are taken by value")]
+#[get("/v2/<_>/ServiceProviderConfig")]
+fn service_provider_config(token: ScimToken) -> ScimResponse {
+    ScimResponse::ok(json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+        "documentationUri": "https://github.com/croftinator/vaultwarden-scim-v2",
+        "patch": { "supported": true },
+        "bulk": { "supported": false, "maxOperations": 0, "maxPayloadSize": 0 },
+        "filter": { "supported": true, "maxResults": 200 },
+        "changePassword": { "supported": false },
+        "sort": { "supported": false },
+        "etag": { "supported": false },
+        "authenticationSchemes": [{
+            "type": "oauthbearertoken",
+            "name": "OAuth Bearer Token",
+            "description": "Static bearer token generated per organization",
+            "primary": true,
+        }],
+        "meta": {
+            "resourceType": "ServiceProviderConfig",
+            "location": format!("{}/ServiceProviderConfig", scim_base(&token.org_uuid)),
+        },
+    }))
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "Rocket request guards are taken by value")]
+#[get("/v2/<_>/ResourceTypes")]
+fn resource_types(token: ScimToken) -> ScimResponse {
+    let base = scim_base(&token.org_uuid);
+    ScimResponse::ok(list_response(&[
+        json!({
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+            "id": "User",
+            "name": "User",
+            "endpoint": "/Users",
+            "description": "Organization member",
+            "schema": USER_SCHEMA_URN,
+            "meta": { "resourceType": "ResourceType", "location": format!("{base}/ResourceTypes/User") },
+        }),
+        json!({
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+            "id": "Group",
+            "name": "Group",
+            "endpoint": "/Groups",
+            "description": "Organization group",
+            "schema": GROUP_SCHEMA_URN,
+            "meta": { "resourceType": "ResourceType", "location": format!("{base}/ResourceTypes/Group") },
+        }),
+    ]))
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "Rocket request guards are taken by value")]
+#[get("/v2/<_>/Schemas")]
+fn schemas(token: ScimToken) -> ScimResponse {
+    let base = scim_base(&token.org_uuid);
+    ScimResponse::ok(list_response(&[
+        json!({
+            "id": USER_SCHEMA_URN,
+            "name": "User",
+            "description": "SCIM core User. Supported attributes: userName, externalId, name, displayName, emails, active.",
+            "meta": { "resourceType": "Schema", "location": format!("{base}/Schemas/{USER_SCHEMA_URN}") },
+        }),
+        json!({
+            "id": GROUP_SCHEMA_URN,
+            "name": "Group",
+            "description": "SCIM core Group. Supported attributes: displayName, externalId, members.",
+            "meta": { "resourceType": "Schema", "location": format!("{base}/Schemas/{GROUP_SCHEMA_URN}") },
+        }),
+    ]))
+}

--- a/src/api/scim/discovery.rs
+++ b/src/api/scim/discovery.rs
@@ -19,7 +19,7 @@ pub fn routes() -> Vec<Route> {
     routes![service_provider_config, resource_types, schemas]
 }
 
-const LIST_RESPONSE_URN: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+pub(crate) const LIST_RESPONSE_URN: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
 pub const USER_SCHEMA_URN: &str = "urn:ietf:params:scim:schemas:core:2.0:User";
 pub const GROUP_SCHEMA_URN: &str = "urn:ietf:params:scim:schemas:core:2.0:Group";
 
@@ -45,7 +45,7 @@ fn service_provider_config(token: ScimToken) -> ScimResponse {
         "documentationUri": "https://github.com/croftinator/vaultwarden-scim-v2",
         "patch": { "supported": true },
         "bulk": { "supported": false, "maxOperations": 0, "maxPayloadSize": 0 },
-        "filter": { "supported": true, "maxResults": 200 },
+        "filter": { "supported": true, "maxResults": crate::api::scim::SCIM_MAX_RESULTS },
         "changePassword": { "supported": false },
         "sort": { "supported": false },
         "etag": { "supported": false },

--- a/src/api/scim/error.rs
+++ b/src/api/scim/error.rs
@@ -72,6 +72,14 @@ impl ScimError {
         }
     }
 
+    pub fn not_implemented(detail: &str) -> Self {
+        Self {
+            status: Status::NotImplemented,
+            scim_type: None,
+            detail: String::from(detail),
+        }
+    }
+
     pub fn internal() -> Self {
         Self {
             status: Status::InternalServerError,

--- a/src/api/scim/error.rs
+++ b/src/api/scim/error.rs
@@ -40,6 +40,22 @@ impl ScimError {
         }
     }
 
+    pub fn conflict(scim_type: &'static str, detail: &str) -> Self {
+        Self {
+            status: Status::Conflict,
+            scim_type: Some(scim_type),
+            detail: String::from(detail),
+        }
+    }
+
+    pub fn payload_too_large() -> Self {
+        Self {
+            status: Status::PayloadTooLarge,
+            scim_type: None,
+            detail: String::from("Payload too large"),
+        }
+    }
+
     pub fn not_found() -> Self {
         Self {
             status: Status::NotFound,

--- a/src/api/scim/error.rs
+++ b/src/api/scim/error.rs
@@ -1,0 +1,93 @@
+//
+// SCIM error envelope, RFC 7644 section 3.12.
+//
+// Every error leaving the /scim mount must use this shape. Auth failures are
+// deliberately uniform: the guard logs the specific cause server-side and the
+// caller always receives the same 401 body, so responses carry no signal about
+// which check failed.
+//
+use std::io::Cursor;
+
+use rocket::{
+    http::{ContentType, Status},
+    request::Request,
+    response::{self, Responder, Response},
+};
+
+pub const SCIM_ERROR_URN: &str = "urn:ietf:params:scim:api:messages:2.0:Error";
+
+#[derive(Debug)]
+pub struct ScimError {
+    pub status: Status,
+    pub scim_type: Option<&'static str>,
+    pub detail: String,
+}
+
+impl ScimError {
+    pub fn unauthorized() -> Self {
+        Self {
+            status: Status::Unauthorized,
+            scim_type: None,
+            detail: String::from("Unauthorized"),
+        }
+    }
+
+    pub fn too_many_requests() -> Self {
+        Self {
+            status: Status::TooManyRequests,
+            scim_type: None,
+            detail: String::from("Too many requests"),
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self {
+            status: Status::NotFound,
+            scim_type: None,
+            detail: String::from("Resource not found"),
+        }
+    }
+
+    pub fn bad_request(scim_type: &'static str, detail: &str) -> Self {
+        Self {
+            status: Status::BadRequest,
+            scim_type: Some(scim_type),
+            detail: String::from(detail),
+        }
+    }
+
+    pub fn internal() -> Self {
+        Self {
+            status: Status::InternalServerError,
+            scim_type: None,
+            detail: String::from("Internal server error"),
+        }
+    }
+
+    fn body(&self) -> String {
+        let mut body = json!({
+            "schemas": [SCIM_ERROR_URN],
+            "status": self.status.code.to_string(),
+            "detail": self.detail,
+        });
+        if let Some(scim_type) = self.scim_type {
+            body["scimType"] = json!(scim_type);
+        }
+        body.to_string()
+    }
+}
+
+pub fn scim_content_type() -> ContentType {
+    ContentType::new("application", "scim+json")
+}
+
+impl Responder<'_, 'static> for ScimError {
+    fn respond_to(self, _: &Request<'_>) -> response::Result<'static> {
+        let body = self.body();
+        Response::build()
+            .status(self.status)
+            .header(scim_content_type())
+            .sized_body(Some(body.len()), Cursor::new(body))
+            .ok()
+    }
+}

--- a/src/api/scim/filter.rs
+++ b/src/api/scim/filter.rs
@@ -1,0 +1,93 @@
+//
+// Minimal SCIM filter parser, RFC 7644 section 3.4.2.2.
+//
+// Only the form Entra uses for existence checks is supported:
+//     attribute eq "value"
+// Anything else (and/or, co, sw, grouping, valuePath) is rejected with
+// scimType invalidFilter. That is the correct signal for a partially
+// supported filter grammar; 501 would claim filtering is entirely absent.
+//
+use crate::api::scim::error::ScimError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EqFilter {
+    // Lowercased: SCIM attribute names are case-insensitive (RFC 7643 s2.1).
+    pub attribute: String,
+    pub value: String,
+}
+
+pub fn parse_eq_filter(raw: &str) -> Result<EqFilter, ScimError> {
+    let unsupported =
+        || ScimError::bad_request("invalidFilter", "Only filters of the form `attr eq \"value\"` are supported");
+
+    let trimmed = raw.trim();
+    // Split "attr eq "value"" on whitespace, keeping the quoted tail intact.
+    let (attribute, rest) = trimmed.split_once(char::is_whitespace).ok_or_else(unsupported)?;
+    let rest = rest.trim_start();
+    let (operator, rest) = rest.split_once(char::is_whitespace).ok_or_else(unsupported)?;
+    if !operator.eq_ignore_ascii_case("eq") {
+        return Err(unsupported());
+    }
+
+    let quoted = rest.trim();
+    let value = quoted.strip_prefix('"').and_then(|v| v.strip_suffix('"')).ok_or_else(unsupported)?;
+    if value.contains('"') || attribute.is_empty() || value.is_empty() {
+        return Err(unsupported());
+    }
+
+    Ok(EqFilter {
+        attribute: attribute.to_lowercase(),
+        value: value.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: &str) -> Result<EqFilter, ScimError> {
+        parse_eq_filter(raw)
+    }
+
+    #[test]
+    fn parses_username_eq() {
+        let f = parse("userName eq \"john@example.com\"").expect("valid filter");
+        assert_eq!(f.attribute, "username");
+        assert_eq!(f.value, "john@example.com");
+    }
+
+    #[test]
+    fn parses_externalid_eq_case_insensitive_attr_and_op() {
+        let f = parse("ExternalId EQ \"abc-123\"").expect("valid filter");
+        assert_eq!(f.attribute, "externalid");
+        assert_eq!(f.value, "abc-123");
+    }
+
+    #[test]
+    fn value_may_contain_spaces() {
+        let f = parse("displayName eq \"Jane van Der Berg\"").expect("valid filter");
+        assert_eq!(f.value, "Jane van Der Berg");
+    }
+
+    #[test]
+    fn rejects_unsupported_grammar() {
+        for raw in [
+            "",
+            "userName",
+            "userName eq",
+            "userName eq unquoted",
+            "userName co \"x\"",
+            "userName sw \"x\"",
+            "userName eq \"a\" and active eq true",
+            "emails[type eq \"work\"].value eq \"x\"",
+            "userName eq \"broken",
+            "userName eq \"\"",
+        ] {
+            let result = parse(raw);
+            match result {
+                Err(e) => assert_eq!(e.scim_type, Some("invalidFilter"), "wrong scimType for {raw:?}"),
+                Ok(f) => panic!("filter {raw:?} unexpectedly parsed to {f:?}"),
+            }
+        }
+    }
+}

--- a/src/api/scim/groups.rs
+++ b/src/api/scim/groups.rs
@@ -20,7 +20,7 @@ use crate::{
     api::{
         core::log_event,
         scim::{
-            ScimJson, ScimResponse,
+            SCIM_ACTOR, SCIM_DEVICE_TYPE, ScimJson, ScimResponse,
             error::ScimError,
             filter::parse_eq_filter,
             guard::ScimToken,
@@ -36,9 +36,6 @@ use crate::{
 pub fn routes() -> Vec<Route> {
     routes![list_groups, get_group, post_group, put_group, patch_group, delete_group]
 }
-
-const SCIM_ACTOR: &str = "vaultwarden-scim-00000-000000000000";
-const SCIM_DEVICE_TYPE: i32 = 14;
 
 fn check_groups_enabled() -> Result<(), ScimError> {
     if !CONFIG.org_groups_enabled() {
@@ -58,12 +55,14 @@ struct ScimGroupMember {
 struct ScimGroupRequest {
     display_name: Option<String>,
     external_id: Option<String>,
+    // None (attribute omitted) and Some(vec![]) are different on PUT: an
+    // omitted member list leaves membership unchanged, an empty one clears it.
     #[serde(default)]
-    members: Vec<ScimGroupMember>,
+    members: Option<Vec<ScimGroupMember>>,
 }
 
 async fn to_scim_group(group: &Group, token: &ScimToken, include_members: bool, conn: &DbConn) -> Value {
-    let location = format!("{}/scim/v2/{}/Groups/{}", CONFIG.domain(), token.org_uuid, group.uuid);
+    let location = crate::api::scim::resource_location(&token.org_uuid, "Groups", &group.uuid);
     let mut body = json!({
         "schemas": [crate::api::scim::discovery::GROUP_SCHEMA_URN],
         "id": group.uuid,
@@ -85,17 +84,9 @@ async fn to_scim_group(group: &Group, token: &ScimToken, include_members: bool, 
     body
 }
 
-async fn log_group_event(event_type: EventType, group: &Group, token: &ScimToken, conn: &DbConn) {
-    log_event(
-        event_type as i32,
-        &group.uuid,
-        &token.org_uuid,
-        &SCIM_ACTOR.into(),
-        SCIM_DEVICE_TYPE,
-        &token.ip.ip,
-        conn,
-    )
-    .await;
+async fn log_group_event(event_type: EventType, group_uuid: &GroupId, token: &ScimToken, conn: &DbConn) {
+    log_event(event_type as i32, group_uuid, &token.org_uuid, &SCIM_ACTOR.into(), SCIM_DEVICE_TYPE, &token.ip.ip, conn)
+        .await;
 }
 
 // Resolves a SCIM member value to a membership of THIS org, or a 400: group
@@ -108,6 +99,23 @@ async fn resolve_member(value: &str, token: &ScimToken, conn: &DbConn) -> Result
             "invalidValue",
             "members must reference existing members of this organization (provision the user first)",
         )),
+    }
+}
+
+// The externalId is the correlation key: enforce uniqueness within the org on
+// every write path, mirroring the Users endpoints. Re-asserting the group's
+// own current externalId is allowed (Entra repeats it on PUT).
+async fn check_external_id_available(
+    group: &Group,
+    external_id: &str,
+    token: &ScimToken,
+    conn: &DbConn,
+) -> Result<(), ScimError> {
+    match Group::find_by_external_id_and_org(external_id, &token.org_uuid, conn).await {
+        Some(existing) if existing.uuid != group.uuid => {
+            Err(ScimError::conflict("uniqueness", "A group with this externalId already exists"))
+        }
+        _ => Ok(()),
     }
 }
 
@@ -166,21 +174,14 @@ async fn list_groups(params: GroupListParams, token: ScimToken, conn: DbConn) ->
     let include_members = !params.excluded_attributes.as_deref().is_some_and(|excluded| excluded.contains("members"));
 
     let total = groups.len();
-    let start_index = usize::try_from(params.start_index.unwrap_or(1)).unwrap_or(1).max(1);
-    let count = usize::try_from(params.count.unwrap_or(100)).unwrap_or(0).min(200);
+    let (start_index, count) = crate::api::scim::page_bounds(params.start_index, params.count);
 
     let mut resources = Vec::new();
     for group in groups.into_iter().skip(start_index - 1).take(count) {
         resources.push(to_scim_group(&group, &token, include_members, &conn).await);
     }
 
-    Ok(ScimResponse::ok(json!({
-        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-        "totalResults": total,
-        "itemsPerPage": resources.len(),
-        "startIndex": start_index,
-        "Resources": resources,
-    })))
+    Ok(crate::api::scim::list_response(total, start_index, &resources))
 }
 
 #[get("/v2/<_>/Groups/<group_id>")]
@@ -212,9 +213,11 @@ async fn post_group(
     }
 
     // Resolve members before creating anything, so a bad member list cannot
-    // leave a half-created group behind.
-    let mut member_ids = Vec::with_capacity(request.members.len());
-    for member in &request.members {
+    // leave a half-created group behind. On create, omitted members and an
+    // empty list mean the same thing: a group with no members.
+    let request_members = request.members.as_deref().unwrap_or_default();
+    let mut member_ids = Vec::with_capacity(request_members.len());
+    for member in request_members {
         member_ids.push(resolve_member(&member.value, &token, &conn).await?);
     }
 
@@ -222,14 +225,17 @@ async fn post_group(
     group.save(&conn).await.map_err(|_| ScimError::internal())?;
     set_members(&group, member_ids, &token, &conn).await?;
 
-    log_group_event(EventType::GroupCreated, &group, &token, &conn).await;
+    log_group_event(EventType::GroupCreated, &group.uuid, &token, &conn).await;
 
-    let location = format!("{}/scim/v2/{}/Groups/{}", CONFIG.domain(), token.org_uuid, group.uuid);
+    let location = crate::api::scim::resource_location(&token.org_uuid, "Groups", &group.uuid);
     let body = to_scim_group(&group, &token, true, &conn).await;
     Ok(ScimResponse::created(location, body))
 }
 
-// PUT is a full replacement: displayName, externalId, and the member set.
+// PUT replaces the attributes it carries: displayName, externalId, and the
+// member set. members omitted (as opposed to explicitly empty) leaves the
+// member set unchanged, so a sparse non-Entra client cannot wipe a group by
+// accident; Entra always sends the full member list.
 #[put("/v2/<_>/Groups/<group_id>", data = "<data>")]
 async fn put_group(
     group_id: GroupId,
@@ -243,9 +249,20 @@ async fn put_group(
     };
     let request = data.0;
 
-    let mut member_ids = Vec::with_capacity(request.members.len());
-    for member in &request.members {
-        member_ids.push(resolve_member(&member.value, &token, &conn).await?);
+    // Resolve everything before writing anything, so a bad member list or a
+    // conflicting externalId cannot leave a half-applied replacement behind.
+    let member_ids = match request.members.as_deref() {
+        Some(members) => {
+            let mut ids = Vec::with_capacity(members.len());
+            for member in members {
+                ids.push(resolve_member(&member.value, &token, &conn).await?);
+            }
+            Some(ids)
+        }
+        None => None,
+    };
+    if let Some(external_id) = request.external_id.as_deref() {
+        check_external_id_available(&group, external_id, &token, &conn).await?;
     }
 
     if let Some(display_name) = request.display_name.as_deref().filter(|n| !n.trim().is_empty()) {
@@ -255,9 +272,11 @@ async fn put_group(
         group.set_external_id(request.external_id.clone());
     }
     group.save(&conn).await.map_err(|_| ScimError::internal())?;
-    set_members(&group, member_ids, &token, &conn).await?;
+    if let Some(member_ids) = member_ids {
+        set_members(&group, member_ids, &token, &conn).await?;
+    }
 
-    log_group_event(EventType::GroupUpdated, &group, &token, &conn).await;
+    log_group_event(EventType::GroupUpdated, &group.uuid, &token, &conn).await;
 
     Ok(ScimResponse::ok(to_scim_group(&group, &token, true, &conn).await))
 }
@@ -276,12 +295,19 @@ async fn patch_group(
 
     let patch = parse_group_patch(&data.0)?;
 
-    if let Some(display_name) = patch.display_name.as_deref().filter(|n| !n.trim().is_empty()) {
+    if let Some(external_id) = patch.external_id.as_deref() {
+        check_external_id_available(&group, external_id, &token, &conn).await?;
+    }
+
+    let new_name = patch.display_name.as_deref().filter(|n| !n.trim().is_empty());
+    if let Some(display_name) = new_name {
         group.name = display_name.to_owned();
-        group.save(&conn).await.map_err(|_| ScimError::internal())?;
     }
     if let Some(external_id) = patch.external_id.clone() {
         group.set_external_id(Some(external_id));
+    }
+    // One save covers both owned attributes; skip the write for member-only patches.
+    if new_name.is_some() || patch.external_id.is_some() {
         group.save(&conn).await.map_err(|_| ScimError::internal())?;
     }
 
@@ -309,7 +335,7 @@ async fn patch_group(
         }
     }
 
-    log_group_event(EventType::GroupUpdated, &group, &token, &conn).await;
+    log_group_event(EventType::GroupUpdated, &group.uuid, &token, &conn).await;
 
     Ok(ScimResponse::ok(to_scim_group(&group, &token, true, &conn).await))
 }
@@ -323,7 +349,10 @@ async fn delete_group(group_id: GroupId, token: ScimToken, conn: DbConn) -> Resu
     let Some(group) = Group::find_by_uuid_and_org(&group_id, &token.org_uuid, &conn).await else {
         return Err(ScimError::not_found());
     };
-    log_group_event(EventType::GroupDeleted, &group, &token, &conn).await;
+    let group_uuid = group.uuid.clone();
     group.delete(&token.org_uuid, &conn).await.map_err(|_| ScimError::internal())?;
+    // Log only after the delete succeeds, so the audit log never claims a
+    // deletion that failed.
+    log_group_event(EventType::GroupDeleted, &group_uuid, &token, &conn).await;
     Ok(ScimResponse::no_content())
 }

--- a/src/api/scim/groups.rs
+++ b/src/api/scim/groups.rs
@@ -1,0 +1,329 @@
+//
+// SCIM /Groups endpoints. The SCIM Group id is Vaultwarden's GroupId, and
+// member values are MembershipIds (the same ids the /Users endpoints expose),
+// which is why User provisioning must precede Group assignment.
+//
+// SCIM owns group existence and membership only. Collection access stays an
+// in-app admin decision: the IdP decides who is in a group, the vault admin
+// decides what the group can see.
+//
+// Requires ORG_GROUPS_ENABLED. Unlike ldap_import, which silently skips
+// groups when disabled, these endpoints fail loudly so a misconfigured
+// deployment is visible in the IdP instead of quietly not syncing.
+//
+use rocket::Route;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    CONFIG,
+    api::{
+        core::log_event,
+        scim::{
+            ScimJson, ScimResponse,
+            error::ScimError,
+            filter::parse_eq_filter,
+            guard::ScimToken,
+            patch::{PatchOp, parse_group_patch},
+        },
+    },
+    db::{
+        DbConn,
+        models::{EventType, Group, GroupId, GroupUser, Membership, MembershipId},
+    },
+};
+
+pub fn routes() -> Vec<Route> {
+    routes![list_groups, get_group, post_group, put_group, patch_group, delete_group]
+}
+
+const SCIM_ACTOR: &str = "vaultwarden-scim-00000-000000000000";
+const SCIM_DEVICE_TYPE: i32 = 14;
+
+fn check_groups_enabled() -> Result<(), ScimError> {
+    if !CONFIG.org_groups_enabled() {
+        return Err(ScimError::not_implemented("Group support is disabled on this server (ORG_GROUPS_ENABLED=false)"));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScimGroupMember {
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScimGroupRequest {
+    display_name: Option<String>,
+    external_id: Option<String>,
+    #[serde(default)]
+    members: Vec<ScimGroupMember>,
+}
+
+async fn to_scim_group(group: &Group, token: &ScimToken, include_members: bool, conn: &DbConn) -> Value {
+    let location = format!("{}/scim/v2/{}/Groups/{}", CONFIG.domain(), token.org_uuid, group.uuid);
+    let mut body = json!({
+        "schemas": [crate::api::scim::discovery::GROUP_SCHEMA_URN],
+        "id": group.uuid,
+        "externalId": group.external_id,
+        "displayName": group.name,
+        "meta": {
+            "resourceType": "Group",
+            "location": location,
+        },
+    });
+    if include_members {
+        let members: Vec<Value> = GroupUser::find_by_group(&group.uuid, &token.org_uuid, conn)
+            .await
+            .iter()
+            .map(|gu| json!({"value": gu.users_organizations_uuid}))
+            .collect();
+        body["members"] = json!(members);
+    }
+    body
+}
+
+async fn log_group_event(event_type: EventType, group: &Group, token: &ScimToken, conn: &DbConn) {
+    log_event(
+        event_type as i32,
+        &group.uuid,
+        &token.org_uuid,
+        &SCIM_ACTOR.into(),
+        SCIM_DEVICE_TYPE,
+        &token.ip.ip,
+        conn,
+    )
+    .await;
+}
+
+// Resolves a SCIM member value to a membership of THIS org, or a 400: group
+// assignment requires the user to be provisioned into the org first.
+async fn resolve_member(value: &str, token: &ScimToken, conn: &DbConn) -> Result<MembershipId, ScimError> {
+    let member_id: MembershipId = value.to_owned().into();
+    match Membership::find_by_uuid_and_org(&member_id, &token.org_uuid, conn).await {
+        Some(member) => Ok(member.uuid),
+        None => Err(ScimError::bad_request(
+            "invalidValue",
+            "members must reference existing members of this organization (provision the user first)",
+        )),
+    }
+}
+
+async fn set_members(
+    group: &Group,
+    member_ids: Vec<MembershipId>,
+    token: &ScimToken,
+    conn: &DbConn,
+) -> Result<(), ScimError> {
+    GroupUser::delete_all_by_group(&group.uuid, &token.org_uuid, conn).await.map_err(|_| ScimError::internal())?;
+    for member_id in member_ids {
+        let mut group_user = GroupUser::new(group.uuid.clone(), member_id);
+        group_user.save(conn).await.map_err(|_| ScimError::internal())?;
+    }
+    Ok(())
+}
+
+#[derive(FromForm)]
+pub struct GroupListParams {
+    filter: Option<String>,
+    #[field(name = "startIndex")]
+    start_index: Option<i64>,
+    count: Option<i64>,
+    #[field(name = "excludedAttributes")]
+    excluded_attributes: Option<String>,
+}
+
+#[get("/v2/<_>/Groups?<params..>")]
+async fn list_groups(params: GroupListParams, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+
+    let groups: Vec<Group> = if let Some(raw_filter) = params.filter.as_deref() {
+        let eq = parse_eq_filter(raw_filter)?;
+        match eq.attribute.as_str() {
+            "displayname" => Group::find_by_organization(&token.org_uuid, &conn)
+                .await
+                .into_iter()
+                .filter(|g| g.name == eq.value)
+                .collect(),
+            "externalid" => {
+                Group::find_by_external_id_and_org(&eq.value, &token.org_uuid, &conn).await.into_iter().collect()
+            }
+            _ => {
+                return Err(ScimError::bad_request(
+                    "invalidFilter",
+                    "Filterable attributes are displayName and externalId",
+                ));
+            }
+        }
+    } else {
+        Group::find_by_organization(&token.org_uuid, &conn).await
+    };
+
+    // Entra requests excludedAttributes=members on list syncs; honoring it
+    // avoids loading every group's member set.
+    let include_members = !params.excluded_attributes.as_deref().is_some_and(|excluded| excluded.contains("members"));
+
+    let total = groups.len();
+    let start_index = usize::try_from(params.start_index.unwrap_or(1)).unwrap_or(1).max(1);
+    let count = usize::try_from(params.count.unwrap_or(100)).unwrap_or(0).min(200);
+
+    let mut resources = Vec::new();
+    for group in groups.into_iter().skip(start_index - 1).take(count) {
+        resources.push(to_scim_group(&group, &token, include_members, &conn).await);
+    }
+
+    Ok(ScimResponse::ok(json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        "totalResults": total,
+        "itemsPerPage": resources.len(),
+        "startIndex": start_index,
+        "Resources": resources,
+    })))
+}
+
+#[get("/v2/<_>/Groups/<group_id>")]
+async fn get_group(group_id: GroupId, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+    let Some(group) = Group::find_by_uuid_and_org(&group_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    Ok(ScimResponse::ok(to_scim_group(&group, &token, true, &conn).await))
+}
+
+#[post("/v2/<_>/Groups", data = "<data>")]
+async fn post_group(
+    data: ScimJson<ScimGroupRequest>,
+    token: ScimToken,
+    conn: DbConn,
+) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+    let request = data.0;
+
+    let Some(display_name) = request.display_name.as_deref().filter(|n| !n.trim().is_empty()) else {
+        return Err(ScimError::bad_request("invalidValue", "displayName is required"));
+    };
+
+    if let Some(external_id) = request.external_id.as_deref()
+        && Group::find_by_external_id_and_org(external_id, &token.org_uuid, &conn).await.is_some()
+    {
+        return Err(ScimError::conflict("uniqueness", "A group with this externalId already exists"));
+    }
+
+    // Resolve members before creating anything, so a bad member list cannot
+    // leave a half-created group behind.
+    let mut member_ids = Vec::with_capacity(request.members.len());
+    for member in &request.members {
+        member_ids.push(resolve_member(&member.value, &token, &conn).await?);
+    }
+
+    let mut group = Group::new(token.org_uuid.clone(), display_name.to_owned(), false, request.external_id.clone());
+    group.save(&conn).await.map_err(|_| ScimError::internal())?;
+    set_members(&group, member_ids, &token, &conn).await?;
+
+    log_group_event(EventType::GroupCreated, &group, &token, &conn).await;
+
+    let location = format!("{}/scim/v2/{}/Groups/{}", CONFIG.domain(), token.org_uuid, group.uuid);
+    let body = to_scim_group(&group, &token, true, &conn).await;
+    Ok(ScimResponse::created(location, body))
+}
+
+// PUT is a full replacement: displayName, externalId, and the member set.
+#[put("/v2/<_>/Groups/<group_id>", data = "<data>")]
+async fn put_group(
+    group_id: GroupId,
+    data: ScimJson<ScimGroupRequest>,
+    token: ScimToken,
+    conn: DbConn,
+) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+    let Some(mut group) = Group::find_by_uuid_and_org(&group_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    let request = data.0;
+
+    let mut member_ids = Vec::with_capacity(request.members.len());
+    for member in &request.members {
+        member_ids.push(resolve_member(&member.value, &token, &conn).await?);
+    }
+
+    if let Some(display_name) = request.display_name.as_deref().filter(|n| !n.trim().is_empty()) {
+        group.name = display_name.to_owned();
+    }
+    if request.external_id.is_some() {
+        group.set_external_id(request.external_id.clone());
+    }
+    group.save(&conn).await.map_err(|_| ScimError::internal())?;
+    set_members(&group, member_ids, &token, &conn).await?;
+
+    log_group_event(EventType::GroupUpdated, &group, &token, &conn).await;
+
+    Ok(ScimResponse::ok(to_scim_group(&group, &token, true, &conn).await))
+}
+
+#[patch("/v2/<_>/Groups/<group_id>", data = "<data>")]
+async fn patch_group(
+    group_id: GroupId,
+    data: ScimJson<PatchOp>,
+    token: ScimToken,
+    conn: DbConn,
+) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+    let Some(mut group) = Group::find_by_uuid_and_org(&group_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+
+    let patch = parse_group_patch(&data.0)?;
+
+    if let Some(display_name) = patch.display_name.as_deref().filter(|n| !n.trim().is_empty()) {
+        group.name = display_name.to_owned();
+        group.save(&conn).await.map_err(|_| ScimError::internal())?;
+    }
+    if let Some(external_id) = patch.external_id.clone() {
+        group.set_external_id(Some(external_id));
+        group.save(&conn).await.map_err(|_| ScimError::internal())?;
+    }
+
+    if let Some(replacement) = patch.replace_members {
+        let mut member_ids = Vec::with_capacity(replacement.len());
+        for value in &replacement {
+            member_ids.push(resolve_member(value, &token, &conn).await?);
+        }
+        set_members(&group, member_ids, &token, &conn).await?;
+    } else {
+        // True diff semantics: adds insert (idempotently via replace_into in
+        // GroupUser::save), removes delete only the listed member links.
+        for value in &patch.add_members {
+            let member_id = resolve_member(value, &token, &conn).await?;
+            let mut group_user = GroupUser::new(group.uuid.clone(), member_id);
+            group_user.save(&conn).await.map_err(|_| ScimError::internal())?;
+        }
+        for value in &patch.remove_members {
+            // Removing a member who is not in the org (or already absent from
+            // the group) is a no-op, not an error: Entra retries removals.
+            let member_id: MembershipId = value.clone().into();
+            GroupUser::delete_by_group_and_member(&group.uuid, &member_id, &conn)
+                .await
+                .map_err(|_| ScimError::internal())?;
+        }
+    }
+
+    log_group_event(EventType::GroupUpdated, &group, &token, &conn).await;
+
+    Ok(ScimResponse::ok(to_scim_group(&group, &token, true, &conn).await))
+}
+
+// Deleting a group only removes an access mapping: it carries no E2EE state
+// (unlike memberships, where delete would destroy the wrapped org key), so a
+// real delete is safe and matches RFC semantics.
+#[delete("/v2/<_>/Groups/<group_id>")]
+async fn delete_group(group_id: GroupId, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    check_groups_enabled()?;
+    let Some(group) = Group::find_by_uuid_and_org(&group_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    log_group_event(EventType::GroupDeleted, &group, &token, &conn).await;
+    group.delete(&token.org_uuid, &conn).await.map_err(|_| ScimError::internal())?;
+    Ok(ScimResponse::no_content())
+}

--- a/src/api/scim/guard.rs
+++ b/src/api/scim/guard.rs
@@ -1,0 +1,142 @@
+//
+// Request guard for the /scim/v2/<org_id> endpoints.
+//
+// The credential is a per-organization static bearer token of the form
+//   scim_v1.<org_uuid>.<secret>
+// as configured in the IdP (Entra ID sends a static "Secret Token"; it cannot
+// drive an OAuth flow, which rules out the short-lived organization api-key
+// JWT used by /api/public). Only the sha256 digest of the secret is stored.
+//
+// Failure behaviour: every rejection logs its specific cause via err_handler!
+// (target "auth", server log only) and surfaces to the caller as a bare 401
+// that the scim catcher turns into one fixed SCIM error body. Rate limiting
+// runs before any parsing so unauthenticated floods are cut off first.
+//
+use rocket::{
+    Request,
+    http::Status,
+    request::{FromRequest, Outcome},
+};
+
+use crate::{
+    CONFIG,
+    auth::ClientIp,
+    db::{
+        DbConn,
+        models::{OrganizationId, ScimApiKey},
+    },
+    ratelimit,
+};
+
+// Digest compared when no key row exists, so a miss costs the same ct_eq as a
+// hit. The DB lookup itself still dominates timing; this is hygiene, not a
+// timing-safety guarantee.
+const DUMMY_DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+// Handlers must scope every query to token.org_uuid, never to a path or body
+// value.
+pub struct ScimToken {
+    pub org_uuid: OrganizationId,
+}
+
+impl ScimToken {
+    // Splits "scim_v1.<org_uuid>.<secret>" into (org_uuid, secret).
+    fn parse_token(token: &str) -> Option<(&str, &str)> {
+        let rest = token.strip_prefix("scim_v1.")?;
+        let (org_uuid, secret) = rest.split_once('.')?;
+        if org_uuid.is_empty() || secret.is_empty() {
+            return None;
+        }
+        Some((org_uuid, secret))
+    }
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for ScimToken {
+    type Error = &'static str;
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let Outcome::Success(ip) = ClientIp::from_request(request).await else {
+            err_handler!("Error getting Client IP")
+        };
+
+        // Rate limit before any parsing or database work.
+        if ratelimit::check_limit_scim(&ip.ip).is_err() {
+            warn!(target: "auth", "SCIM rate limit exceeded. IP: {}", ip.ip);
+            return Outcome::Error((Status::TooManyRequests, "Too many requests"));
+        }
+
+        if !CONFIG.scim_enabled() {
+            err_handler!("SCIM is disabled")
+        }
+
+        let Some(auth_header) = request.headers().get_one("Authorization") else {
+            err_handler!("No access token provided")
+        };
+        let Some(bearer) = auth_header.strip_prefix("Bearer ") else {
+            err_handler!("No access token provided")
+        };
+
+        let Some((token_org, secret)) = Self::parse_token(bearer) else {
+            err_handler!("Malformed SCIM token")
+        };
+
+        // The org embedded in the token must match the org in the request
+        // path, before any database work. Route shape is /v2/<org_id>/...,
+        // so the org id is path parameter index 1.
+        let Some(Ok(path_org)) = request.param::<OrganizationId>(1) else {
+            err_handler!("Missing org_id in path")
+        };
+        if token_org != &*path_org {
+            err_handler!("SCIM token does not match the requested organization", format!("IP: {}", ip.ip))
+        }
+
+        let Outcome::Success(conn) = DbConn::from_request(request).await else {
+            err_handler!("Error getting DB")
+        };
+
+        let org_uuid: OrganizationId = token_org.to_owned().into();
+        let Some(scim_key) = ScimApiKey::find_active_by_org(&org_uuid, &conn).await else {
+            // Burn an equivalent comparison so a missing key row does not
+            // return faster than a wrong secret.
+            let _ = crate::crypto::ct_eq(DUMMY_DIGEST, crate::crypto::sha256_hex(secret.as_bytes()));
+            err_handler!("No active SCIM api key for organization", format!("IP: {}. Organization: {org_uuid}", ip.ip))
+        };
+        if !scim_key.check_valid_secret(secret) {
+            err_handler!("Invalid SCIM token secret", format!("IP: {}. Organization: {org_uuid}", ip.ip))
+        }
+
+        Outcome::Success(ScimToken {
+            org_uuid,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_token_valid() {
+        let parsed = ScimToken::parse_token("scim_v1.11111111-2222-3333-4444-555555555555.some-secret-value");
+        assert_eq!(parsed, Some(("11111111-2222-3333-4444-555555555555", "some-secret-value")));
+    }
+
+    #[test]
+    fn parse_token_secret_may_contain_dots() {
+        // Only the first dot after the org uuid separates; the secret keeps the rest.
+        let parsed = ScimToken::parse_token("scim_v1.org-uuid.part1.part2");
+        assert_eq!(parsed, Some(("org-uuid", "part1.part2")));
+    }
+
+    #[test]
+    fn parse_token_rejects_bad_shapes() {
+        assert_eq!(ScimToken::parse_token(""), None);
+        assert_eq!(ScimToken::parse_token("scim_v1."), None);
+        assert_eq!(ScimToken::parse_token("scim_v1.orgonly"), None);
+        assert_eq!(ScimToken::parse_token("scim_v1..secret"), None);
+        assert_eq!(ScimToken::parse_token("scim_v1.org."), None);
+        assert_eq!(ScimToken::parse_token("scim_v2.org.secret"), None);
+        assert_eq!(ScimToken::parse_token("Bearer scim_v1.org.secret"), None);
+    }
+}

--- a/src/api/scim/guard.rs
+++ b/src/api/scim/guard.rs
@@ -34,9 +34,10 @@ use crate::{
 const DUMMY_DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
 // Handlers must scope every query to token.org_uuid, never to a path or body
-// value.
+// value. The ip is carried for audit logging.
 pub struct ScimToken {
     pub org_uuid: OrganizationId,
+    pub ip: ClientIp,
 }
 
 impl ScimToken {
@@ -108,6 +109,7 @@ impl<'r> FromRequest<'r> for ScimToken {
 
         Outcome::Success(ScimToken {
             org_uuid,
+            ip,
         })
     }
 }

--- a/src/api/scim/manage.rs
+++ b/src/api/scim/manage.rs
@@ -11,12 +11,12 @@ use rocket::{Route, serde::json::Json};
 
 use crate::{
     CONFIG,
-    api::{EmptyResult, JsonResult, PasswordOrOtpData},
+    api::{EmptyResult, JsonResult, PasswordOrOtpData, core::log_event},
     auth::AdminHeaders,
     crypto,
     db::{
         DbConn,
-        models::{OrganizationId, ScimApiKey},
+        models::{EventType, OrganizationId, ScimApiKey},
     },
     util::format_date,
 };
@@ -32,6 +32,44 @@ fn check_scim_enabled() -> EmptyResult {
     Ok(())
 }
 
+// Records a SCIM token management action in the org event log under the acting
+// admin's own identity (this is an interactive, re-authenticated admin action,
+// not a SCIM-driven one, so it does not use the synthetic SCIM actor). The org
+// itself is the event source; OrganizationUpdated is the closest existing type,
+// matching how the admin panel logs org-level configuration changes.
+async fn log_scim_key_event(headers: &AdminHeaders, org_id: &OrganizationId, conn: &DbConn) {
+    log_event(
+        EventType::OrganizationUpdated as i32,
+        org_id,
+        org_id,
+        &headers.user.uuid,
+        headers.device.atype,
+        &headers.ip.ip,
+        conn,
+    )
+    .await;
+}
+
+// The single place a SCIM token is minted. Generates the secret, replaces any
+// existing key row (rotation: the previous token stops working immediately),
+// and returns the full bearer token plus the stored row. The integration
+// tests call this too, so the minted format and the guard's verification
+// cannot drift apart.
+pub(crate) async fn mint_scim_token(
+    org_id: &OrganizationId,
+    conn: &DbConn,
+) -> Result<(String, ScimApiKey), crate::Error> {
+    // 256-bit secret; the stored digest can only be brute-forced, not inverted.
+    let secret = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
+    let key_hash = crypto::sha256_hex(secret.as_bytes());
+
+    ScimApiKey::delete_all_by_organization(org_id, conn).await?;
+    let scim_key = ScimApiKey::new(org_id.clone(), key_hash);
+    scim_key.save(conn).await?;
+
+    Ok((format!("scim_v1.{org_id}.{secret}"), scim_key))
+}
+
 #[post("/organizations/<org_id>/scim/api-key", data = "<data>")]
 async fn generate_scim_key(
     org_id: OrganizationId,
@@ -45,18 +83,12 @@ async fn generate_scim_key(
     check_scim_enabled()?;
     data.into_inner().validate(&headers.user, true, &conn).await?;
 
-    // 256-bit secret; the stored digest can only be brute-forced, not inverted.
-    let secret = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
-    let key_hash = crypto::sha256_hex(secret.as_bytes());
-
-    // Rotation is replacement: any previous key stops working immediately.
-    ScimApiKey::delete_all_by_organization(&org_id, &conn).await?;
-    let scim_key = ScimApiKey::new(org_id.clone(), key_hash);
-    scim_key.save(&conn).await?;
+    let (token, scim_key) = mint_scim_token(&org_id, &conn).await?;
+    log_scim_key_event(&headers, &org_id, &conn).await;
 
     Ok(Json(json!({
         "object": "scim-api-key",
-        "token": format!("scim_v1.{org_id}.{secret}"),
+        "token": token,
         "scimBaseUrl": format!("{}/scim/v2/{org_id}", CONFIG.domain()),
         "revisionDate": format_date(&scim_key.revision_date),
     })))
@@ -74,7 +106,9 @@ async fn delete_scim_key(
     }
     data.into_inner().validate(&headers.user, true, &conn).await?;
 
-    ScimApiKey::delete_all_by_organization(&org_id, &conn).await
+    ScimApiKey::delete_all_by_organization(&org_id, &conn).await?;
+    log_scim_key_event(&headers, &org_id, &conn).await;
+    Ok(())
 }
 
 #[get("/organizations/<org_id>/scim/status")]

--- a/src/api/scim/manage.rs
+++ b/src/api/scim/manage.rs
@@ -1,0 +1,95 @@
+//
+// Management endpoints for the per-organization SCIM api key. These live
+// under /api (not /scim) and require an interactive admin session plus
+// password or OTP re-authentication, mirroring the existing organization
+// api-key rotation endpoints.
+//
+// The plaintext token is returned exactly once, from the generate/rotate
+// call. Only its sha256 digest is stored.
+//
+use rocket::{Route, serde::json::Json};
+
+use crate::{
+    CONFIG,
+    api::{EmptyResult, JsonResult, PasswordOrOtpData},
+    auth::AdminHeaders,
+    crypto,
+    db::{
+        DbConn,
+        models::{OrganizationId, ScimApiKey},
+    },
+    util::format_date,
+};
+
+pub fn routes() -> Vec<Route> {
+    routes![generate_scim_key, delete_scim_key, scim_status]
+}
+
+fn check_scim_enabled() -> EmptyResult {
+    if !CONFIG.scim_enabled() {
+        err!("SCIM support is disabled")
+    }
+    Ok(())
+}
+
+#[post("/organizations/<org_id>/scim/api-key", data = "<data>")]
+async fn generate_scim_key(
+    org_id: OrganizationId,
+    data: Json<PasswordOrOtpData>,
+    headers: AdminHeaders,
+    conn: DbConn,
+) -> JsonResult {
+    if org_id != headers.org_id {
+        err!("Organization not found", "Organization id's do not match");
+    }
+    check_scim_enabled()?;
+    data.into_inner().validate(&headers.user, true, &conn).await?;
+
+    // 256-bit secret; the stored digest can only be brute-forced, not inverted.
+    let secret = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
+    let key_hash = crypto::sha256_hex(secret.as_bytes());
+
+    // Rotation is replacement: any previous key stops working immediately.
+    ScimApiKey::delete_all_by_organization(&org_id, &conn).await?;
+    let scim_key = ScimApiKey::new(org_id.clone(), key_hash);
+    scim_key.save(&conn).await?;
+
+    Ok(Json(json!({
+        "object": "scim-api-key",
+        "token": format!("scim_v1.{org_id}.{secret}"),
+        "scimBaseUrl": format!("{}/scim/v2/{org_id}", CONFIG.domain()),
+        "revisionDate": format_date(&scim_key.revision_date),
+    })))
+}
+
+#[delete("/organizations/<org_id>/scim/api-key", data = "<data>")]
+async fn delete_scim_key(
+    org_id: OrganizationId,
+    data: Json<PasswordOrOtpData>,
+    headers: AdminHeaders,
+    conn: DbConn,
+) -> EmptyResult {
+    if org_id != headers.org_id {
+        err!("Organization not found", "Organization id's do not match");
+    }
+    data.into_inner().validate(&headers.user, true, &conn).await?;
+
+    ScimApiKey::delete_all_by_organization(&org_id, &conn).await
+}
+
+#[get("/organizations/<org_id>/scim/status")]
+async fn scim_status(org_id: OrganizationId, headers: AdminHeaders, conn: DbConn) -> JsonResult {
+    if org_id != headers.org_id {
+        err!("Organization not found", "Organization id's do not match");
+    }
+
+    let scim_key = ScimApiKey::find_by_org(&org_id, &conn).await;
+    Ok(Json(json!({
+        "object": "scim-status",
+        "scimEnabled": CONFIG.scim_enabled(),
+        "keyConfigured": scim_key.is_some(),
+        "keyEnabled": scim_key.as_ref().is_some_and(|k| k.enabled),
+        "createdAt": scim_key.as_ref().map(|k| format_date(&k.created_at)),
+        "revisionDate": scim_key.as_ref().map(|k| format_date(&k.revision_date)),
+    })))
+}

--- a/src/api/scim/mod.rs
+++ b/src/api/scim/mod.rs
@@ -1,0 +1,90 @@
+//
+// SCIM v2 provisioning endpoints (RFC 7643 / RFC 7644), Entra ID first.
+//
+// Mounted at /scim (see main.rs). Authentication is the per-organization
+// static bearer token checked by guard::ScimToken. Management of that token
+// is an admin-session concern and lives under /api via manage::routes().
+//
+pub mod guard;
+
+mod discovery;
+mod error;
+mod manage;
+
+use std::io::Cursor;
+
+use rocket::{
+    Catcher, Route,
+    http::Status,
+    request::Request,
+    response::{self, Responder, Response},
+};
+use serde_json::Value;
+
+pub use error::ScimError;
+pub use manage::routes as manage_routes;
+
+pub fn routes() -> Vec<Route> {
+    discovery::routes()
+}
+
+// A JSON body with Content-Type application/scim+json, RFC 7644 section 3.1.
+pub struct ScimResponse {
+    status: Status,
+    body: Value,
+}
+
+impl ScimResponse {
+    pub fn ok(body: Value) -> Self {
+        Self {
+            status: Status::Ok,
+            body,
+        }
+    }
+}
+
+impl Responder<'_, 'static> for ScimResponse {
+    fn respond_to(self, _: &Request<'_>) -> response::Result<'static> {
+        let body = self.body.to_string();
+        Response::build()
+            .status(self.status)
+            .header(error::scim_content_type())
+            .sized_body(Some(body.len()), Cursor::new(body))
+            .ok()
+    }
+}
+
+// Catchers keep every error under /scim inside the SCIM envelope, including
+// guard rejections (which carry only a status). The 401 body is a constant:
+// all auth failure causes look identical to the caller.
+pub fn catchers() -> Vec<Catcher> {
+    catchers![scim_bad_request, scim_unauthorized, scim_not_found, scim_too_many_requests, scim_internal]
+}
+
+#[catch(400)]
+fn scim_bad_request() -> ScimError {
+    ScimError::bad_request("invalidValue", "Bad request")
+}
+
+#[catch(401)]
+fn scim_unauthorized() -> ScimError {
+    ScimError::unauthorized()
+}
+
+#[catch(404)]
+fn scim_not_found() -> ScimError {
+    ScimError::not_found()
+}
+
+#[catch(429)]
+fn scim_too_many_requests() -> ScimError {
+    ScimError::too_many_requests()
+}
+
+#[catch(500)]
+fn scim_internal() -> ScimError {
+    ScimError::internal()
+}
+
+#[cfg(all(test, sqlite))]
+mod tests;

--- a/src/api/scim/mod.rs
+++ b/src/api/scim/mod.rs
@@ -28,14 +28,57 @@ use rocket::{
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
+use crate::db::models::{DeviceType, OrganizationId};
+
 pub use error::ScimError;
 pub use manage::routes as manage_routes;
+
+// Synthetic acting user recorded in the org event log for SCIM-driven
+// changes, following the ACTING_ADMIN_USER precedent in the admin panel.
+pub(crate) const SCIM_ACTOR: &str = "vaultwarden-scim-00000-000000000000";
+// Device type recorded for SCIM events, same as the admin panel actor.
+pub(crate) const SCIM_DEVICE_TYPE: i32 = DeviceType::UnknownBrowser as i32;
+
+// Page-size cap advertised in ServiceProviderConfig (filter.maxResults) and
+// enforced by every list endpoint; keep the two in sync through this constant.
+pub(crate) const SCIM_MAX_RESULTS: usize = 200;
+pub(crate) const SCIM_DEFAULT_PAGE_SIZE: i64 = 100;
+
+// The "scim" data limit: registered in main.rs and used as the fallback when
+// the figment carries no limit by that name (e.g. a test rocket built from
+// Config::default()).
+pub const SCIM_BODY_LIMIT: rocket::data::ByteUnit = rocket::data::ByteUnit::Kibibyte(512);
 
 pub fn routes() -> Vec<Route> {
     let mut routes = discovery::routes();
     routes.append(&mut users::routes());
     routes.append(&mut groups::routes());
     routes
+}
+
+// Clamps SCIM pagination parameters: startIndex is 1-based (RFC 7644
+// section 3.4.2.4; zero, negative, and absent all become 1) and a negative
+// count collapses to 0 while anything above the cap is truncated.
+pub(crate) fn page_bounds(start_index: Option<i64>, count: Option<i64>) -> (usize, usize) {
+    let start_index = usize::try_from(start_index.unwrap_or(1)).unwrap_or(1).max(1);
+    let count = usize::try_from(count.unwrap_or(SCIM_DEFAULT_PAGE_SIZE)).unwrap_or(0).min(SCIM_MAX_RESULTS);
+    (start_index, count)
+}
+
+pub(crate) fn list_response(total: usize, start_index: usize, resources: &[Value]) -> ScimResponse {
+    ScimResponse::ok(json!({
+        "schemas": [discovery::LIST_RESPONSE_URN],
+        "totalResults": total,
+        "itemsPerPage": resources.len(),
+        "startIndex": start_index,
+        "Resources": resources,
+    }))
+}
+
+// Canonical location URL for a Users/Groups resource, used for both the
+// Location header and meta.location.
+pub(crate) fn resource_location(org_uuid: &OrganizationId, resource_type: &str, id: &dyn std::fmt::Display) -> String {
+    format!("{}/scim/v2/{org_uuid}/{resource_type}/{id}", crate::CONFIG.domain())
 }
 
 // A JSON body limited by the "scim" size limit. Accepts both
@@ -48,7 +91,7 @@ impl<'r, T: DeserializeOwned> FromData<'r> for ScimJson<T> {
     type Error = ScimError;
 
     async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> DataOutcome<'r, Self> {
-        let limit = request.limits().get("scim").unwrap_or_else(|| rocket::data::ByteUnit::Kibibyte(512));
+        let limit = request.limits().get("scim").unwrap_or(SCIM_BODY_LIMIT);
         let bytes = match data.open(limit).into_bytes().await {
             Ok(bytes) if bytes.is_complete() => bytes.into_inner(),
             Ok(_) => return DataOutcome::Error((Status::PayloadTooLarge, ScimError::payload_too_large())),

--- a/src/api/scim/mod.rs
+++ b/src/api/scim/mod.rs
@@ -9,48 +9,109 @@ pub mod guard;
 
 mod discovery;
 mod error;
+mod filter;
 mod manage;
+mod models;
+mod patch;
+mod users;
 
 use std::io::Cursor;
 
 use rocket::{
     Catcher, Route,
+    data::{Data, FromData, Outcome as DataOutcome},
     http::Status,
     request::Request,
     response::{self, Responder, Response},
 };
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 pub use error::ScimError;
 pub use manage::routes as manage_routes;
 
 pub fn routes() -> Vec<Route> {
-    discovery::routes()
+    let mut routes = discovery::routes();
+    routes.append(&mut users::routes());
+    routes
+}
+
+// A JSON body limited by the "scim" size limit. Accepts both
+// application/scim+json (what Entra sends) and application/json; rocket's
+// own Json<T> would reject the former.
+pub struct ScimJson<T>(pub T);
+
+#[rocket::async_trait]
+impl<'r, T: DeserializeOwned> FromData<'r> for ScimJson<T> {
+    type Error = ScimError;
+
+    async fn from_data(request: &'r Request<'_>, data: Data<'r>) -> DataOutcome<'r, Self> {
+        let limit = request.limits().get("scim").unwrap_or_else(|| rocket::data::ByteUnit::Kibibyte(512));
+        let bytes = match data.open(limit).into_bytes().await {
+            Ok(bytes) if bytes.is_complete() => bytes.into_inner(),
+            Ok(_) => return DataOutcome::Error((Status::PayloadTooLarge, ScimError::payload_too_large())),
+            Err(_) => {
+                return DataOutcome::Error((
+                    Status::BadRequest,
+                    ScimError::bad_request("invalidSyntax", "Unreadable body"),
+                ));
+            }
+        };
+        match serde_json::from_slice::<T>(&bytes) {
+            Ok(value) => DataOutcome::Success(ScimJson(value)),
+            Err(e) => {
+                warn!(target: "scim", "Rejecting unparseable SCIM body: {e}");
+                DataOutcome::Error((Status::BadRequest, ScimError::bad_request("invalidSyntax", "Malformed SCIM body")))
+            }
+        }
+    }
 }
 
 // A JSON body with Content-Type application/scim+json, RFC 7644 section 3.1.
 pub struct ScimResponse {
     status: Status,
-    body: Value,
+    location: Option<String>,
+    body: Option<Value>,
 }
 
 impl ScimResponse {
     pub fn ok(body: Value) -> Self {
         Self {
             status: Status::Ok,
-            body,
+            location: None,
+            body: Some(body),
+        }
+    }
+
+    pub fn created(location: String, body: Value) -> Self {
+        Self {
+            status: Status::Created,
+            location: Some(location),
+            body: Some(body),
+        }
+    }
+
+    pub fn no_content() -> Self {
+        Self {
+            status: Status::NoContent,
+            location: None,
+            body: None,
         }
     }
 }
 
 impl Responder<'_, 'static> for ScimResponse {
     fn respond_to(self, _: &Request<'_>) -> response::Result<'static> {
-        let body = self.body.to_string();
-        Response::build()
-            .status(self.status)
-            .header(error::scim_content_type())
-            .sized_body(Some(body.len()), Cursor::new(body))
-            .ok()
+        let mut builder = Response::build();
+        builder.status(self.status);
+        if let Some(location) = self.location {
+            builder.raw_header("Location", location);
+        }
+        if let Some(body) = self.body {
+            let body = body.to_string();
+            builder.header(error::scim_content_type()).sized_body(Some(body.len()), Cursor::new(body));
+        }
+        builder.ok()
     }
 }
 
@@ -58,7 +119,14 @@ impl Responder<'_, 'static> for ScimResponse {
 // guard rejections (which carry only a status). The 401 body is a constant:
 // all auth failure causes look identical to the caller.
 pub fn catchers() -> Vec<Catcher> {
-    catchers![scim_bad_request, scim_unauthorized, scim_not_found, scim_too_many_requests, scim_internal]
+    catchers![
+        scim_bad_request,
+        scim_unauthorized,
+        scim_not_found,
+        scim_payload_too_large,
+        scim_too_many_requests,
+        scim_internal
+    ]
 }
 
 #[catch(400)]
@@ -74,6 +142,11 @@ fn scim_unauthorized() -> ScimError {
 #[catch(404)]
 fn scim_not_found() -> ScimError {
     ScimError::not_found()
+}
+
+#[catch(413)]
+fn scim_payload_too_large() -> ScimError {
+    ScimError::payload_too_large()
 }
 
 #[catch(429)]

--- a/src/api/scim/mod.rs
+++ b/src/api/scim/mod.rs
@@ -10,6 +10,7 @@ pub mod guard;
 mod discovery;
 mod error;
 mod filter;
+mod groups;
 mod manage;
 mod models;
 mod patch;
@@ -33,6 +34,7 @@ pub use manage::routes as manage_routes;
 pub fn routes() -> Vec<Route> {
     let mut routes = discovery::routes();
     routes.append(&mut users::routes());
+    routes.append(&mut groups::routes());
     routes
 }
 

--- a/src/api/scim/models.rs
+++ b/src/api/scim/models.rs
@@ -1,0 +1,160 @@
+//
+// Serde models for SCIM request bodies, RFC 7643.
+//
+// Deliberately NOT #[serde(deny_unknown_fields)]: RFC 7643 section 2.1
+// requires service providers to ignore attributes they do not recognize, and
+// Entra sends several (addresses, phoneNumbers, preferredLanguage, ...).
+//
+use serde::Deserialize;
+use serde_json::Value;
+
+// Entra sometimes sends booleans as strings ("True"/"False"), particularly in
+// PATCH values. Accept both without losing strictness for other types.
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(try_from = "Value")]
+pub struct ScimBool(pub bool);
+
+impl TryFrom<Value> for ScimBool {
+    type Error = String;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Bool(b) => Ok(ScimBool(b)),
+            Value::String(s) => match s.to_lowercase().as_str() {
+                "true" => Ok(ScimBool(true)),
+                "false" => Ok(ScimBool(false)),
+                _ => Err(format!("not a boolean: {s:?}")),
+            },
+            other => Err(format!("not a boolean: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimName {
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub formatted: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimEmail {
+    pub value: String,
+    #[serde(default)]
+    pub primary: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimUserRequest {
+    pub user_name: Option<String>,
+    pub external_id: Option<String>,
+    pub display_name: Option<String>,
+    pub name: Option<ScimName>,
+    #[serde(default)]
+    pub emails: Vec<ScimEmail>,
+    pub active: Option<ScimBool>,
+}
+
+impl ScimUserRequest {
+    // Entra maps userName to the login identifier; some tenants map the
+    // routable address only into emails[]. Prefer userName when it looks like
+    // an email, else fall back to the primary (or first) email value.
+    pub fn email(&self) -> Option<&str> {
+        let user_name = self.user_name.as_deref().filter(|v| v.contains('@'));
+        let from_emails =
+            self.emails.iter().find(|e| e.primary).or_else(|| self.emails.first()).map(|e| e.value.as_str());
+        user_name.or(from_emails)
+    }
+
+    // Compose a display name the way the web vault shows members.
+    pub fn display_name(&self) -> Option<String> {
+        if let Some(display_name) = &self.display_name {
+            return Some(display_name.clone());
+        }
+        if let Some(name) = &self.name {
+            if let Some(formatted) = &name.formatted {
+                return Some(formatted.clone());
+            }
+            let composed = match (&name.given_name, &name.family_name) {
+                (Some(given), Some(family)) => Some(format!("{given} {family}")),
+                (Some(given), None) => Some(given.clone()),
+                (None, Some(family)) => Some(family.clone()),
+                (None, None) => None,
+            };
+            return composed;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scim_bool_coerces_entra_strings() {
+        for (raw, expected) in [
+            (json!(true), true),
+            (json!(false), false),
+            (json!("True"), true),
+            (json!("true"), true),
+            (json!("FALSE"), false),
+            (json!("false"), false),
+        ] {
+            let b: ScimBool = serde_json::from_value(raw).expect("coercible");
+            assert_eq!(b.0, expected);
+        }
+        for bad in [json!("yes"), json!(1), json!(null), json!({})] {
+            assert!(serde_json::from_value::<ScimBool>(bad).is_err());
+        }
+    }
+
+    #[test]
+    fn email_prefers_username_then_primary_email() {
+        let parsed: ScimUserRequest = serde_json::from_value(json!({
+            "userName": "user@example.com",
+            "emails": [{"value": "other@example.com", "primary": true}],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.email(), Some("user@example.com"));
+
+        // Non-email userName (a bare UPN-less identifier) falls back to emails.
+        let parsed: ScimUserRequest = serde_json::from_value(json!({
+            "userName": "just-an-id",
+            "emails": [{"value": "second@example.com"}, {"value": "first@example.com", "primary": true}],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.email(), Some("first@example.com"));
+
+        let parsed: ScimUserRequest = serde_json::from_value(json!({})).expect("valid");
+        assert_eq!(parsed.email(), None);
+    }
+
+    #[test]
+    fn display_name_composition() {
+        let parsed: ScimUserRequest = serde_json::from_value(json!({
+            "name": {"givenName": "Ada", "familyName": "Lovelace"},
+        }))
+        .expect("valid");
+        assert_eq!(parsed.display_name().as_deref(), Some("Ada Lovelace"));
+
+        let parsed: ScimUserRequest = serde_json::from_value(json!({
+            "displayName": "Display Wins",
+            "name": {"formatted": "Formatted Loses"},
+        }))
+        .expect("valid");
+        assert_eq!(parsed.display_name().as_deref(), Some("Display Wins"));
+
+        // Unknown attributes are ignored per RFC 7643 section 2.1.
+        let parsed: ScimUserRequest = serde_json::from_value(json!({
+            "userName": "a@b.com",
+            "preferredLanguage": "en-US",
+            "addresses": [],
+        }))
+        .expect("unknown attrs must not fail");
+        assert_eq!(parsed.email(), Some("a@b.com"));
+    }
+}

--- a/src/api/scim/patch.rs
+++ b/src/api/scim/patch.rs
@@ -34,6 +34,29 @@ pub struct PatchOperation {
 #[derive(Debug, Default, PartialEq)]
 pub struct UserPatch {
     pub active: Option<bool>,
+    pub external_id: Option<String>,
+}
+
+// Attributes Entra maps by default but Vaultwarden does not sync after
+// creation. Accepted and ignored (RFC 7644 allows a service provider to
+// treat immutable-for-it attributes this way in practice), because a 400
+// here would surface as a sync error on every rename in the directory.
+// user.name is global to the person across organizations; an org-scoped
+// provisioning channel must not rewrite it.
+fn is_ignored_user_attribute(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    lower == "displayname"
+        || lower == "name"
+        || lower.starts_with("name.")
+        || lower == "emails"
+        || lower.starts_with("emails[")
+        || lower == "username"
+        || lower == "title"
+        || lower == "roles"
+        || lower == "preferredlanguage"
+        || lower.starts_with("addresses")
+        || lower.starts_with("phonenumbers")
+        || lower.starts_with("urn:ietf:params:scim:schemas:extension:enterprise:2.0:user")
 }
 
 pub fn parse_user_patch(patch: &PatchOp) -> Result<UserPatch, ScimError> {
@@ -60,6 +83,13 @@ pub fn parse_user_patch(patch: &PatchOp) -> Result<UserPatch, ScimError> {
                 let value = operation.value.clone().unwrap_or(Value::Null);
                 result.active = Some(coerce_bool(value)?);
             }
+            Some(op_path) if op_path.eq_ignore_ascii_case("externalid") => {
+                let Some(Value::String(external_id)) = operation.value.as_ref() else {
+                    return Err(ScimError::bad_request("invalidValue", "externalId must be a string"));
+                };
+                result.external_id = Some(external_id.clone());
+            }
+            Some(op_path) if is_ignored_user_attribute(op_path) => {}
             Some(_) => {
                 return Err(ScimError::bad_request("invalidPath", "Unsupported patch path"));
             }
@@ -74,6 +104,13 @@ pub fn parse_user_patch(patch: &PatchOp) -> Result<UserPatch, ScimError> {
                 for (attribute, value) in map {
                     if attribute.eq_ignore_ascii_case("active") {
                         result.active = Some(coerce_bool(value.clone())?);
+                    } else if attribute.eq_ignore_ascii_case("externalid") {
+                        let Value::String(external_id) = value else {
+                            return Err(ScimError::bad_request("invalidValue", "externalId must be a string"));
+                        };
+                        result.external_id = Some(external_id.clone());
+                    } else if is_ignored_user_attribute(attribute) {
+                        // Accepted, not synced; see is_ignored_user_attribute.
                     } else {
                         return Err(ScimError::bad_request("invalidPath", "Unsupported patch attribute"));
                     }
@@ -132,6 +169,38 @@ mod tests {
     }
 
     #[test]
+    fn entra_mapped_attributes_are_accepted_and_ignored() {
+        for path in ["displayName", "name.givenName", "emails[type eq \"work\"].value", "title", "roles"] {
+            let parsed = patch(json!({
+                "schemas": [PATCH_OP_URN],
+                "Operations": [
+                    {"op": "replace", "path": path, "value": "whatever"},
+                    {"op": "replace", "path": "active", "value": true},
+                ],
+            }))
+            .unwrap_or_else(|_| panic!("path {path} must be ignored, not rejected"));
+            assert_eq!(parsed.active, Some(true));
+        }
+    }
+
+    #[test]
+    fn externalid_patch_both_forms() {
+        let parsed = patch(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "replace", "path": "externalId", "value": "new-ext-1"}],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.external_id.as_deref(), Some("new-ext-1"));
+
+        let parsed = patch(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "replace", "value": {"externalId": "new-ext-2", "displayName": "ignored"}}],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.external_id.as_deref(), Some("new-ext-2"));
+    }
+
+    #[test]
     fn rejects_bad_patches() {
         for (payload, expected_type) in [
             (
@@ -141,7 +210,7 @@ mod tests {
             (json!({"schemas": [PATCH_OP_URN], "Operations": []}), "invalidValue"),
             (json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "remove", "path": "active"}]}), "invalidValue"),
             (
-                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "replace", "path": "displayName", "value": "x"}]}),
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "replace", "path": "wibble", "value": "x"}]}),
                 "invalidPath",
             ),
             (

--- a/src/api/scim/patch.rs
+++ b/src/api/scim/patch.rs
@@ -1,0 +1,159 @@
+//
+// SCIM PatchOp parsing, RFC 7644 section 3.5.2, restricted to what the User
+// endpoints support. Entra quirks handled here, all observed in real syncs:
+//   - "op" arrives with any casing ("Replace", "Add").
+//   - boolean values may arrive as strings ("True"/"False").
+//   - an operation may have no "path", carrying a value object instead
+//     ({"op":"replace","value":{"active":false}}).
+//
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::api::scim::{error::ScimError, models::ScimBool};
+
+pub const PATCH_OP_URN: &str = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+
+#[derive(Debug, Deserialize)]
+pub struct PatchOp {
+    #[serde(default)]
+    pub schemas: Vec<String>,
+    #[serde(rename = "Operations", default)]
+    pub operations: Vec<PatchOperation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchOperation {
+    pub op: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub value: Option<Value>,
+}
+
+// What a User PATCH asked for, after normalization.
+#[derive(Debug, Default, PartialEq)]
+pub struct UserPatch {
+    pub active: Option<bool>,
+}
+
+pub fn parse_user_patch(patch: &PatchOp) -> Result<UserPatch, ScimError> {
+    if !patch.schemas.iter().any(|s| s == PATCH_OP_URN) {
+        return Err(ScimError::bad_request("invalidValue", "Missing PatchOp schema"));
+    }
+    if patch.operations.is_empty() {
+        return Err(ScimError::bad_request("invalidValue", "No operations provided"));
+    }
+
+    let mut result = UserPatch::default();
+
+    for operation in &patch.operations {
+        let op = operation.op.to_lowercase();
+        if op != "replace" && op != "add" {
+            return Err(ScimError::bad_request(
+                "invalidValue",
+                "Only add and replace operations are supported for Users",
+            ));
+        }
+
+        match operation.path.as_deref() {
+            Some(op_path) if op_path.eq_ignore_ascii_case("active") => {
+                let value = operation.value.clone().unwrap_or(Value::Null);
+                result.active = Some(coerce_bool(value)?);
+            }
+            Some(_) => {
+                return Err(ScimError::bad_request("invalidPath", "Unsupported patch path"));
+            }
+            None => {
+                // Path-less form: the value is an object of attribute => value.
+                let Some(Value::Object(map)) = operation.value.as_ref() else {
+                    return Err(ScimError::bad_request(
+                        "invalidValue",
+                        "Operation without path must carry an object value",
+                    ));
+                };
+                for (attribute, value) in map {
+                    if attribute.eq_ignore_ascii_case("active") {
+                        result.active = Some(coerce_bool(value.clone())?);
+                    } else {
+                        return Err(ScimError::bad_request("invalidPath", "Unsupported patch attribute"));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn coerce_bool(value: Value) -> Result<bool, ScimError> {
+    serde_json::from_value::<ScimBool>(value)
+        .map(|b| b.0)
+        .map_err(|_| ScimError::bad_request("invalidValue", "Expected a boolean value for active"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patch(payload: Value) -> Result<UserPatch, ScimError> {
+        let parsed: PatchOp = serde_json::from_value(payload).expect("valid PatchOp json");
+        parse_user_patch(&parsed)
+    }
+
+    fn ok_active(payload: Value) -> Option<bool> {
+        patch(payload).expect("expected parse to succeed").active
+    }
+
+    #[test]
+    fn replace_active_with_path() {
+        let active = ok_active(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "replace", "path": "active", "value": false}],
+        }));
+        assert_eq!(active, Some(false));
+    }
+
+    #[test]
+    fn entra_casing_and_string_bool() {
+        let active = ok_active(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "Replace", "path": "active", "value": "False"}],
+        }));
+        assert_eq!(active, Some(false));
+    }
+
+    #[test]
+    fn pathless_value_object() {
+        let active = ok_active(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "replace", "value": {"active": "True"}}],
+        }));
+        assert_eq!(active, Some(true));
+    }
+
+    #[test]
+    fn rejects_bad_patches() {
+        for (payload, expected_type) in [
+            (
+                json!({"schemas": [], "Operations": [{"op": "replace", "path": "active", "value": true}]}),
+                "invalidValue",
+            ),
+            (json!({"schemas": [PATCH_OP_URN], "Operations": []}), "invalidValue"),
+            (json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "remove", "path": "active"}]}), "invalidValue"),
+            (
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "replace", "path": "displayName", "value": "x"}]}),
+                "invalidPath",
+            ),
+            (
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "replace", "path": "active", "value": "maybe"}]}),
+                "invalidValue",
+            ),
+            (json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "replace", "value": 3}]}), "invalidValue"),
+        ] {
+            match patch(payload.clone()) {
+                Err(e) => assert_eq!(e.scim_type, Some(expected_type), "wrong scimType for {payload}"),
+                Ok(p) => panic!("patch {payload} unexpectedly parsed to {p:?}"),
+            }
+        }
+    }
+}

--- a/src/api/scim/patch.rs
+++ b/src/api/scim/patch.rs
@@ -226,3 +226,221 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Group PATCH
+// ---------------------------------------------------------------------------
+
+// What a Group PATCH asked for, after normalization. Member values are
+// MembershipIds (the SCIM User id).
+#[derive(Debug, Default, PartialEq)]
+pub struct GroupPatch {
+    pub display_name: Option<String>,
+    pub external_id: Option<String>,
+    pub add_members: Vec<String>,
+    pub remove_members: Vec<String>,
+    // Some(list) means full replacement of the member set.
+    pub replace_members: Option<Vec<String>>,
+}
+
+// Entra removes single members with a filter path instead of a value list:
+//     {"op": "Remove", "path": "members[value eq \"<id>\"]"}
+// (the value-array form is only sent by apps created with the
+// aadOptscim062020 feature flag). Both forms must work.
+fn parse_members_filter_path(path: &str) -> Option<String> {
+    let inner = path.strip_prefix("members[")?.strip_suffix(']')?;
+    let (attribute, rest) = inner.split_once(char::is_whitespace)?;
+    if !attribute.eq_ignore_ascii_case("value") {
+        return None;
+    }
+    let (operator, rest) = rest.trim_start().split_once(char::is_whitespace)?;
+    if !operator.eq_ignore_ascii_case("eq") {
+        return None;
+    }
+    let value = rest.trim().strip_prefix('"')?.strip_suffix('"')?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.to_owned())
+}
+
+// Extracts member ids from a PATCH value: either [{"value": "id"}, ...] or a
+// single {"value": "id"} object.
+fn member_values(value: Option<&Value>) -> Result<Vec<String>, ScimError> {
+    let invalid = || ScimError::bad_request("invalidValue", "members value must be an array of {value} objects");
+    let items: Vec<&Value> = match value {
+        Some(Value::Array(items)) => items.iter().collect(),
+        Some(single @ Value::Object(_)) => vec![single],
+        _ => return Err(invalid()),
+    };
+    let mut ids = Vec::with_capacity(items.len());
+    for item in items {
+        let Some(Value::String(id)) = item.get("value") else {
+            return Err(invalid());
+        };
+        ids.push(id.clone());
+    }
+    Ok(ids)
+}
+
+pub fn parse_group_patch(patch: &PatchOp) -> Result<GroupPatch, ScimError> {
+    if !patch.schemas.iter().any(|s| s == PATCH_OP_URN) {
+        return Err(ScimError::bad_request("invalidValue", "Missing PatchOp schema"));
+    }
+    if patch.operations.is_empty() {
+        return Err(ScimError::bad_request("invalidValue", "No operations provided"));
+    }
+
+    let mut result = GroupPatch::default();
+
+    for operation in &patch.operations {
+        let op = operation.op.to_lowercase();
+        match operation.path.as_deref() {
+            Some(op_path) if op_path.eq_ignore_ascii_case("members") => match op.as_str() {
+                "add" => result.add_members.append(&mut member_values(operation.value.as_ref())?),
+                "remove" => result.remove_members.append(&mut member_values(operation.value.as_ref())?),
+                "replace" => {
+                    result
+                        .replace_members
+                        .get_or_insert_with(Vec::new)
+                        .append(&mut member_values(operation.value.as_ref())?);
+                }
+                _ => return Err(ScimError::bad_request("invalidValue", "Unsupported operation on members")),
+            },
+            Some(op_path) if op_path.to_lowercase().starts_with("members[") => {
+                let Some(member_id) = parse_members_filter_path(op_path) else {
+                    return Err(ScimError::bad_request("invalidPath", "Unsupported members filter path"));
+                };
+                match op.as_str() {
+                    // Entra's single-member removal form.
+                    "remove" => result.remove_members.push(member_id),
+                    "add" | "replace" => result.add_members.push(member_id),
+                    _ => return Err(ScimError::bad_request("invalidValue", "Unsupported operation on members")),
+                }
+            }
+            Some(op_path) if op_path.eq_ignore_ascii_case("displayname") => {
+                let Some(Value::String(name)) = operation.value.as_ref() else {
+                    return Err(ScimError::bad_request("invalidValue", "displayName must be a string"));
+                };
+                result.display_name = Some(name.clone());
+            }
+            Some(op_path) if op_path.eq_ignore_ascii_case("externalid") => {
+                let Some(Value::String(external_id)) = operation.value.as_ref() else {
+                    return Err(ScimError::bad_request("invalidValue", "externalId must be a string"));
+                };
+                result.external_id = Some(external_id.clone());
+            }
+            Some(_) => return Err(ScimError::bad_request("invalidPath", "Unsupported patch path for Groups")),
+            None => {
+                let Some(Value::Object(map)) = operation.value.as_ref() else {
+                    return Err(ScimError::bad_request(
+                        "invalidValue",
+                        "Operation without path must carry an object value",
+                    ));
+                };
+                for (attribute, value) in map {
+                    if attribute.eq_ignore_ascii_case("displayname") {
+                        let Value::String(name) = value else {
+                            return Err(ScimError::bad_request("invalidValue", "displayName must be a string"));
+                        };
+                        result.display_name = Some(name.clone());
+                    } else if attribute.eq_ignore_ascii_case("externalid") {
+                        let Value::String(external_id) = value else {
+                            return Err(ScimError::bad_request("invalidValue", "externalId must be a string"));
+                        };
+                        result.external_id = Some(external_id.clone());
+                    } else if attribute.eq_ignore_ascii_case("members") {
+                        match op.as_str() {
+                            "add" => result.add_members.append(&mut member_values(Some(value))?),
+                            "remove" => result.remove_members.append(&mut member_values(Some(value))?),
+                            "replace" => {
+                                result
+                                    .replace_members
+                                    .get_or_insert_with(Vec::new)
+                                    .append(&mut member_values(Some(value))?);
+                            }
+                            _ => {
+                                return Err(ScimError::bad_request("invalidValue", "Unsupported operation on members"));
+                            }
+                        }
+                    } else {
+                        return Err(ScimError::bad_request("invalidPath", "Unsupported patch attribute for Groups"));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod group_tests {
+    use super::*;
+
+    fn patch(payload: Value) -> Result<GroupPatch, ScimError> {
+        let parsed: PatchOp = serde_json::from_value(payload).expect("valid PatchOp json");
+        parse_group_patch(&parsed)
+    }
+
+    #[test]
+    fn add_and_remove_member_value_lists() {
+        let parsed = patch(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [
+                {"op": "Add", "path": "members", "value": [{"value": "member-1"}, {"value": "member-2"}]},
+                {"op": "remove", "path": "members", "value": [{"value": "member-3"}]},
+            ],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.add_members, vec!["member-1", "member-2"]);
+        assert_eq!(parsed.remove_members, vec!["member-3"]);
+    }
+
+    #[test]
+    fn entra_filter_path_removal() {
+        let parsed = patch(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [{"op": "Remove", "path": "members[value eq \"member-9\"]"}],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.remove_members, vec!["member-9"]);
+    }
+
+    #[test]
+    fn replace_members_and_rename() {
+        let parsed = patch(json!({
+            "schemas": [PATCH_OP_URN],
+            "Operations": [
+                {"op": "replace", "path": "members", "value": [{"value": "only-member"}]},
+                {"op": "replace", "path": "displayName", "value": "New Group Name"},
+            ],
+        }))
+        .expect("valid");
+        assert_eq!(parsed.replace_members.as_deref(), Some(&["only-member".to_owned()][..]));
+        assert_eq!(parsed.display_name.as_deref(), Some("New Group Name"));
+    }
+
+    #[test]
+    fn group_patch_rejects_garbage() {
+        for (payload, expected_type) in [
+            (
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "remove", "path": "members[display eq \"x\"]"}]}),
+                "invalidPath",
+            ),
+            (
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "add", "path": "members", "value": ["bare-string"]}]}),
+                "invalidValue",
+            ),
+            (
+                json!({"schemas": [PATCH_OP_URN], "Operations": [{"op": "add", "path": "wibble", "value": 1}]}),
+                "invalidPath",
+            ),
+        ] {
+            match patch(payload.clone()) {
+                Err(e) => assert_eq!(e.scim_type, Some(expected_type), "wrong scimType for {payload}"),
+                Ok(p) => panic!("group patch {payload} unexpectedly parsed to {p:?}"),
+            }
+        }
+    }
+}

--- a/src/api/scim/tests/mod.rs
+++ b/src/api/scim/tests/mod.rs
@@ -542,7 +542,7 @@ async fn patch_unsupported_path_is_invalid_path() {
 
     let payload = json!({
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        "Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}],
+        "Operations": [{"op": "replace", "path": "wibble", "value": "New Name"}],
     });
     let (auth, ct, body) = scim_body(&token, &payload);
     let response =
@@ -555,4 +555,136 @@ async fn patch_unsupported_path_is_invalid_path() {
 fn url_escape(raw: &str) -> String {
     // Percent-encode just enough for filter values in test URLs.
     raw.replace('%', "%25").replace(' ', "%20").replace('"', "%22")
+}
+
+// ---------------------------------------------------------------------------
+// Full Users surface (Phase 2: PUT, attribute PATCH, pagination)
+// ---------------------------------------------------------------------------
+
+#[rocket::async_test]
+async fn patch_displayname_rename_is_accepted_noop() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-rename-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member = seed_member(&conn, &org, "renamed.user@example.com", 2, MembershipType::User).await;
+
+    // Entra sends this on every directory rename; it must not error and must
+    // not change membership state.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "displayName", "value": "New Display Name"}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{member}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["active"], json!(true));
+    assert_eq!(member_status(&conn, &member, &org).await, 2);
+}
+
+#[rocket::async_test]
+async fn patch_and_put_update_external_id_with_uniqueness() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-extid-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member_a = seed_member(&conn, &org, "extid.a@example.com", 1, MembershipType::User).await;
+    let member_b = seed_member(&conn, &org, "extid.b@example.com", 1, MembershipType::User).await;
+
+    // PATCH assigns an externalId.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "externalId", "value": "ext-a-1"}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{member_a}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(parse_json(&body_of(response).await)["externalId"], json!("ext-a-1"));
+
+    // PUT replaces it and can toggle active in the same request.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "extid.a@example.com",
+        "externalId": "ext-a-2",
+        "active": false,
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Users/{member_a}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["externalId"], json!("ext-a-2"));
+    assert_eq!(parsed["active"], json!(false));
+    assert_eq!(member_status(&conn, &member_a, &org).await, -127, "accepted (1) revoked to -127");
+
+    // Duplicate externalId on another member is a 409.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "externalId", "value": "ext-a-2"}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{member_b}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+}
+
+#[rocket::async_test]
+async fn put_does_not_change_email_or_role() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-put-immutable-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member = seed_member(&conn, &org, "immutable@example.com", 2, MembershipType::User).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "changed@example.com",
+        "displayName": "Different Person",
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Users/{member}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    // The response reflects the real state: the email did not change.
+    assert_eq!(parsed["userName"], json!("immutable@example.com"));
+    assert_eq!(member_status(&conn, &member, &org).await, 2);
+}
+
+#[rocket::async_test]
+async fn pagination_edges() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-page-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    for i in 1..=3 {
+        seed_member(&conn, &org, &format!("page{i}@example.com"), 1, MembershipType::User).await;
+    }
+
+    // Middle page.
+    let response =
+        client.get(format!("/scim/v2/{org}/Users?startIndex=2&count=1")).header(bearer(&token)).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(3));
+    assert_eq!(parsed["itemsPerPage"], json!(1));
+    assert_eq!(parsed["startIndex"], json!(2));
+
+    // count=0 returns the total with no resources (RFC 7644 s3.4.2.4).
+    let response = client.get(format!("/scim/v2/{org}/Users?count=0")).header(bearer(&token)).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(3));
+    assert_eq!(parsed["itemsPerPage"], json!(0));
+
+    // startIndex beyond the end is an empty page, not an error.
+    let response = client.get(format!("/scim/v2/{org}/Users?startIndex=10")).header(bearer(&token)).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(3));
+    assert_eq!(parsed["itemsPerPage"], json!(0));
 }

--- a/src/api/scim/tests/mod.rs
+++ b/src/api/scim/tests/mod.rs
@@ -688,3 +688,158 @@ async fn pagination_edges() {
     assert_eq!(parsed["totalResults"], json!(3));
     assert_eq!(parsed["itemsPerPage"], json!(0));
 }
+
+// ---------------------------------------------------------------------------
+// Groups (Phase 3)
+// ---------------------------------------------------------------------------
+
+#[rocket::async_test]
+async fn group_crud_and_member_diff_lifecycle() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-group-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member_a = seed_member(&conn, &org, "group.a@example.com", 1, MembershipType::User).await;
+    let member_b = seed_member(&conn, &org, "group.b@example.com", 2, MembershipType::User).await;
+
+    // POST with one initial member.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Engineering",
+        "externalId": "entra-group-1",
+        "members": [{"value": member_a}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response = client.post(format!("/scim/v2/{org}/Groups")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Created);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["displayName"], json!("Engineering"));
+    assert_eq!(parsed["members"].as_array().expect("members").len(), 1);
+    let group_id = parsed["id"].as_str().expect("group id").to_owned();
+
+    // PATCH add member_b via value list.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "Add", "path": "members", "value": [{"value": member_b}]}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["members"].as_array().expect("members").len(), 2);
+
+    // Adding the same member twice is idempotent.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "add", "path": "members", "value": [{"value": member_b}]}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["members"].as_array().expect("members").len(), 2, "duplicate add must not duplicate the link");
+
+    // Entra's filter-path removal form removes member_a only.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "Remove", "path": format!("members[value eq \"{member_a}\"]")}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    let members = parsed["members"].as_array().expect("members");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0]["value"], json!(member_b.to_string()));
+
+    // excludedAttributes=members on list omits the member arrays.
+    let response =
+        client.get(format!("/scim/v2/{org}/Groups?excludedAttributes=members")).header(bearer(&token)).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(1));
+    assert!(parsed["Resources"][0].get("members").is_none(), "members must be excluded");
+
+    // Filter by displayName.
+    let response = client
+        .get(format!("/scim/v2/{org}/Groups?filter={}", url_escape("displayName eq \"Engineering\"")))
+        .header(bearer(&token))
+        .dispatch()
+        .await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(1));
+
+    // DELETE is a real delete for groups (no E2EE state involved).
+    let response = client.delete(format!("/scim/v2/{org}/Groups/{group_id}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::NoContent);
+    let response = client.get(format!("/scim/v2/{org}/Groups/{group_id}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+#[rocket::async_test]
+async fn group_member_must_be_provisioned_first() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-group-order-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let org_other = seed_org(&conn, "scim-group-other-org").await;
+    let foreign_member = seed_member(&conn, &org_other, "other.org@example.com", 1, MembershipType::User).await;
+
+    // A member id from another org must be rejected, same as an unknown id:
+    // GroupUser keys on MembershipId, so cross-org references would otherwise
+    // link silently.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Bad Members",
+        "members": [{"value": foreign_member}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response = client.post(format!("/scim/v2/{org}/Groups")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::BadRequest);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["scimType"], json!("invalidValue"));
+
+    // And the failed create must not leave a group behind.
+    let response = client.get(format!("/scim/v2/{org}/Groups")).header(bearer(&token)).dispatch().await;
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(0));
+}
+
+#[rocket::async_test]
+async fn group_put_replaces_member_set() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-group-put-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member_a = seed_member(&conn, &org, "put.a@example.com", 1, MembershipType::User).await;
+    let member_b = seed_member(&conn, &org, "put.b@example.com", 1, MembershipType::User).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Replace Me",
+        "members": [{"value": member_a}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response = client.post(format!("/scim/v2/{org}/Groups")).header(auth).header(ct).body(body).dispatch().await;
+    let group_id = parse_json(&body_of(response).await)["id"].as_str().expect("id").to_owned();
+
+    // PUT swaps the whole member set and renames.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Replaced",
+        "members": [{"value": member_b}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["displayName"], json!("Replaced"));
+    let members = parsed["members"].as_array().expect("members");
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0]["value"], json!(member_b.to_string()));
+}

--- a/src/api/scim/tests/mod.rs
+++ b/src/api/scim/tests/mod.rs
@@ -67,12 +67,11 @@ async fn seed_org(conn: &DbConn, name: &str) -> OrganizationId {
     org.uuid
 }
 
-// Mirrors manage::generate_scim_key and returns the full bearer token.
+// Mints through the real management path (manage::mint_scim_token), so the
+// token format and the guard's verification cannot drift apart between
+// production and tests.
 async fn seed_scim_key(conn: &DbConn, org_uuid: &OrganizationId) -> String {
-    let secret = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
-    let key_hash = crypto::sha256_hex(secret.as_bytes());
-    ScimApiKey::new(org_uuid.clone(), key_hash).save(conn).await.expect("saving scim key");
-    format!("scim_v1.{org_uuid}.{secret}")
+    scim::manage::mint_scim_token(org_uuid, conn).await.expect("minting scim key").0
 }
 
 fn bearer(token: &str) -> Header<'static> {
@@ -148,6 +147,22 @@ async fn auth_failures_are_uniform_401s() {
             .dispatch()
             .await,
     ));
+    // A key row that exists but is disabled (the column is reserved for a
+    // future disable-without-deleting endpoint) must be rejected identically,
+    // even with the correct secret.
+    let org_d = seed_org(&conn, "scim-authz-d").await;
+    let secret_d = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
+    let mut key_d = ScimApiKey::new(org_d.clone(), crypto::sha256_hex(secret_d.as_bytes()));
+    key_d.enabled = false;
+    key_d.save(&conn).await.expect("saving disabled scim key");
+    failures.push((
+        "disabled key with correct secret",
+        client
+            .get(format!("/scim/v2/{org_d}/ServiceProviderConfig"))
+            .header(bearer(&format!("scim_v1.{org_d}.{secret_d}")))
+            .dispatch()
+            .await,
+    ));
 
     let mut bodies = Vec::new();
     for (case, response) in failures {
@@ -163,6 +178,28 @@ async fn auth_failures_are_uniform_401s() {
     }
     assert!(first.contains("urn:ietf:params:scim:api:messages:2.0:Error"));
     assert!(first.contains("\"status\":\"401\""));
+}
+
+#[rocket::async_test]
+async fn minted_token_round_trips_and_rotation_kills_the_old_one() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-mint-org").await;
+
+    // Mint through the real management path and authenticate with the result.
+    let (token, _) = scim::manage::mint_scim_token(&org, &conn).await.expect("minting");
+    let response = client.get(format!("/scim/v2/{org}/ServiceProviderConfig")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+
+    // Rotation replaces the key row: the old token dies instantly, the new
+    // one works.
+    let (rotated, _) = scim::manage::mint_scim_token(&org, &conn).await.expect("rotating");
+    let response = client.get(format!("/scim/v2/{org}/ServiceProviderConfig")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Unauthorized, "rotation must invalidate the previous token");
+    let response =
+        client.get(format!("/scim/v2/{org}/ServiceProviderConfig")).header(bearer(&rotated)).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
 }
 
 #[rocket::async_test]
@@ -254,7 +291,7 @@ async fn post_creates_invited_user() {
         client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
 
     assert_eq!(response.status(), Status::Created);
-    let location = response.headers().get_one("Location").expect("Location header").to_string();
+    let location = response.headers().get_one("Location").expect("Location header").to_owned();
     let parsed = parse_json(&body_of(response).await);
 
     // Mail is disabled and the user is new (no password): Invited (0).
@@ -658,6 +695,41 @@ async fn put_does_not_change_email_or_role() {
 }
 
 #[rocket::async_test]
+async fn provisioning_rollback_spares_preexisting_users() {
+    let _guard = TEST_LOCK.lock().await;
+    let (_client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-rollback-org").await;
+
+    // A pre-existing account: rollback removes only the new membership. This
+    // is the branch that must never delete someone's account on a transient
+    // invite-mail failure.
+    let user = seed_user(&conn, "rollback.existing@example.com", true).await;
+    let user_uuid = user.uuid.clone();
+    let mut member = Membership::new(user.uuid.clone(), org.clone(), None);
+    member.status = 0;
+    member.save(&conn).await.expect("saving membership");
+    let member_uuid = member.uuid.clone();
+
+    scim::users::rollback_provisioning(user, member, false, &conn).await;
+    assert!(User::find_by_uuid(&user_uuid, &conn).await.is_some(), "pre-existing user must survive rollback");
+    assert!(Membership::find_by_uuid_and_org(&member_uuid, &org, &conn).await.is_none(), "membership must be gone");
+
+    // A shell account created by this request: rollback removes the user,
+    // which cascades to the membership.
+    let user = seed_user(&conn, "rollback.shell@example.com", false).await;
+    let user_uuid = user.uuid.clone();
+    let mut member = Membership::new(user.uuid.clone(), org.clone(), None);
+    member.status = 0;
+    member.save(&conn).await.expect("saving membership");
+    let member_uuid = member.uuid.clone();
+
+    scim::users::rollback_provisioning(user, member, true, &conn).await;
+    assert!(User::find_by_uuid(&user_uuid, &conn).await.is_none(), "shell user must be removed");
+    assert!(Membership::find_by_uuid_and_org(&member_uuid, &org, &conn).await.is_none(), "membership must cascade");
+}
+
+#[rocket::async_test]
 async fn pagination_edges() {
     let _guard = TEST_LOCK.lock().await;
     let (client, pool) = scim_client().await;
@@ -842,4 +914,111 @@ async fn group_put_replaces_member_set() {
     let members = parsed["members"].as_array().expect("members");
     assert_eq!(members.len(), 1);
     assert_eq!(members[0]["value"], json!(member_b.to_string()));
+}
+
+#[rocket::async_test]
+async fn group_put_omitted_members_kept_but_empty_list_clears() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-group-sparse-put-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member_a = seed_member(&conn, &org, "sparse.a@example.com", 1, MembershipType::User).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Sparse",
+        "members": [{"value": member_a}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response = client.post(format!("/scim/v2/{org}/Groups")).header(auth).header(ct).body(body).dispatch().await;
+    let group_id = parse_json(&body_of(response).await)["id"].as_str().expect("id").to_owned();
+
+    // A PUT that omits the members attribute renames without touching the
+    // member set: a sparse client must not be able to wipe a group by accident.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Sparse Renamed",
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["displayName"], json!("Sparse Renamed"));
+    assert_eq!(parsed["members"].as_array().expect("members").len(), 1, "omitted members must keep membership");
+
+    // An explicit empty list is a real replacement and clears the group.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Sparse Renamed",
+        "members": [],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Groups/{group_id}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["members"].as_array().expect("members").len(), 0, "empty members must clear membership");
+}
+
+#[rocket::async_test]
+async fn group_external_id_uniqueness_enforced_on_put_and_patch() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-group-extid-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let mut group_ids = Vec::new();
+    for (name, ext) in [("Ext One", "ext-1"), ("Ext Two", "ext-2")] {
+        let payload = json!({
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": name,
+            "externalId": ext,
+        });
+        let (auth, ct, body) = scim_body(&token, &payload);
+        let response =
+            client.post(format!("/scim/v2/{org}/Groups")).header(auth).header(ct).body(body).dispatch().await;
+        assert_eq!(response.status(), Status::Created);
+        group_ids.push(parse_json(&body_of(response).await)["id"].as_str().expect("id").to_owned());
+    }
+    let group_two = &group_ids[1];
+
+    // PATCH onto a taken externalId is a 409, and must not change the group.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "externalId", "value": "ext-1"}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Groups/{group_two}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+    assert_eq!(parse_json(&body_of(response).await)["scimType"], json!("uniqueness"));
+
+    // PUT onto a taken externalId is the same 409.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Ext Two",
+        "externalId": "ext-1",
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Groups/{group_two}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+
+    let response = client.get(format!("/scim/v2/{org}/Groups/{group_two}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(parse_json(&body_of(response).await)["externalId"], json!("ext-2"), "conflict must not partially apply");
+
+    // Re-asserting a group's own externalId stays a no-op success: Entra
+    // repeats it on every PUT.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "Ext Two",
+        "externalId": "ext-2",
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.put(format!("/scim/v2/{org}/Groups/{group_two}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
 }

--- a/src/api/scim/tests/mod.rs
+++ b/src/api/scim/tests/mod.rs
@@ -1,0 +1,192 @@
+//
+// Integration tests for the SCIM endpoints, driven through a Rocket local
+// client against a temporary sqlite database.
+//
+// Environment: a #[ctor] constructor calls test_support::init_hermetic_env()
+// BEFORE main and before any test thread starts. CONFIG is a process-global
+// LazyLock that reads the environment on first deref, so this is the only
+// point where its inputs can be controlled race-free. The main crate forbids
+// unsafe code, which is why the env mutation lives in the test-support crate.
+//
+// Tests that build a rocket + database serialize on TEST_LOCK: the sqlite
+// file and the CONFIG global are shared process state.
+//
+use std::sync::LazyLock;
+
+use rocket::{
+    http::{Header, Status},
+    local::asynchronous::{Client, LocalResponse},
+};
+
+use crate::{
+    api::scim,
+    crypto,
+    db::{
+        DbConn, DbPool,
+        models::{Organization, OrganizationId, ScimApiKey},
+    },
+};
+
+// Linking test-support activates its #[ctor] constructor, which points CONFIG
+// at a hermetic temp environment before main. See test-support/src/lib.rs.
+use test_support as _;
+
+static TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+const SCIM_CONTENT_TYPE: &str = "application/scim+json";
+
+// One pool for the whole test process: it is never dropped, so no test can
+// hit "database is locked" from a previous test's lazily-dropped connections,
+// and the embedded migrations run exactly once.
+fn test_pool() -> &'static DbPool {
+    static POOL: std::sync::OnceLock<DbPool> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        // main() installs the rustls provider at startup; the test binary
+        // never runs main, and the CONFIG load path builds an http client
+        // that needs it.
+        rustls::crypto::ring::default_provider().install_default().expect("install rustls crypto provider");
+        DbPool::from_config().expect("test db pool (migrations embedded)")
+    })
+}
+
+async fn scim_client() -> (Client, DbPool) {
+    let pool = test_pool().clone();
+    let rocket = rocket::custom(rocket::Config::default())
+        .mount("/scim", scim::routes())
+        .register("/scim", scim::catchers())
+        .manage(pool.clone());
+    let client = Client::untracked(rocket).await.expect("local rocket client");
+    (client, pool)
+}
+
+async fn seed_org(conn: &DbConn, name: &str) -> OrganizationId {
+    let org = Organization::new(String::from(name), "admin@example.com", None, None);
+    org.save(conn).await.expect("saving test org");
+    org.uuid
+}
+
+// Mirrors manage::generate_scim_key and returns the full bearer token.
+async fn seed_scim_key(conn: &DbConn, org_uuid: &OrganizationId) -> String {
+    let secret = crypto::encode_random_bytes::<32>(&data_encoding::BASE64URL_NOPAD);
+    let key_hash = crypto::sha256_hex(secret.as_bytes());
+    ScimApiKey::new(org_uuid.clone(), key_hash).save(conn).await.expect("saving scim key");
+    format!("scim_v1.{org_uuid}.{secret}")
+}
+
+fn bearer(token: &str) -> Header<'static> {
+    Header::new("Authorization", format!("Bearer {token}"))
+}
+
+async fn body_of(response: LocalResponse<'_>) -> String {
+    response.into_string().await.expect("response body")
+}
+
+#[rocket::async_test]
+async fn valid_token_reaches_discovery() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-authz-ok").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let response = client.get(format!("/scim/v2/{org}/ServiceProviderConfig")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let content_type = response.headers().get_one("Content-Type").expect("content type");
+    assert!(content_type.starts_with(SCIM_CONTENT_TYPE), "unexpected content type {content_type}");
+    let body = body_of(response).await;
+    assert!(body.contains("urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"));
+
+    let response = client.get(format!("/scim/v2/{org}/ResourceTypes")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    let body = body_of(response).await;
+    assert!(body.contains("urn:ietf:params:scim:api:messages:2.0:ListResponse"));
+    assert!(body.contains("\"endpoint\":\"/Users\""));
+
+    let response = client.get(format!("/scim/v2/{org}/Schemas")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+}
+
+#[rocket::async_test]
+async fn auth_failures_are_uniform_401s() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+
+    let org_a = seed_org(&conn, "scim-authz-a").await;
+    let token_a = seed_scim_key(&conn, &org_a).await;
+    let org_b = seed_org(&conn, "scim-authz-b").await;
+    let _token_b = seed_scim_key(&conn, &org_b).await;
+    // An org that exists but has no SCIM key configured.
+    let org_c = seed_org(&conn, "scim-authz-c").await;
+
+    let url_a = format!("/scim/v2/{org_a}/ServiceProviderConfig");
+
+    let mut failures: Vec<(&str, LocalResponse<'_>)> = Vec::new();
+    failures.push(("no auth header", client.get(&url_a).dispatch().await));
+    failures
+        .push(("not a bearer", client.get(&url_a).header(Header::new("Authorization", "Basic abc")).dispatch().await));
+    failures.push(("malformed token", client.get(&url_a).header(bearer("garbage")).dispatch().await));
+    failures.push((
+        "wrong version prefix",
+        client.get(&url_a).header(bearer(&format!("scim_v0.{org_a}.x"))).dispatch().await,
+    ));
+    failures.push((
+        "wrong secret",
+        client.get(&url_a).header(bearer(&format!("scim_v1.{org_a}.bm90LXRoZS1zZWNyZXQ"))).dispatch().await,
+    ));
+    failures.push((
+        "token org != path org",
+        client.get(format!("/scim/v2/{org_b}/ServiceProviderConfig")).header(bearer(&token_a)).dispatch().await,
+    ));
+    failures.push((
+        "org without key",
+        client
+            .get(format!("/scim/v2/{org_c}/ServiceProviderConfig"))
+            .header(bearer(&format!("scim_v1.{org_c}.c2VjcmV0")))
+            .dispatch()
+            .await,
+    ));
+
+    let mut bodies = Vec::new();
+    for (case, response) in failures {
+        assert_eq!(response.status(), Status::Unauthorized, "expected 401 for case: {case}");
+        bodies.push((case, body_of(response).await));
+    }
+
+    // Every failure cause must produce a byte-identical body: no signal about
+    // which check rejected the request.
+    let (_, first) = &bodies[0];
+    for (case, body) in &bodies {
+        assert_eq!(body, first, "401 body differs for case: {case}");
+    }
+    assert!(first.contains("urn:ietf:params:scim:api:messages:2.0:Error"));
+    assert!(first.contains("\"status\":\"401\""));
+}
+
+#[rocket::async_test]
+async fn unknown_scim_route_is_scim_enveloped_404() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, _pool) = scim_client().await;
+
+    let response = client.get("/scim/v2/some-org/Nope").dispatch().await;
+    assert_eq!(response.status(), Status::NotFound);
+    let body = body_of(response).await;
+    assert!(body.contains("urn:ietf:params:scim:api:messages:2.0:Error"));
+    assert!(body.contains("\"status\":\"404\""));
+}
+
+#[test]
+fn rate_limiter_returns_429_when_drained() {
+    // Uses a synthetic IP so draining this bucket cannot affect the shared
+    // bucket the HTTP tests consume from (the limiter is keyed by IP).
+    let ip: std::net::IpAddr = "10.99.99.99".parse().expect("test ip");
+    let burst = crate::CONFIG.scim_ratelimit_max_burst();
+    let mut limited = false;
+    for _ in 0..=burst {
+        if crate::ratelimit::check_limit_scim(&ip).is_err() {
+            limited = true;
+            break;
+        }
+    }
+    assert!(limited, "limiter never tripped after {burst} + 1 requests");
+}

--- a/src/api/scim/tests/mod.rs
+++ b/src/api/scim/tests/mod.rs
@@ -18,12 +18,14 @@ use rocket::{
     local::asynchronous::{Client, LocalResponse},
 };
 
+use serde_json::Value;
+
 use crate::{
     api::scim,
     crypto,
     db::{
         DbConn, DbPool,
-        models::{Organization, OrganizationId, ScimApiKey},
+        models::{Membership, MembershipId, MembershipType, Organization, OrganizationId, ScimApiKey, User},
     },
 };
 
@@ -189,4 +191,368 @@ fn rate_limiter_returns_429_when_drained() {
         }
     }
     assert!(limited, "limiter never tripped after {burst} + 1 requests");
+}
+
+// ---------------------------------------------------------------------------
+// Users lifecycle (Phase 1: provision, deprovision, restore)
+// ---------------------------------------------------------------------------
+
+fn scim_body(header_token: &str, body: &Value) -> (Header<'static>, Header<'static>, String) {
+    (bearer(header_token), Header::new("Content-Type", "application/scim+json"), body.to_string())
+}
+
+async fn seed_user(conn: &DbConn, email: &str, with_password: bool) -> User {
+    let mut user = User::new(email, None);
+    if with_password {
+        user.password_hash = vec![1, 2, 3];
+    }
+    user.save(conn).await.expect("saving test user");
+    user
+}
+
+async fn seed_member(
+    conn: &DbConn,
+    org: &OrganizationId,
+    email: &str,
+    status: i32,
+    atype: MembershipType,
+) -> MembershipId {
+    let user = seed_user(conn, email, true).await;
+    let mut member = Membership::new(user.uuid, org.clone(), None);
+    member.status = status;
+    member.atype = atype as i32;
+    member.save(conn).await.expect("saving test member");
+    member.uuid
+}
+
+async fn member_status(conn: &DbConn, member_id: &MembershipId, org: &OrganizationId) -> i32 {
+    Membership::find_by_uuid_and_org(member_id, org, conn).await.expect("membership row must exist").status
+}
+
+fn parse_json(body: &str) -> Value {
+    serde_json::from_str(body).expect("valid json body")
+}
+
+#[rocket::async_test]
+async fn post_creates_invited_user() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-post-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "Provision.Me@Example.com",
+        "externalId": "entra-obj-001",
+        "name": {"givenName": "Provision", "familyName": "Me"},
+        "emails": [{"value": "Provision.Me@Example.com", "primary": true}],
+        "active": true,
+    });
+    let (auth, content_type, body) = scim_body(&token, &payload);
+    let response =
+        client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
+
+    assert_eq!(response.status(), Status::Created);
+    let location = response.headers().get_one("Location").expect("Location header").to_string();
+    let parsed = parse_json(&body_of(response).await);
+
+    // Mail is disabled and the user is new (no password): Invited (0).
+    assert_eq!(parsed["active"], json!(true));
+    assert_eq!(parsed["userName"], json!("provision.me@example.com"), "email must be stored lowercased");
+    assert_eq!(parsed["externalId"], json!("entra-obj-001"));
+    let member_id: MembershipId = parsed["id"].as_str().expect("id").to_owned().into();
+    assert!(location.ends_with(&format!("/scim/v2/{org}/Users/{member_id}")));
+
+    assert_eq!(member_status(&conn, &member_id, &org).await, 0, "new shell user must land at Invited");
+    assert!(User::find_by_mail("provision.me@example.com", &conn).await.is_some());
+}
+
+#[rocket::async_test]
+async fn post_existing_credentialed_user_becomes_accepted() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-post-accepted-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    seed_user(&conn, "has.password@example.com", true).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "has.password@example.com",
+        "externalId": "entra-obj-002",
+    });
+    let (auth, content_type, body) = scim_body(&token, &payload);
+    let response =
+        client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
+
+    assert_eq!(response.status(), Status::Created);
+    let parsed = parse_json(&body_of(response).await);
+    let member_id: MembershipId = parsed["id"].as_str().expect("id").to_owned().into();
+    // Mail disabled + existing credentials: straight to Accepted (1).
+    assert_eq!(member_status(&conn, &member_id, &org).await, 1);
+}
+
+#[rocket::async_test]
+async fn post_duplicate_is_409_uniqueness() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-dup-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "dup@example.com",
+        "externalId": "entra-dup-1",
+    });
+    let (auth, content_type, body) = scim_body(&token, &payload);
+    let response =
+        client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Created);
+
+    // Same externalId again.
+    let (auth, content_type, body) = scim_body(&token, &payload);
+    let response =
+        client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["scimType"], json!("uniqueness"));
+
+    // Same email, different externalId.
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "dup@example.com",
+        "externalId": "entra-dup-2",
+    });
+    let (auth, content_type, body) = scim_body(&token, &payload);
+    let response =
+        client.post(format!("/scim/v2/{org}/Users")).header(auth).header(content_type).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+}
+
+#[rocket::async_test]
+async fn patch_active_lifecycle_hits_correct_status_offsets() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-patch-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let invited = seed_member(&conn, &org, "patch.invited@example.com", 0, MembershipType::User).await;
+    let confirmed = seed_member(&conn, &org, "patch.confirmed@example.com", 2, MembershipType::User).await;
+
+    let deactivate = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "Replace", "path": "active", "value": "False"}],
+    });
+    let activate = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "value": {"active": true}}],
+    });
+
+    // Invited (0) revokes to -128, never -1.
+    let (auth, ct, body) = scim_body(&token, &deactivate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{invited}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(parse_json(&body_of(response).await)["active"], json!(false));
+    assert_eq!(member_status(&conn, &invited, &org).await, -128);
+
+    // Deprovisioning is idempotent.
+    let (auth, ct, body) = scim_body(&token, &deactivate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{invited}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(member_status(&conn, &invited, &org).await, -128);
+
+    // Restore is lossless: straight back to Invited (0).
+    let (auth, ct, body) = scim_body(&token, &activate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{invited}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(member_status(&conn, &invited, &org).await, 0);
+
+    // Confirmed (2) revokes to -126 and restores to 2 with akey intact.
+    let (auth, ct, body) = scim_body(&token, &deactivate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{confirmed}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(member_status(&conn, &confirmed, &org).await, -126);
+
+    let response = client.get(format!("/scim/v2/{org}/Users/{confirmed}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(parse_json(&body_of(response).await)["active"], json!(false));
+
+    let (auth, ct, body) = scim_body(&token, &activate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{confirmed}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(member_status(&conn, &confirmed, &org).await, 2);
+}
+
+#[rocket::async_test]
+async fn delete_revokes_and_keeps_the_row() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-delete-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member = seed_member(&conn, &org, "delete.me@example.com", 2, MembershipType::User).await;
+
+    let response = client.delete(format!("/scim/v2/{org}/Users/{member}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::NoContent);
+    // The row survives (revoked), so restore stays lossless.
+    assert_eq!(member_status(&conn, &member, &org).await, -126);
+
+    // Idempotent.
+    let response = client.delete(format!("/scim/v2/{org}/Users/{member}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::NoContent);
+    assert_eq!(member_status(&conn, &member, &org).await, -126);
+}
+
+#[rocket::async_test]
+async fn last_confirmed_owner_cannot_be_revoked() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-owner-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let owner = seed_member(&conn, &org, "sole.owner@example.com", 2, MembershipType::Owner).await;
+
+    let deactivate = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "active", "value": false}],
+    });
+    let (auth, ct, body) = scim_body(&token, &deactivate);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{owner}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["scimType"], json!("mutability"));
+    assert_eq!(member_status(&conn, &owner, &org).await, 2, "owner must remain untouched");
+
+    // DELETE takes the same path.
+    let response = client.delete(format!("/scim/v2/{org}/Users/{owner}")).header(bearer(&token)).dispatch().await;
+    assert_eq!(response.status(), Status::Conflict);
+    assert_eq!(member_status(&conn, &owner, &org).await, 2);
+}
+
+#[rocket::async_test]
+async fn filter_round_trip_and_enumeration_shape() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-filter-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    seed_member(&conn, &org, "filter.target@example.com", 1, MembershipType::User).await;
+
+    // Mixed-case filter value must match the lowercased stored email.
+    let filter = "userName eq \"Filter.Target@Example.COM\"";
+    let response = client
+        .get(format!("/scim/v2/{org}/Users?filter={}", url_escape(filter)))
+        .header(bearer(&token))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(1));
+    assert_eq!(parsed["Resources"][0]["userName"], json!("filter.target@example.com"));
+
+    // A miss is an empty 200 list, not a 404: Entra's Test Connection probes
+    // exactly this, and a distinguishable miss would enable enumeration.
+    let filter = "userName eq \"nobody-here@example.com\"";
+    let response = client
+        .get(format!("/scim/v2/{org}/Users?filter={}", url_escape(filter)))
+        .header(bearer(&token))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["totalResults"], json!(0));
+
+    // Unsupported grammar is a 400 invalidFilter.
+    let filter = "userName co \"partial\"";
+    let response = client
+        .get(format!("/scim/v2/{org}/Users?filter={}", url_escape(filter)))
+        .header(bearer(&token))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::BadRequest);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["scimType"], json!("invalidFilter"));
+}
+
+#[rocket::async_test]
+async fn unknown_member_and_foreign_member_are_identical_404s() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org_a = seed_org(&conn, "scim-404-a").await;
+    let token_a = seed_scim_key(&conn, &org_a).await;
+    let org_b = seed_org(&conn, "scim-404-b").await;
+    let _token_b = seed_scim_key(&conn, &org_b).await;
+    let foreign = seed_member(&conn, &org_b, "foreign.member@example.com", 2, MembershipType::User).await;
+
+    let response = client
+        .get(format!("/scim/v2/{org_a}/Users/00000000-dead-beef-0000-000000000000"))
+        .header(bearer(&token_a))
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::NotFound);
+    let unknown_body = body_of(response).await;
+
+    // Another org's member id must be indistinguishable from a nonexistent one.
+    let response = client.get(format!("/scim/v2/{org_a}/Users/{foreign}")).header(bearer(&token_a)).dispatch().await;
+    assert_eq!(response.status(), Status::NotFound);
+    let foreign_body = body_of(response).await;
+    assert_eq!(unknown_body, foreign_body);
+}
+
+#[rocket::async_test]
+async fn post_inactive_creates_revoked_membership() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-inactive-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "userName": "born.disabled@example.com",
+        "externalId": "entra-inactive-1",
+        "active": "False",
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response = client.post(format!("/scim/v2/{org}/Users")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::Created);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["active"], json!(false));
+    let member_id: MembershipId = parsed["id"].as_str().expect("id").to_owned().into();
+    assert_eq!(member_status(&conn, &member_id, &org).await, -128, "invited-then-revoked offset");
+}
+
+#[rocket::async_test]
+async fn patch_unsupported_path_is_invalid_path() {
+    let _guard = TEST_LOCK.lock().await;
+    let (client, pool) = scim_client().await;
+    let conn = pool.get().await.expect("conn");
+    let org = seed_org(&conn, "scim-badpatch-org").await;
+    let token = seed_scim_key(&conn, &org).await;
+    let member = seed_member(&conn, &org, "bad.patch@example.com", 1, MembershipType::User).await;
+
+    let payload = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "replace", "path": "displayName", "value": "New Name"}],
+    });
+    let (auth, ct, body) = scim_body(&token, &payload);
+    let response =
+        client.patch(format!("/scim/v2/{org}/Users/{member}")).header(auth).header(ct).body(body).dispatch().await;
+    assert_eq!(response.status(), Status::BadRequest);
+    let parsed = parse_json(&body_of(response).await);
+    assert_eq!(parsed["scimType"], json!("invalidPath"));
+}
+
+fn url_escape(raw: &str) -> String {
+    // Percent-encode just enough for filter values in test URLs.
+    raw.replace('%', "%25").replace(' ', "%20").replace('"', "%22")
 }

--- a/src/api/scim/users.rs
+++ b/src/api/scim/users.rs
@@ -1,0 +1,373 @@
+//
+// SCIM /Users endpoints. The SCIM User id is the org-membership uuid
+// (MembershipId), not the global user uuid: SCIM is org-scoped and one person
+// can belong to several organizations.
+//
+// Deprovisioning maps to REVOKE, never delete: the membership row and its
+// akey survive, so restore is lossless and needs no re-confirmation. This is
+// a deliberate deviation from RFC 7644 DELETE semantics, matching the
+// existing Directory Connector import endpoint, and it means a compromised
+// SCIM token cannot destroy memberships.
+//
+// Provisioning creates at most Invited (or Accepted when mail is disabled
+// and the user already has credentials). Confirmed requires an admin client
+// to wrap the org key for the member; no server-side path can do that.
+//
+use rocket::Route;
+use serde_json::Value;
+
+use crate::{
+    CONFIG,
+    api::{
+        EmptyResult,
+        core::log_event,
+        scim::{
+            ScimJson, ScimResponse,
+            error::ScimError,
+            filter::parse_eq_filter,
+            guard::ScimToken,
+            models::ScimUserRequest,
+            patch::{PatchOp, parse_user_patch},
+        },
+    },
+    db::{
+        DbConn,
+        models::{
+            EventType, Invitation, Membership, MembershipId, MembershipStatus, MembershipType, OrgPolicy, Organization,
+            User,
+        },
+    },
+    mail,
+    util::is_valid_email,
+};
+
+pub fn routes() -> Vec<Route> {
+    routes![list_users, get_user, post_user, patch_user, delete_user]
+}
+
+// Synthetic acting user recorded in the org event log for SCIM-driven
+// changes, following the ACTING_ADMIN_USER precedent in the admin panel.
+const SCIM_ACTOR: &str = "vaultwarden-scim-00000-000000000000";
+// Device type recorded for SCIM events: 14 = UnknownBrowser, same as admin.
+const SCIM_DEVICE_TYPE: i32 = 14;
+
+// The single place the revocation encoding is interpreted: revoked statuses
+// are stored as status - 128 (ACTIVATE_REVOKE_DIFF), so every stored revoked
+// value is <= Revoked (-1). Never compare equality against Revoked.
+fn membership_active(member: &Membership) -> bool {
+    member.status > MembershipStatus::Revoked as i32
+}
+
+fn to_scim_user(member: &Membership, user: &User, token: &ScimToken) -> Value {
+    let location = format!("{}/scim/v2/{}/Users/{}", CONFIG.domain(), token.org_uuid, member.uuid);
+    json!({
+        "schemas": [crate::api::scim::discovery::USER_SCHEMA_URN],
+        "id": member.uuid,
+        "externalId": member.external_id,
+        "userName": user.email,
+        "displayName": user.name,
+        "active": membership_active(member),
+        "emails": [{"value": user.email, "primary": true, "type": "work"}],
+        "meta": {
+            "resourceType": "User",
+            "location": location,
+        },
+    })
+}
+
+async fn log_scim_event(event_type: EventType, member: &Membership, token: &ScimToken, conn: &DbConn) {
+    log_event(
+        event_type as i32,
+        &member.uuid,
+        &token.org_uuid,
+        &SCIM_ACTOR.into(),
+        SCIM_DEVICE_TYPE,
+        &token.ip.ip,
+        conn,
+    )
+    .await;
+}
+
+fn list_response(total: usize, start_index: usize, resources: &[Value]) -> ScimResponse {
+    ScimResponse::ok(json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        "totalResults": total,
+        "itemsPerPage": resources.len(),
+        "startIndex": start_index,
+        "Resources": resources,
+    }))
+}
+
+#[derive(FromForm)]
+pub struct ListParams {
+    filter: Option<String>,
+    #[field(name = "startIndex")]
+    start_index: Option<i64>,
+    count: Option<i64>,
+}
+
+#[get("/v2/<_>/Users?<params..>")]
+async fn list_users(params: ListParams, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    // Resolve the matching memberships first, then paginate.
+    let members: Vec<Membership> = if let Some(raw_filter) = params.filter.as_deref() {
+        let eq = parse_eq_filter(raw_filter)?;
+        match eq.attribute.as_str() {
+            // find_by_mail lowercases internally, so a mixed-case userName
+            // from Entra still matches the lowercased stored email.
+            "username" | "emails.value" => match User::find_by_mail(&eq.value, &conn).await {
+                Some(user) => {
+                    Membership::find_by_user_and_org(&user.uuid, &token.org_uuid, &conn).await.into_iter().collect()
+                }
+                None => Vec::new(),
+            },
+            "externalid" => {
+                Membership::find_by_external_id_and_org(&eq.value, &token.org_uuid, &conn).await.into_iter().collect()
+            }
+            _ => {
+                return Err(ScimError::bad_request(
+                    "invalidFilter",
+                    "Filterable attributes are userName and externalId",
+                ));
+            }
+        }
+    } else {
+        Membership::find_by_org(&token.org_uuid, &conn).await
+    };
+
+    let total = members.len();
+    let start_index = usize::try_from(params.start_index.unwrap_or(1)).unwrap_or(1).max(1);
+    let count = usize::try_from(params.count.unwrap_or(100)).unwrap_or(0).min(200);
+
+    let mut resources = Vec::new();
+    for member in members.into_iter().skip(start_index - 1).take(count) {
+        // A membership always references a user; a missing row would be a
+        // dangling foreign key, so surface it as a 500 rather than skip.
+        let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
+            return Err(ScimError::internal());
+        };
+        resources.push(to_scim_user(&member, &user, &token));
+    }
+
+    Ok(list_response(total, start_index, &resources))
+}
+
+#[get("/v2/<_>/Users/<member_id>")]
+async fn get_user(member_id: MembershipId, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    let Some(member) = Membership::find_by_uuid_and_org(&member_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
+        return Err(ScimError::internal());
+    };
+    Ok(ScimResponse::ok(to_scim_user(&member, &user, &token)))
+}
+
+#[post("/v2/<_>/Users", data = "<data>")]
+async fn post_user(data: ScimJson<ScimUserRequest>, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    let request = data.0;
+
+    let Some(email) = request.email() else {
+        return Err(ScimError::bad_request("invalidValue", "userName (or a primary email) must be an email address"));
+    };
+    if !is_valid_email(email) {
+        return Err(ScimError::bad_request("invalidValue", "userName is not a valid email address"));
+    }
+
+    // Uniqueness: by externalId and by email, both scoped to the org.
+    if let Some(external_id) = request.external_id.as_deref()
+        && Membership::find_by_external_id_and_org(external_id, &token.org_uuid, &conn).await.is_some()
+    {
+        return Err(ScimError::conflict("uniqueness", "A member with this externalId already exists"));
+    }
+    if Membership::find_by_email_and_org(email, &token.org_uuid, &conn).await.is_some() {
+        return Err(ScimError::conflict("uniqueness", "A member with this userName already exists"));
+    }
+
+    let Some(org) = Organization::find_by_uuid(&token.org_uuid, &conn).await else {
+        return Err(ScimError::internal());
+    };
+
+    // Mirrors the Directory Connector import: link an existing account by
+    // email, or create a shell account (no keypair yet) that the invite email
+    // lets the person register.
+    let mut user_created = false;
+    let user = if let Some(user) = User::find_by_mail(email, &conn).await {
+        user
+    } else {
+        let mut new_user = User::new(email, request.display_name());
+        new_user.save(&conn).await.map_err(|_| ScimError::internal())?;
+        if !CONFIG.mail_enabled() {
+            Invitation::new(&new_user.email).save(&conn).await.map_err(|_| ScimError::internal())?;
+        }
+        user_created = true;
+        new_user
+    };
+
+    // Reaching Accepted directly is only possible when no invite mail will be
+    // sent and the account already has credentials to log in with.
+    let member_status = if CONFIG.mail_enabled() || user.password_hash.is_empty() {
+        MembershipStatus::Invited as i32
+    } else {
+        MembershipStatus::Accepted as i32
+    };
+
+    // RFC 7644 allows creating a resource already deactivated; store the
+    // membership pre-revoked and send no invite mail in that case.
+    let create_active = request.active.is_none_or(|b| b.0);
+
+    let mut member = Membership::new(user.uuid.clone(), token.org_uuid.clone(), Some(org.billing_email.clone()));
+    member.set_external_id(request.external_id.clone());
+    member.access_all = false;
+    member.atype = MembershipType::User as i32;
+    member.status = member_status;
+    if !create_active {
+        member.revoke();
+    }
+    member.save(&conn).await.map_err(|_| ScimError::internal())?;
+
+    if create_active
+        && CONFIG.mail_enabled()
+        && let Err(e) = mail::send_invite(
+            &user,
+            token.org_uuid.clone(),
+            member.uuid.clone(),
+            &org.name,
+            Some(org.billing_email.clone()),
+        )
+        .await
+    {
+        error!("SCIM provisioning rollback, invite mail failed: {e:#?}");
+        let rollback: EmptyResult = if user_created {
+            user.delete(&conn).await
+        } else {
+            member.delete(&conn).await
+        };
+        drop(rollback);
+        return Err(ScimError::internal());
+    }
+
+    log_scim_event(EventType::OrganizationUserInvited, &member, &token, &conn).await;
+    if !create_active {
+        log_scim_event(EventType::OrganizationUserRevoked, &member, &token, &conn).await;
+    }
+
+    let location = format!("{}/scim/v2/{}/Users/{}", CONFIG.domain(), token.org_uuid, member.uuid);
+    Ok(ScimResponse::created(location, to_scim_user(&member, &user, &token)))
+}
+
+#[patch("/v2/<_>/Users/<member_id>", data = "<data>")]
+async fn patch_user(
+    member_id: MembershipId,
+    data: ScimJson<PatchOp>,
+    token: ScimToken,
+    conn: DbConn,
+) -> Result<ScimResponse, ScimError> {
+    let Some(mut member) = Membership::find_by_uuid_and_org(&member_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+
+    let patch = parse_user_patch(&data.0)?;
+    let Some(desired_active) = patch.active else {
+        return Err(ScimError::bad_request("invalidValue", "No supported attributes in patch (supported: active)"));
+    };
+
+    if desired_active {
+        restore_member(&mut member, &token, &conn).await?;
+    } else {
+        revoke_member(&mut member, &token, &conn).await?;
+    }
+
+    let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
+        return Err(ScimError::internal());
+    };
+    Ok(ScimResponse::ok(to_scim_user(&member, &user, &token)))
+}
+
+// DELETE deprovisions by revoking, identically to PATCH active:false. The
+// membership row is kept: see the module comment.
+#[delete("/v2/<_>/Users/<member_id>")]
+async fn delete_user(member_id: MembershipId, token: ScimToken, conn: DbConn) -> Result<ScimResponse, ScimError> {
+    let Some(mut member) = Membership::find_by_uuid_and_org(&member_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    revoke_member(&mut member, &token, &conn).await?;
+    Ok(ScimResponse::no_content())
+}
+
+async fn revoke_member(member: &mut Membership, token: &ScimToken, conn: &DbConn) -> Result<(), ScimError> {
+    if !membership_active(member) {
+        // Already revoked: deprovisioning is idempotent.
+        return Ok(());
+    }
+
+    // Never leave an organization without a confirmed owner.
+    if member.atype == MembershipType::Owner
+        && member.status == MembershipStatus::Confirmed as i32
+        && Membership::count_confirmed_by_org_and_type(&token.org_uuid, MembershipType::Owner, conn).await <= 1
+    {
+        return Err(ScimError::conflict("mutability", "Cannot revoke the last confirmed owner of the organization"));
+    }
+
+    member.revoke();
+    member.save(conn).await.map_err(|_| ScimError::internal())?;
+    log_scim_event(EventType::OrganizationUserRevoked, member, token, conn).await;
+    Ok(())
+}
+
+async fn restore_member(member: &mut Membership, token: &ScimToken, conn: &DbConn) -> Result<(), ScimError> {
+    if membership_active(member) {
+        return Ok(());
+    }
+
+    member.restore();
+    // Policy check runs on the restored status, mirroring restore_member_impl.
+    if OrgPolicy::check_user_allowed(member, "restore", conn).await.is_err() {
+        return Err(ScimError::bad_request("invalidValue", "Restore is blocked by an organization policy"));
+    }
+    member.save(conn).await.map_err(|_| ScimError::internal())?;
+    log_scim_event(EventType::OrganizationUserRestored, member, token, conn).await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn member_with_status(status: i32) -> Membership {
+        let mut member = Membership::new("test-user".to_owned().into(), "test-org".to_owned().into(), None);
+        member.status = status;
+        member
+    }
+
+    #[test]
+    fn active_mapping_handles_revocation_offsets() {
+        // Stored revoked values are status - 128; Revoked (-1) itself is a
+        // sentinel that never hits the database.
+        for (status, expected_active) in [(2, true), (1, true), (0, true), (-126, false), (-127, false), (-128, false)]
+        {
+            assert_eq!(membership_active(&member_with_status(status)), expected_active, "status {status}");
+        }
+    }
+
+    #[test]
+    fn revoke_restore_arithmetic_round_trips() {
+        for initial in [0, 1, 2] {
+            let mut member = member_with_status(initial);
+            assert!(member.revoke());
+            assert_eq!(member.status, initial - 128);
+            assert!(!member.revoke(), "revoke must be idempotent");
+            assert!(member.restore());
+            assert_eq!(member.status, initial);
+            assert!(!member.restore(), "restore must be idempotent");
+        }
+    }
+
+    #[test]
+    fn from_i32_still_rejects_revoked_values() {
+        // Regression canary: OrgHeaders relies on revoked statuses mapping to
+        // None. If upstream ever changes this, revisit membership_active().
+        assert!(MembershipStatus::from_i32(-126).is_none());
+        assert!(MembershipStatus::from_i32(-128).is_none());
+        assert!(MembershipStatus::from_i32(-1).is_none());
+    }
+}

--- a/src/api/scim/users.rs
+++ b/src/api/scim/users.rs
@@ -13,6 +13,8 @@
 // and the user already has credentials). Confirmed requires an admin client
 // to wrap the org key for the member; no server-side path can do that.
 //
+use std::collections::HashMap;
+
 use rocket::Route;
 use serde_json::Value;
 
@@ -22,7 +24,7 @@ use crate::{
         EmptyResult,
         core::log_event,
         scim::{
-            ScimJson, ScimResponse,
+            SCIM_ACTOR, SCIM_DEVICE_TYPE, ScimJson, ScimResponse,
             error::ScimError,
             filter::parse_eq_filter,
             guard::ScimToken,
@@ -34,7 +36,7 @@ use crate::{
         DbConn,
         models::{
             EventType, Invitation, Membership, MembershipId, MembershipStatus, MembershipType, OrgPolicy, Organization,
-            User,
+            User, UserId,
         },
     },
     mail,
@@ -45,12 +47,6 @@ pub fn routes() -> Vec<Route> {
     routes![list_users, get_user, post_user, put_user, patch_user, delete_user]
 }
 
-// Synthetic acting user recorded in the org event log for SCIM-driven
-// changes, following the ACTING_ADMIN_USER precedent in the admin panel.
-const SCIM_ACTOR: &str = "vaultwarden-scim-00000-000000000000";
-// Device type recorded for SCIM events: 14 = UnknownBrowser, same as admin.
-const SCIM_DEVICE_TYPE: i32 = 14;
-
 // The single place the revocation encoding is interpreted: revoked statuses
 // are stored as status - 128 (ACTIVATE_REVOKE_DIFF), so every stored revoked
 // value is <= Revoked (-1). Never compare equality against Revoked.
@@ -59,7 +55,7 @@ fn membership_active(member: &Membership) -> bool {
 }
 
 fn to_scim_user(member: &Membership, user: &User, token: &ScimToken) -> Value {
-    let location = format!("{}/scim/v2/{}/Users/{}", CONFIG.domain(), token.org_uuid, member.uuid);
+    let location = crate::api::scim::resource_location(&token.org_uuid, "Users", &member.uuid);
     json!({
         "schemas": [crate::api::scim::discovery::USER_SCHEMA_URN],
         "id": member.uuid,
@@ -86,16 +82,6 @@ async fn log_scim_event(event_type: EventType, member: &Membership, token: &Scim
         conn,
     )
     .await;
-}
-
-fn list_response(total: usize, start_index: usize, resources: &[Value]) -> ScimResponse {
-    ScimResponse::ok(json!({
-        "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-        "totalResults": total,
-        "itemsPerPage": resources.len(),
-        "startIndex": start_index,
-        "Resources": resources,
-    }))
 }
 
 #[derive(FromForm)]
@@ -135,20 +121,24 @@ async fn list_users(params: ListParams, token: ScimToken, conn: DbConn) -> Resul
     };
 
     let total = members.len();
-    let start_index = usize::try_from(params.start_index.unwrap_or(1)).unwrap_or(1).max(1);
-    let count = usize::try_from(params.count.unwrap_or(100)).unwrap_or(0).min(200);
+    let (start_index, count) = crate::api::scim::page_bounds(params.start_index, params.count);
 
-    let mut resources = Vec::new();
-    for member in members.into_iter().skip(start_index - 1).take(count) {
+    let page: Vec<Membership> = members.into_iter().skip(start_index - 1).take(count).collect();
+    let user_ids: Vec<UserId> = page.iter().map(|member| member.user_uuid.clone()).collect();
+    let users: HashMap<UserId, User> =
+        User::find_by_uuids(&user_ids, &conn).await.into_iter().map(|user| (user.uuid.clone(), user)).collect();
+
+    let mut resources = Vec::with_capacity(page.len());
+    for member in &page {
         // A membership always references a user; a missing row would be a
         // dangling foreign key, so surface it as a 500 rather than skip.
-        let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
+        let Some(user) = users.get(&member.user_uuid) else {
             return Err(ScimError::internal());
         };
-        resources.push(to_scim_user(&member, &user, &token));
+        resources.push(to_scim_user(member, user, &token));
     }
 
-    Ok(list_response(total, start_index, &resources))
+    Ok(crate::api::scim::list_response(total, start_index, &resources))
 }
 
 #[get("/v2/<_>/Users/<member_id>")]
@@ -237,12 +227,7 @@ async fn post_user(data: ScimJson<ScimUserRequest>, token: ScimToken, conn: DbCo
         .await
     {
         error!("SCIM provisioning rollback, invite mail failed: {e:#?}");
-        let rollback: EmptyResult = if user_created {
-            user.delete(&conn).await
-        } else {
-            member.delete(&conn).await
-        };
-        drop(rollback);
+        rollback_provisioning(user, member, user_created, &conn).await;
         return Err(ScimError::internal());
     }
 
@@ -251,8 +236,28 @@ async fn post_user(data: ScimJson<ScimUserRequest>, token: ScimToken, conn: DbCo
         log_scim_event(EventType::OrganizationUserRevoked, &member, &token, &conn).await;
     }
 
-    let location = format!("{}/scim/v2/{}/Users/{}", CONFIG.domain(), token.org_uuid, member.uuid);
+    let location = crate::api::scim::resource_location(&token.org_uuid, "Users", &member.uuid);
     Ok(ScimResponse::created(location, to_scim_user(&member, &user, &token)))
+}
+
+// Rollback for a provisioning that failed after its rows were written. The
+// destructive decision lives here so it can be tested directly: a user this
+// request created is removed entirely (User::delete cascades the membership),
+// while a pre-existing account must survive and only the new membership goes.
+pub(super) async fn rollback_provisioning(user: User, member: Membership, user_created: bool, conn: &DbConn) {
+    let rollback: EmptyResult = if user_created {
+        user.delete(conn).await
+    } else {
+        member.delete(conn).await
+    };
+    if let Err(rollback_err) = rollback {
+        let orphan = if user_created {
+            "user"
+        } else {
+            "membership"
+        };
+        error!("SCIM provisioning rollback failed, orphaned {orphan} row remains: {rollback_err:#?}");
+    }
 }
 
 #[patch("/v2/<_>/Users/<member_id>", data = "<data>")]
@@ -379,6 +384,29 @@ async fn restore_member(member: &mut Membership, token: &ScimToken, conn: &DbCon
         return Err(ScimError::bad_request("invalidValue", "Restore is blocked by an organization policy"));
     }
     member.save(conn).await.map_err(|_| ScimError::internal())?;
+
+    // A member restored to Invited has never joined the org. The original
+    // invite may never have been sent (created active:false) or have expired,
+    // so re-send it; otherwise the person has a membership and shell account
+    // they were never told about and cannot register into.
+    if member.status == MembershipStatus::Invited as i32
+        && CONFIG.mail_enabled()
+        && let (Some(user), Some(org)) =
+            (User::find_by_uuid(&member.user_uuid, conn).await, Organization::find_by_uuid(&token.org_uuid, conn).await)
+        && let Err(e) = mail::send_invite(
+            &user,
+            token.org_uuid.clone(),
+            member.uuid.clone(),
+            &org.name,
+            Some(org.billing_email.clone()),
+        )
+        .await
+    {
+        // The membership is already restored and valid; a mail hiccup must not
+        // fail the deprovision-reprovision cycle. Surface it in the log.
+        error!("SCIM restore succeeded but re-sending the invite failed: {e:#?}");
+    }
+
     log_scim_event(EventType::OrganizationUserRestored, member, token, conn).await;
     Ok(())
 }

--- a/src/api/scim/users.rs
+++ b/src/api/scim/users.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 pub fn routes() -> Vec<Route> {
-    routes![list_users, get_user, post_user, patch_user, delete_user]
+    routes![list_users, get_user, post_user, put_user, patch_user, delete_user]
 }
 
 // Synthetic acting user recorded in the org event log for SCIM-driven
@@ -267,20 +267,74 @@ async fn patch_user(
     };
 
     let patch = parse_user_patch(&data.0)?;
-    let Some(desired_active) = patch.active else {
-        return Err(ScimError::bad_request("invalidValue", "No supported attributes in patch (supported: active)"));
-    };
 
-    if desired_active {
-        restore_member(&mut member, &token, &conn).await?;
-    } else {
-        revoke_member(&mut member, &token, &conn).await?;
+    if let Some(external_id) = patch.external_id.as_deref() {
+        update_external_id(&mut member, external_id, &token, &conn).await?;
+    }
+
+    match patch.active {
+        Some(true) => restore_member(&mut member, &token, &conn).await?,
+        Some(false) => revoke_member(&mut member, &token, &conn).await?,
+        // Every operation was an accepted-but-ignored attribute (for example
+        // a displayName rename): succeed and return the current state.
+        None => {}
     }
 
     let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
         return Err(ScimError::internal());
     };
     Ok(ScimResponse::ok(to_scim_user(&member, &user, &token)))
+}
+
+// PUT replaces the attributes SCIM owns: externalId and active. userName,
+// name, and role deliberately do not sync: email is the login identity and
+// user.name is global to the person, while roles cannot round-trip through
+// Vaultwarden's membership types. The response reflects the actual state.
+#[put("/v2/<_>/Users/<member_id>", data = "<data>")]
+async fn put_user(
+    member_id: MembershipId,
+    data: ScimJson<ScimUserRequest>,
+    token: ScimToken,
+    conn: DbConn,
+) -> Result<ScimResponse, ScimError> {
+    let Some(mut member) = Membership::find_by_uuid_and_org(&member_id, &token.org_uuid, &conn).await else {
+        return Err(ScimError::not_found());
+    };
+    let request = data.0;
+
+    if let Some(external_id) = request.external_id.as_deref() {
+        update_external_id(&mut member, external_id, &token, &conn).await?;
+    }
+
+    match request.active.map(|b| b.0) {
+        Some(true) => restore_member(&mut member, &token, &conn).await?,
+        Some(false) => revoke_member(&mut member, &token, &conn).await?,
+        None => {}
+    }
+
+    let Some(user) = User::find_by_uuid(&member.user_uuid, &conn).await else {
+        return Err(ScimError::internal());
+    };
+    Ok(ScimResponse::ok(to_scim_user(&member, &user, &token)))
+}
+
+async fn update_external_id(
+    member: &mut Membership,
+    external_id: &str,
+    token: &ScimToken,
+    conn: &DbConn,
+) -> Result<(), ScimError> {
+    if member.external_id.as_deref() == Some(external_id) {
+        return Ok(());
+    }
+    // The externalId is the correlation key: enforce uniqueness within the org.
+    if Membership::find_by_external_id_and_org(external_id, &token.org_uuid, conn).await.is_some() {
+        return Err(ScimError::conflict("uniqueness", "A member with this externalId already exists"));
+    }
+    member.set_external_id(Some(external_id.to_owned()));
+    member.save(conn).await.map_err(|_| ScimError::internal())?;
+    log_scim_event(EventType::OrganizationUserUpdated, member, token, conn).await;
+    Ok(())
 }
 
 // DELETE deprovisions by revoking, identically to PATCH active:false. The

--- a/src/config.rs
+++ b/src/config.rs
@@ -1008,6 +1008,11 @@ fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
         println!("[WARNING] To enable the admin page without a token, use `DISABLE_ADMIN_TOKEN`.");
     }
 
+    if cfg.scim_enabled && !cfg.org_events_enabled {
+        println!("[WARNING] `SCIM_ENABLED` is set, but `ORG_EVENTS_ENABLED` is not.");
+        println!("[WARNING] SCIM provisioning changes will not appear in the organization event log.");
+    }
+
     if cfg.push_enabled && (cfg.push_installation_id == String::new() || cfg.push_installation_key == String::new()) {
         err!(
             "Misconfigured Push Notification service\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -779,6 +779,13 @@ make_config! {
         /// Enable groups (BETA!) (Know the risks!) |> Enables groups support for organizations (Currently contains known issues!).
         org_groups_enabled:            bool, false, def, false;
 
+        /// Enable SCIM v2 provisioning (BETA!) |> Master switch for the /scim/v2 endpoints. An organization also needs a generated SCIM API key before its endpoints accept requests.
+        scim_enabled:                  bool, false, def, false;
+        /// Seconds between SCIM requests |> Number of seconds, on average, between SCIM requests from the same IP address before rate limiting kicks in
+        scim_ratelimit_seconds:        u64, false, def, 1;
+        /// Max burst size for SCIM requests |> Allow a burst of requests of up to this size, while maintaining the average indicated by `scim_ratelimit_seconds`. Entra ID sends bursts during sync cycles.
+        scim_ratelimit_max_burst:      u32, false, def, 60;
+
         /// Increase note size limit (Know the risks!) |> Sets the secure note size limit to 100_000 instead of the default 10_000.
         /// WARNING: This could cause issues with clients. Also exports will not work on Bitwarden servers!
         increase_note_size_limit:      bool,  true,  def, false;

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -11,6 +11,7 @@ mod folder;
 mod group;
 mod org_policy;
 mod organization;
+mod scim_api_key;
 mod send;
 mod sso_auth;
 mod two_factor;
@@ -34,6 +35,7 @@ pub use self::organization::{
     Membership, MembershipId, MembershipStatus, MembershipType, OrgApiKeyId, Organization, OrganizationApiKey,
     OrganizationId,
 };
+pub use self::scim_api_key::ScimApiKey;
 pub use self::send::{Send, SendFileId, SendId, SendType};
 pub use self::sso_auth::{OIDCAuthenticatedUser, OIDCCodeResponseError, SsoAuth};
 pub use self::two_factor::{TwoFactor, TwoFactorType};

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -383,6 +383,7 @@ impl Organization {
         OrgPolicy::delete_all_by_organization(&self.uuid, conn).await?;
         Group::delete_all_by_organization(&self.uuid, conn).await?;
         OrganizationApiKey::delete_all_by_organization(&self.uuid, conn).await?;
+        super::ScimApiKey::delete_all_by_organization(&self.uuid, conn).await?;
 
         conn.run(move |conn| {
             diesel::delete(organizations::table.filter(organizations::uuid.eq(self.uuid)))

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -210,7 +210,7 @@ impl Organization {
             "useGroups": CONFIG.org_groups_enabled(),
             "useTotp": true,
             "usePolicies": true,
-            "useScim": false, // Not supported (Not AGPLv3 Licensed)
+            "useScim": CONFIG.scim_enabled(), // Implemented in this fork; see src/api/scim
             "useSso": false, // Not supported
             "useKeyConnector": false, // Not supported
             "usePasswordManager": true,
@@ -480,7 +480,7 @@ impl Membership {
             "useEvents": CONFIG.org_events_enabled(),
             "useGroups": CONFIG.org_groups_enabled(),
             "useTotp": true,
-            "useScim": false, // Not supported (Not AGPLv3 Licensed)
+            "useScim": CONFIG.scim_enabled(), // Implemented in this fork; see src/api/scim
             "usePolicies": true,
             "useApi": true,
             "selfHost": true,

--- a/src/db/models/scim_api_key.rs
+++ b/src/db/models/scim_api_key.rs
@@ -18,6 +18,9 @@ pub struct ScimApiKey {
     // sha256 hex digest of the token secret. The plaintext secret is shown once
     // at generation time and never stored or logged.
     pub key_hash: String,
+    // Reserved for a future disable-without-deleting management endpoint.
+    // Nothing sets this to false yet, but the guard already honors it via
+    // find_active_by_org (asserted in the uniform-401 authz matrix test).
     pub enabled: bool,
     pub created_at: NaiveDateTime,
     pub revision_date: NaiveDateTime,
@@ -47,8 +50,9 @@ impl ScimApiKey {
     }
 
     pub async fn save(&self, conn: &DbConn) -> EmptyResult {
-        // Rotation replaces the row wholesale (delete + insert), so a plain
-        // insert with an update fallback covers every backend identically.
+        // Standard Vaultwarden upsert idiom: replace_into with an update
+        // fallback on sqlite/mysql, ON CONFLICT upsert on postgresql.
+        // Rotation itself goes through delete_all_by_organization + save.
         db_run! { conn:
             sqlite, mysql {
                 match diesel::replace_into(scim_api_key::table)

--- a/src/db/models/scim_api_key.rs
+++ b/src/db/models/scim_api_key.rs
@@ -1,0 +1,105 @@
+use chrono::{NaiveDateTime, Utc};
+use derive_more::Display;
+use diesel::prelude::*;
+
+use crate::{
+    api::EmptyResult,
+    crypto,
+    db::{DbConn, models::OrganizationId, schema::scim_api_key},
+    error::MapResult,
+};
+
+#[derive(Identifiable, Queryable, Insertable, AsChangeset)]
+#[diesel(table_name = scim_api_key)]
+#[diesel(primary_key(uuid))]
+pub struct ScimApiKey {
+    pub uuid: ScimApiKeyId,
+    pub org_uuid: OrganizationId,
+    // sha256 hex digest of the token secret. The plaintext secret is shown once
+    // at generation time and never stored or logged.
+    pub key_hash: String,
+    pub enabled: bool,
+    pub created_at: NaiveDateTime,
+    pub revision_date: NaiveDateTime,
+}
+
+#[derive(Clone, Debug, DieselNewType, Display, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScimApiKeyId(String);
+
+impl ScimApiKey {
+    pub fn new(org_uuid: OrganizationId, key_hash: String) -> Self {
+        let now = Utc::now().naive_utc();
+        Self {
+            uuid: ScimApiKeyId(crate::util::get_uuid()),
+            org_uuid,
+            key_hash,
+            enabled: true,
+            created_at: now,
+            revision_date: now,
+        }
+    }
+
+    // Constant-time comparison against a plaintext secret's digest. A dummy
+    // digest is compared when no key row exists so the caller can keep the
+    // verification cost independent of row presence.
+    pub fn check_valid_secret(&self, secret: &str) -> bool {
+        crypto::ct_eq(&self.key_hash, crypto::sha256_hex(secret.as_bytes()))
+    }
+
+    pub async fn save(&self, conn: &DbConn) -> EmptyResult {
+        // Rotation replaces the row wholesale (delete + insert), so a plain
+        // insert with an update fallback covers every backend identically.
+        db_run! { conn:
+            sqlite, mysql {
+                match diesel::replace_into(scim_api_key::table)
+                    .values(self)
+                    .execute(conn)
+                {
+                    Ok(_) => Ok(()),
+                    Err(diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::ForeignKeyViolation, _)) => {
+                        diesel::update(scim_api_key::table)
+                            .filter(scim_api_key::uuid.eq(&self.uuid))
+                            .set(self)
+                            .execute(conn)
+                            .map_res("Error saving SCIM api key")
+                    }
+                    Err(e) => Err(e.into()),
+                }.map_res("Error saving SCIM api key")
+            }
+            postgresql {
+                diesel::insert_into(scim_api_key::table)
+                    .values(self)
+                    .on_conflict(scim_api_key::uuid)
+                    .do_update()
+                    .set(self)
+                    .execute(conn)
+                    .map_res("Error saving SCIM api key")
+            }
+        }
+    }
+
+    pub async fn find_by_org(org_uuid: &OrganizationId, conn: &DbConn) -> Option<Self> {
+        conn.run(move |conn| scim_api_key::table.filter(scim_api_key::org_uuid.eq(org_uuid)).first::<Self>(conn).ok())
+            .await
+    }
+
+    pub async fn find_active_by_org(org_uuid: &OrganizationId, conn: &DbConn) -> Option<Self> {
+        conn.run(move |conn| {
+            scim_api_key::table
+                .filter(scim_api_key::org_uuid.eq(org_uuid))
+                .filter(scim_api_key::enabled.eq(true))
+                .first::<Self>(conn)
+                .ok()
+        })
+        .await
+    }
+
+    pub async fn delete_all_by_organization(org_uuid: &OrganizationId, conn: &DbConn) -> EmptyResult {
+        conn.run(move |conn| {
+            diesel::delete(scim_api_key::table.filter(scim_api_key::org_uuid.eq(org_uuid)))
+                .execute(conn)
+                .map_res("Error removing SCIM api key from organization")
+        })
+        .await
+    }
+}

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -394,6 +394,12 @@ impl User {
         conn.run(move |conn| users::table.filter(users::uuid.eq(uuid)).first::<Self>(conn).ok()).await
     }
 
+    pub async fn find_by_uuids(uuids: &[UserId], conn: &DbConn) -> Vec<Self> {
+        let uuids = uuids.to_vec();
+        conn.run(move |conn| users::table.filter(users::uuid.eq_any(uuids)).load::<Self>(conn).unwrap_or_default())
+            .await
+    }
+
     pub async fn find_by_device_for_email2fa(device_uuid: &DeviceId, conn: &DbConn) -> Option<Self> {
         if let Some(user_uuid) = conn
             .run(move |conn| {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -256,6 +256,17 @@ table! {
 }
 
 table! {
+    scim_api_key (uuid) {
+        uuid -> Text,
+        org_uuid -> Text,
+        key_hash -> Text,
+        enabled -> Bool,
+        created_at -> Timestamp,
+        revision_date -> Timestamp,
+    }
+}
+
+table! {
     sso_auth (state) {
         state -> Text,
         client_challenge -> Text,
@@ -373,6 +384,7 @@ joinable!(users_organizations -> organizations (org_uuid));
 joinable!(users_organizations -> users (user_uuid));
 joinable!(users_organizations -> ciphers (org_uuid));
 joinable!(organization_api_key -> organizations (org_uuid));
+joinable!(scim_api_key -> organizations (org_uuid));
 joinable!(emergency_access -> users (grantor_uuid));
 joinable!(groups -> organizations (organizations_uuid));
 joinable!(groups_users -> users_organizations (users_organizations_uuid));
@@ -402,6 +414,7 @@ allow_tables_to_appear_in_same_query!(
     users_collections,
     users_organizations,
     organization_api_key,
+    scim_api_key,
     emergency_access,
     groups,
     groups_users,

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,7 +577,8 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
     config.limits = Limits::new()
         .limit("json", 20.megabytes()) // 20MB should be enough for very large imports, something like 5000+ vault entries
         .limit("data-form", 525.megabytes()) // This needs to match the maximum allowed file size for Send
-        .limit("file", 525.megabytes()); // This needs to match the maximum allowed file size for attachments
+        .limit("file", 525.megabytes()) // This needs to match the maximum allowed file size for attachments
+        .limit("scim", 512.kibibytes()); // SCIM bodies are small; a tight cap limits abuse of the machine-auth endpoint
 
     // If adding more paths here, consider also adding them to
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log
@@ -589,9 +590,11 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         .mount([basepath, "/identity"].concat(), api::identity_routes())
         .mount([basepath, "/icons"].concat(), api::icons_routes())
         .mount([basepath, "/notifications"].concat(), api::notifications_routes())
+        .mount([basepath, "/scim"].concat(), api::scim_routes())
         .register([basepath, "/"].concat(), api::web_catchers())
         .register([basepath, "/api"].concat(), api::core_catchers())
         .register([basepath, "/admin"].concat(), api::admin_catchers())
+        .register([basepath, "/scim"].concat(), api::scim_catchers())
         .manage(pool)
         .manage(Arc::clone(&WS_USERS))
         .manage(Arc::clone(&WS_ANONYMOUS_SUBSCRIPTIONS))

--- a/src/main.rs
+++ b/src/main.rs
@@ -578,7 +578,7 @@ async fn launch_rocket(pool: db::DbPool, extra_debug: bool) -> Result<(), Error>
         .limit("json", 20.megabytes()) // 20MB should be enough for very large imports, something like 5000+ vault entries
         .limit("data-form", 525.megabytes()) // This needs to match the maximum allowed file size for Send
         .limit("file", 525.megabytes()) // This needs to match the maximum allowed file size for attachments
-        .limit("scim", 512.kibibytes()); // SCIM bodies are small; a tight cap limits abuse of the machine-auth endpoint
+        .limit("scim", api::scim::SCIM_BODY_LIMIT); // SCIM bodies are small; a tight cap limits abuse of the machine-auth endpoint
 
     // If adding more paths here, consider also adding them to
     // crate::utils::LOGGED_ROUTES to make sure they appear in the log

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -18,6 +18,12 @@ static LIMITER_ADMIN: LazyLock<Limiter> = LazyLock::new(|| {
     RateLimiter::keyed(Quota::with_period(seconds).expect("Non-zero admin ratelimit seconds").allow_burst(burst))
 });
 
+static LIMITER_SCIM: LazyLock<Limiter> = LazyLock::new(|| {
+    let seconds = Duration::from_secs(CONFIG.scim_ratelimit_seconds());
+    let burst = NonZeroU32::new(CONFIG.scim_ratelimit_max_burst()).expect("Non-zero scim ratelimit burst");
+    RateLimiter::keyed(Quota::with_period(seconds).expect("Non-zero scim ratelimit seconds").allow_burst(burst))
+});
+
 pub fn check_limit_login(ip: &IpAddr) -> Result<(), Error> {
     match LIMITER_LOGIN.check_key(ip) {
         Ok(()) => Ok(()),
@@ -32,6 +38,15 @@ pub fn check_limit_admin(ip: &IpAddr) -> Result<(), Error> {
         Ok(()) => Ok(()),
         Err(_e) => {
             err_code!("Too many admin requests", 429);
+        }
+    }
+}
+
+pub fn check_limit_scim(ip: &IpAddr) -> Result<(), Error> {
+    match LIMITER_SCIM.check_key(ip) {
+        Ok(()) => Ok(()),
+        Err(_e) => {
+            err_code!("Too many SCIM requests", 429);
         }
     }
 }

--- a/test-support/Cargo.toml
+++ b/test-support/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-support"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ctor = "1.0.9"

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -1,0 +1,67 @@
+//! Test-only environment bootstrap.
+//!
+//! The main crate forbids `unsafe`, and `std::env::set_var` is `unsafe` on
+//! edition 2024, so the mutation lives here. The `#[ctor]` constructor runs
+//! before `main` and before any test thread exists, which is the only point
+//! where the process environment can be changed race-free and the only point
+//! early enough to beat the first deref of Vaultwarden's process-global
+//! `CONFIG` (a `LazyLock` that reads the environment).
+//!
+//! Linkage is intentional: this crate only takes effect in test binaries that
+//! reference it (`use test_support as _;`). Feature combos that do not compile
+//! those test modules never link it and keep upstream behaviour.
+
+/// Points every config-relevant environment variable at a per-process
+/// temporary directory and enables the flags the SCIM test suite needs.
+///
+/// `DATABASE_URL` is deliberately left unset: Vaultwarden derives it as
+/// `sqlite://{DATA_FOLDER}/db.sqlite3`, which lands inside the hermetic
+/// directory, and hardcoding a sqlite URL here would poison config validation
+/// for mysql/postgresql-only feature combos.
+pub fn init_hermetic_env() {
+    let base = std::env::temp_dir().join(format!("vaultwarden-test-{}", std::process::id()));
+    let data = base.join("data");
+    std::fs::create_dir_all(&data).expect("creating hermetic test data dir");
+
+    // An empty env file: a configured-but-missing ENV_FILE makes Vaultwarden
+    // exit at config load, and an unset one falls back to the repo's dev .env.
+    let env_file = base.join("test.env");
+    std::fs::write(&env_file, "").expect("creating hermetic test env file");
+
+    let vars: &[(&str, String)] = &[
+        ("ENV_FILE", env_file.to_string_lossy().into_owned()),
+        ("DATA_FOLDER", data.to_string_lossy().into_owned()),
+        ("DOMAIN", String::from("http://localhost:8000")),
+        ("WEB_VAULT_ENABLED", String::from("false")),
+        ("SIGNUPS_ALLOWED", String::from("true")),
+        ("INVITATIONS_ALLOWED", String::from("true")),
+        ("ORG_GROUPS_ENABLED", String::from("true")),
+        ("SCIM_ENABLED", String::from("true")),
+        ("SCIM_RATELIMIT_SECONDS", String::from("1")),
+        // High burst so the shared per-IP limiter never trips ordinary tests;
+        // the 429 path is exercised against a distinct synthetic IP.
+        ("SCIM_RATELIMIT_MAX_BURST", String::from("10000")),
+    ];
+
+    for (key, value) in vars {
+        // SAFETY: runs pre-main via #[ctor]; the process is single-threaded,
+        // so mutating the environment cannot race with any reader.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    // Make sure a developer shell exporting SMTP settings cannot leak mail
+    // sending into tests.
+    for key in ["SMTP_HOST", "SMTP_FROM", "USE_SENDMAIL"] {
+        // SAFETY: as above.
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+}
+
+#[ctor::ctor(unsafe)]
+fn hermetic_env() {
+    init_hermetic_env();
+}


### PR DESCRIPTION
## Summary

Adds a **SCIM v2 provisioning server** (RFC 7643 / RFC 7644) to this Vaultwarden fork, targeting Microsoft Entra ID, so organization membership can be driven from an identity provider: automated invite, update, and immediate deprovision. End-to-end encryption caps automation at *Invited*/*Accepted* (confirm stays a manual admin action, documented), matching upstream's `ldap_import` precedent while doing better on three axes it lacks: **rate limiting, audit logging, and tests**.

**Endpoints & auth** (`b1d02618`, `a4d1d870`, `45f19e00`, `780cb9e2`, `f67e7641`)
- `/scim/v2/<org>/Users` and `/Groups` full lifecycle, discovery endpoints, per-org static bearer token (`scim_v1.<org>.<secret>`, sha256 at rest, constant-time compare + dummy-compare on miss), pre-auth rate limiter, uniform 401 bodies, SCIM error envelope + catchers.
- Deprovision = **revoke, not delete** (preserves the wrapped org key; restore is lossless). Revocation is a status offset (`status - 128`), interpreted through one `membership_active()` helper.
- Token management under `/api/.../scim/api-key` behind an admin session + password/OTP re-auth. `useScim` becomes dynamic (`CONFIG.scim_enabled()`).

**Hardening from this ship's review + CSO + adversarial passes**
- **MySQL FK actually created** (`6d1cd3b3`) — inline column REFERENCES are silently ignored by InnoDB; now a table-level `FOREIGN KEY` with matched `VARCHAR(40)`.
- **Audit-trail warning** (`2ac68220`) — startup warning when `SCIM_ENABLED` is set without `ORG_EVENTS_ENABLED`.
- **Group PUT/PATCH hardening** (`57f65646`) — externalId uniqueness on every write path; `members` optional on PUT (omitted keeps, `[]` clears) so a sparse client can't wipe a group; resolve-before-write; single save; log-after-delete.
- **Token management audited, rollback logged, invite resent on restore** (`d7e94fa4`) — token generate/rotate/delete now log an org event under the acting admin; `mint_scim_token` is the one minting path shared with tests; a member restored to *Invited* gets a fresh invite (previously left un-joinable).
- **Batched user lookup + shared helpers** (`bcbbf370`, `a99d05e6`, `bd977e3c`) — one query instead of N in the Users list; actor constants, page caps, body limit, and helpers centralized.

## Test Coverage

~82% of coded branches (25 integration tests + 23 inline unit tests, **77 total, all green**). Full Entra lifecycle with exact status-offset assertions (`-126`/`-127`/`-128`), uniform-401 auth matrix (8 cases incl. disabled key), group diff sync, enumeration-safe 404/empty-list, token mint/rotation round-trip, and rollback (pre-existing user survives, shell user cascades) are all covered.

Known gaps, tracked in `TODOS.md`: the `SCIM_ENABLED=false` / `ORG_GROUPS_ENABLED=false` denial paths (need a second test process — `CONFIG` is a process-global pinned by the test-support ctor), the live-SMTP invite-failure path (its rollback logic is unit-tested directly), and error-envelope edges (bad/oversized body, HTTP 429).

## Pre-Landing Review

`/review` + `/cso` + two adversarial passes ran; all findings fixed or tracked. Final adversarial pass surfaced two the earlier passes missed, both resolved in this ship:
- **Reinstatement exposure** (documented, no behavior change): lossless restore means `active:true` reinstates an admin-revoked *Confirmed* member to full access. Documented in README + design.md — **revocation must be driven from the IdP**, and a leaked token is an access-reinstatement credential (rotate it).
- **Invite-on-restore** (fixed): reactivated *Invited* members were left un-joinable.

## Plan Completion

44/50 plan items done or changed-equivalent (88%). Deferred/tracked: live Entra tenant validation (user-driven, needs a tenant), config-gated denial tests, and the lower-severity adversarial robustness items (externalId TOCTOU, MySQL length→500, `scim_status` re-auth) — all in `TODOS.md`.

## TODOS

`TODOS.md` created, seeded with the deferred SCIM follow-ups (config-gated tests, live Entra validation, coverage edges, perf backlog, write-edge hardening) and the pre-existing upstream `ip_constant` clippy lints.

## Documentation

`docs/scim/README.md` (operator + Entra setup, attribute mapping, deviations, IdP-authoritative revocation) and `docs/scim/design.md` (architecture, sha256-vs-argon2 rationale, 4 mermaid diagrams, reinstatement note) updated to match the shipped behavior.

## Test plan

- [x] `cargo test --features sqlite` — 77 passed, 0 failed
- [x] `cargo clippy --features sqlite` — clean under the project CI gate
- [x] `cargo fmt --check` — clean
- [ ] Live validation against a throwaway Entra tenant (user-driven, tracked in TODOS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
