### PR TITLE
fix: use nix access for USE_SENDMAIL executable check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,6 +3255,18 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -5930,6 +5948,7 @@ dependencies = [
  "macros",
  "mimalloc",
  "moka",
+ "nix",
  "num-derive",
  "num-traits",
  "opendal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,9 +3258,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ unstable = []
 # Logging
 syslog = "7.0.0"
 # Filesystem access checks (e.g. sendmail executability for the current user)
-nix = { version = "0.30.1", default-features = false, features = ["fs"] }
+nix = { version = "0.31.3", default-features = false, features = ["fs"] }
 
 [dependencies]
 macros = { path = "./macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ unstable = []
 [target."cfg(unix)".dependencies]
 # Logging
 syslog = "7.0.0"
+# Filesystem access checks (e.g. sendmail executability for the current user)
+nix = { version = "0.30.1", default-features = false, features = ["fs"] }
 
 [dependencies]
 macros = { path = "./macros" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -920,28 +920,6 @@ make_config! {
     },
 }
 
-#[cfg(unix)]
-fn mode_is_executable(mode: u32) -> bool {
-    mode & 0o111 != 0
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::mode_is_executable;
-
-    #[test]
-    fn executable_mode_accepts_any_execute_bit() {
-        assert!(mode_is_executable(0o100));
-        assert!(mode_is_executable(0o010));
-        assert!(mode_is_executable(0o001));
-        assert!(mode_is_executable(0o700));
-        assert!(mode_is_executable(0o750));
-        assert!(mode_is_executable(0o755));
-        assert!(!mode_is_executable(0o600));
-        assert!(!mode_is_executable(0o000));
-    }
-}
-
 fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
     // Validate connection URL is valid and DB feature is enabled
     #[cfg(sqlite)]
@@ -1157,8 +1135,8 @@ fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
 
                     #[cfg(unix)]
                     {
-                        use std::os::unix::fs::PermissionsExt;
-                        if !mode_is_executable(metadata.permissions().mode()) {
+                        // Check actual execute permission for the current process, not just mode bits.
+                        if nix::unistd::access(&path, nix::unistd::AccessFlags::X_OK).is_err() {
                             err!(format!("sendmail command at `{path:?}` isn't executable"));
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -920,6 +920,28 @@ make_config! {
     },
 }
 
+#[cfg(unix)]
+fn mode_is_executable(mode: u32) -> bool {
+    mode & 0o111 != 0
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::mode_is_executable;
+
+    #[test]
+    fn executable_mode_accepts_any_execute_bit() {
+        assert!(mode_is_executable(0o100));
+        assert!(mode_is_executable(0o010));
+        assert!(mode_is_executable(0o001));
+        assert!(mode_is_executable(0o700));
+        assert!(mode_is_executable(0o750));
+        assert!(mode_is_executable(0o755));
+        assert!(!mode_is_executable(0o600));
+        assert!(!mode_is_executable(0o000));
+    }
+}
+
 fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
     // Validate connection URL is valid and DB feature is enabled
     #[cfg(sqlite)]
@@ -1136,7 +1158,7 @@ fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
                     #[cfg(unix)]
                     {
                         use std::os::unix::fs::PermissionsExt;
-                        if !metadata.permissions().mode() & 0o111 != 0 {
+                        if !mode_is_executable(metadata.permissions().mode()) {
                             err!(format!("sendmail command at `{path:?}` isn't executable"));
                         }
                     }


### PR DESCRIPTION
## Problem

`USE_SENDMAIL` startup validation rejected valid sendmail binaries that the **current process** can execute, but whose mode bits are not world-executable (e.g. `0700` / `0750`).

The old check was based on mode bits and also had operator-precedence issues:

```rust
if !metadata.permissions().mode() & 0o111 != 0
```

## Fix

On Unix, use `nix::unistd::access(path, AccessFlags::X_OK)` so validation matches real execute permission for the running process (same approach suggested in https://github.com/dani-garcia/vaultwarden/issues/7445#issuecomment-5023808210).

- Add Unix-only dependency `nix = 0.31.3` with `fs` feature
- Drop mode-bit-only checks / related unit tests (per review)

## Test plan

- [x] Logic: `access(X_OK)` accepts owner-executable sendmail for the running user
- [x] `nix` pinned to **0.31.3** in `Cargo.toml` / `Cargo.lock`

Fixes #7445