### PR TITLE
Add support for collection management settings

### DIFF
--- a/migrations/mysql/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/mysql/2026-07-21-120000_add_collection_management/down.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
-ALTER TABLE organizations DROP COLUMN limit_collection_creation;
-ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
-ALTER TABLE organizations DROP COLUMN limit_item_deletion;
+ALTER TABLE organizations DROP COLUMN collection_settings;

--- a/migrations/mysql/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/mysql/2026-07-21-120000_add_collection_management/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
+ALTER TABLE organizations DROP COLUMN limit_collection_creation;
+ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
+ALTER TABLE organizations DROP COLUMN limit_item_deletion;

--- a/migrations/mysql/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/mysql/2026-07-21-120000_add_collection_management/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/mysql/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/mysql/2026-07-21-120000_add_collection_management/up.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
-ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN collection_settings SMALLINT NOT NULL DEFAULT 1;

--- a/migrations/postgresql/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/postgresql/2026-07-21-120000_add_collection_management/down.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
-ALTER TABLE organizations DROP COLUMN limit_collection_creation;
-ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
-ALTER TABLE organizations DROP COLUMN limit_item_deletion;
+ALTER TABLE organizations DROP COLUMN collection_settings;

--- a/migrations/postgresql/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/postgresql/2026-07-21-120000_add_collection_management/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
+ALTER TABLE organizations DROP COLUMN limit_collection_creation;
+ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
+ALTER TABLE organizations DROP COLUMN limit_item_deletion;

--- a/migrations/postgresql/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/postgresql/2026-07-21-120000_add_collection_management/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/postgresql/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/postgresql/2026-07-21-120000_add_collection_management/up.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
-ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN collection_settings SMALLINT NOT NULL DEFAULT 1;

--- a/migrations/sqlite/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/sqlite/2026-07-21-120000_add_collection_management/down.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
-ALTER TABLE organizations DROP COLUMN limit_collection_creation;
-ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
-ALTER TABLE organizations DROP COLUMN limit_item_deletion;
+ALTER TABLE organizations DROP COLUMN collection_settings;

--- a/migrations/sqlite/2026-07-21-120000_add_collection_management/down.sql
+++ b/migrations/sqlite/2026-07-21-120000_add_collection_management/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations DROP COLUMN allow_admin_access_to_all_collection_items;
+ALTER TABLE organizations DROP COLUMN limit_collection_creation;
+ALTER TABLE organizations DROP COLUMN limit_collection_deletion;
+ALTER TABLE organizations DROP COLUMN limit_item_deletion;

--- a/migrations/sqlite/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/sqlite/2026-07-21-120000_add_collection_management/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sqlite/2026-07-21-120000_add_collection_management/up.sql
+++ b/migrations/sqlite/2026-07-21-120000_add_collection_management/up.sql
@@ -1,4 +1,1 @@
-ALTER TABLE organizations ADD COLUMN allow_admin_access_to_all_collection_items BOOLEAN NOT NULL DEFAULT TRUE;
-ALTER TABLE organizations ADD COLUMN limit_collection_creation BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_collection_deletion BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE organizations ADD COLUMN limit_item_deletion BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN collection_settings SMALLINT NOT NULL DEFAULT 1;

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -13,8 +13,7 @@ use serde_json::Value;
 use crate::{
     CONFIG,
     api::{self, EmptyResult, JsonResult, Notify, PasswordOrOtpData, UpdateType, core::log_event},
-    auth::ClientVersion,
-    auth::{Headers, OrgIdGuard, OwnerHeaders},
+    auth::{ClientVersion, Headers, OrgIdGuard, OwnerHeaders},
     config::PathType,
     crypto,
     db::{
@@ -1778,7 +1777,7 @@ async fn delete_cipher_by_uuid(
         err!("Cipher doesn't exist")
     };
 
-    if !cipher.is_write_accessible_to_user(&headers.user.uuid, conn).await {
+    if !cipher.is_deletable_by_user(&headers.user.uuid, conn).await {
         err!("Cipher can't be deleted by user")
     }
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -367,18 +367,11 @@ async fn put_organization_collection_management(
         err!("Organization not found")
     };
 
-    if let Some(flag) = data.allow_admin_access_to_all_collection_items {
-        org.allow_admin_access_to_all_collection_items = flag;
-    };
-    if let Some(flag) = data.limit_collection_creation {
-        org.limit_collection_creation = flag;
-    };
-    if let Some(flag) = data.limit_collection_deletion {
-        org.limit_collection_deletion = flag;
-    };
-    if let Some(flag) = data.limit_item_deletion {
-        org.limit_item_deletion = flag;
-    };
+    org.collection_settings.allow_admin_access_to_all_collection_items =
+        data.allow_admin_access_to_all_collection_items.unwrap_or(false);
+    org.collection_settings.limit_collection_creation = data.limit_collection_creation.unwrap_or(false);
+    org.collection_settings.limit_collection_deletion = data.limit_collection_deletion.unwrap_or(false);
+    org.collection_settings.limit_item_deletion = data.limit_item_deletion.unwrap_or(false);
 
     org.save(&conn).await?;
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -767,7 +767,7 @@ async fn delete_organization_collection_impl(
     if org_id != &headers.org_id {
         err!("Organization not found", "Organization id's do not match");
     }
-    let Some(org_settings) = Organization::find_collection_settings_by_uuid(&org_id, &conn).await else {
+    let Some(org_settings) = Organization::find_collection_settings_by_uuid(org_id, conn).await else {
         err!("Can't find organization details")
     };
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -767,9 +767,18 @@ async fn delete_organization_collection_impl(
     if org_id != &headers.org_id {
         err!("Organization not found", "Organization id's do not match");
     }
+    let Some(org_settings) = Organization::find_collection_settings_by_uuid(&org_id, &conn).await else {
+        err!("Can't find organization details")
+    };
+
     let Some(collection) = Collection::find_by_uuid_and_org(col_id, org_id, conn).await else {
         err!("Collection not found", "Collection does not exist or does not belong to this organization")
     };
+
+    if headers.membership_type <= MembershipType::Manager && org_settings.limit_collection_deletion {
+        err!("The current user isn't allowed to delete this collection")
+    }
+
     log_event(
         EventType::CollectionDeleted as i32,
         &collection.uuid,

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -555,7 +555,13 @@ async fn post_organization_collections(
     let data: FullCollectionData = data.into_inner();
     data.validate(&org_id, &conn).await?;
 
-    if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
+    let Some(org_settings) = Organization::find_collection_settings_by_uuid(&org_id, &conn).await else {
+        err!("Can't find organization details")
+    };
+
+    if headers.membership.atype == MembershipType::Manager
+        && (!headers.membership.access_all || org_settings.limit_collection_creation)
+    {
         err!("You don't have permission to create collections")
     }
 
@@ -1854,6 +1860,10 @@ async fn post_org_import(
     if org_id != headers.membership.org_uuid {
         err!("Organization not found", "Organization id's do not match");
     }
+    let Some(org_settings) = Organization::find_collection_settings_by_uuid(&org_id, &conn).await else {
+        err!("Can't find organization details")
+    };
+
     let data: ImportData = data.into_inner();
 
     // Validate the import before continuing
@@ -1878,7 +1888,9 @@ async fn post_org_import(
         } else {
             // We do not allow users or managers which can not manage all collections to create new collections
             // If there is any collection other than an existing import collection, abort the import.
-            if headers.membership.atype <= MembershipType::Manager && !headers.membership.has_full_access() {
+            if headers.membership.atype <= MembershipType::Manager
+                && (!headers.membership.has_full_access() || org_settings.limit_collection_creation)
+            {
                 err!(Compact, "The current user isn't allowed to create new collections")
             }
             let new_collection = Collection::new(org_id.clone(), col.name, col.external_id);

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -39,6 +39,7 @@ pub fn routes() -> Vec<Route> {
         get_collection_users,
         put_organization,
         post_organization,
+        put_organization_collection_management,
         post_organization_collections,
         post_bulk_access_collections,
         post_organization_collection_update,
@@ -124,6 +125,15 @@ struct OrgData {
 struct OrganizationUpdateData {
     billing_email: String,
     name: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct OrganizationCollectionManagementUpdateData {
+    allow_admin_access_to_all_collection_items: Option<bool>,
+    limit_collection_creation: Option<bool>,
+    limit_collection_deletion: Option<bool>,
+    limit_item_deletion: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -323,6 +333,52 @@ async fn post_organization(
 
     org.name = data.name;
     org.billing_email = data.billing_email.to_lowercase();
+
+    org.save(&conn).await?;
+
+    log_event(
+        EventType::OrganizationUpdated as i32,
+        org_id.as_ref(),
+        &org_id,
+        &headers.user.uuid,
+        headers.device.atype,
+        &headers.ip.ip,
+        &conn,
+    )
+    .await;
+
+    Ok(Json(org.to_json()))
+}
+
+#[put("/organizations/<org_id>/collection-management", data = "<data>")]
+async fn put_organization_collection_management(
+    org_id: OrganizationId,
+    headers: OwnerHeaders,
+    data: Json<OrganizationCollectionManagementUpdateData>,
+    conn: DbConn,
+) -> JsonResult {
+    if org_id != headers.org_id {
+        err!("Organization not found", "Organization id's do not match");
+    }
+
+    let data: OrganizationCollectionManagementUpdateData = data.into_inner();
+
+    let Some(mut org) = Organization::find_by_uuid(&org_id, &conn).await else {
+        err!("Organization not found")
+    };
+
+    if let Some(flag) = data.allow_admin_access_to_all_collection_items {
+        org.allow_admin_access_to_all_collection_items = flag;
+    };
+    if let Some(flag) = data.limit_collection_creation {
+        org.limit_collection_creation = flag;
+    };
+    if let Some(flag) = data.limit_collection_deletion {
+        org.limit_collection_deletion = flag;
+    };
+    if let Some(flag) = data.limit_item_deletion {
+        org.limit_item_deletion = flag;
+    };
 
     org.save(&conn).await?;
 

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 
 use crate::{
     CONFIG,
-    api::admin::FAKE_ADMIN_UUID,
     api::{
         EmptyResult, JsonResult, Notify, PasswordOrOtpData, UpdateType,
+        admin::FAKE_ADMIN_UUID,
         core::{CipherSyncData, CipherSyncType, accept_org_invite, log_event, two_factor},
     },
     auth::{AdminHeaders, Headers, ManagerHeaders, ManagerHeadersLoose, OrgMemberHeaders, OwnerHeaders, decode_invite},
@@ -17,7 +17,8 @@ use crate::{
         models::{
             Cipher, CipherId, Collection, CollectionCipher, CollectionGroup, CollectionId, CollectionUser, EventType,
             Group, GroupId, GroupUser, Invitation, Membership, MembershipId, MembershipStatus, MembershipType,
-            OrgPolicy, OrgPolicyType, Organization, OrganizationApiKey, OrganizationId, User, UserId,
+            OrgCollectionSetting, OrgPolicy, OrgPolicyType, Organization, OrganizationApiKey, OrganizationId, User,
+            UserId,
         },
     },
     mail,
@@ -367,11 +368,16 @@ async fn put_organization_collection_management(
         err!("Organization not found")
     };
 
-    org.collection_settings.allow_admin_access_to_all_collection_items =
-        data.allow_admin_access_to_all_collection_items.unwrap_or(false);
-    org.collection_settings.limit_collection_creation = data.limit_collection_creation.unwrap_or(false);
-    org.collection_settings.limit_collection_deletion = data.limit_collection_deletion.unwrap_or(false);
-    org.collection_settings.limit_item_deletion = data.limit_item_deletion.unwrap_or(false);
+    org.collection_settings.set_flag(
+        OrgCollectionSetting::AllowAdminAccessToAllCollectionItems,
+        data.allow_admin_access_to_all_collection_items.unwrap_or(false),
+    );
+    org.collection_settings
+        .set_flag(OrgCollectionSetting::LimitCollectionCreation, data.limit_collection_creation.unwrap_or(false));
+    org.collection_settings
+        .set_flag(OrgCollectionSetting::LimitCollectionDeletion, data.limit_collection_deletion.unwrap_or(false));
+    org.collection_settings
+        .set_flag(OrgCollectionSetting::LimitItemDeletion, data.limit_item_deletion.unwrap_or(false));
 
     org.save(&conn).await?;
 
@@ -560,7 +566,7 @@ async fn post_organization_collections(
     };
 
     if headers.membership.atype == MembershipType::Manager
-        && (!headers.membership.access_all || org_settings.limit_collection_creation)
+        && (!headers.membership.access_all || org_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation))
     {
         err!("You don't have permission to create collections")
     }
@@ -775,7 +781,9 @@ async fn delete_organization_collection_impl(
         err!("Collection not found", "Collection does not exist or does not belong to this organization")
     };
 
-    if headers.membership_type <= MembershipType::Manager && org_settings.limit_collection_deletion {
+    if headers.membership_type <= MembershipType::Manager
+        && org_settings.get_flag(OrgCollectionSetting::LimitCollectionDeletion)
+    {
         err!("The current user isn't allowed to delete this collection")
     }
 
@@ -1898,7 +1906,8 @@ async fn post_org_import(
             // We do not allow users or managers which can not manage all collections to create new collections
             // If there is any collection other than an existing import collection, abort the import.
             if headers.membership.atype <= MembershipType::Manager
-                && (!headers.membership.has_full_access() || org_settings.limit_collection_creation)
+                && (!headers.membership.has_full_access()
+                    || org_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation))
             {
                 err!(Compact, "The current user isn't allowed to create new collections")
             }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -868,6 +868,7 @@ pub struct ManagerHeaders {
     pub host: String,
     pub device: Device,
     pub user: User,
+    pub membership_type: MembershipType,
     pub ip: ClientIp,
     pub org_id: OrganizationId,
 }
@@ -895,6 +896,7 @@ impl<'r> FromRequest<'r> for ManagerHeaders {
                 host: headers.host,
                 device: headers.device,
                 user: headers.user,
+                membership_type: headers.membership_type,
                 ip: headers.ip,
                 org_id: headers.membership.org_uuid,
             })
@@ -975,6 +977,7 @@ impl ManagerHeaders {
             host: h.host,
             device: h.device,
             user: h.user,
+            membership_type: MembershipType::from_i32(h.membership.atype).unwrap(),
             ip: h.ip,
             org_id: h.membership.org_uuid,
         })

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     db::{
         DbConn,
+        models::OrgCollectionSetting,
         schema::{
             ciphers, ciphers_collections, collections, collections_groups, folders, folders_ciphers, groups,
             groups_users, users_collections, users_organizations,
@@ -728,7 +729,7 @@ impl Cipher {
     pub async fn is_deletable_by_user(&self, user_uuid: &UserId, conn: &DbConn) -> bool {
         let manage_required = match self.organization_uuid {
             Some(ref org_id) => match Organization::find_collection_settings_by_uuid(org_id, conn).await {
-                Some(settings) => settings.limit_item_deletion,
+                Some(settings) => settings.get_flag(OrgCollectionSetting::LimitItemDeletion),
                 None => false,
             },
             None => false,

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -187,6 +187,8 @@ impl Cipher {
             (false, false, false)
         };
 
+        let can_delete = self.is_deletable_by_user(user_uuid, conn).await;
+
         let fields_json: Vec<_> = self
             .fields
             .as_ref()
@@ -393,8 +395,8 @@ impl Cipher {
             json_object["viewPassword"] = json!(!hide_passwords);
             // The new key used by clients since v2025.6.0
             json_object["permissions"] = json!({
-                "delete": !read_only,
-                "restore": !read_only,
+                "delete": can_delete && self.deleted_at.is_none(),
+                "restore": can_delete && self.deleted_at.is_none(),
             });
         }
 

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -727,7 +727,7 @@ impl Cipher {
 
     pub async fn is_deletable_by_user(&self, user_uuid: &UserId, conn: &DbConn) -> bool {
         let manage_required = match self.organization_uuid {
-            Some(ref org_id) => match Organization::find_collection_settings_by_uuid(&org_id, &conn).await {
+            Some(ref org_id) => match Organization::find_collection_settings_by_uuid(org_id, conn).await {
                 Some(settings) => settings.limit_item_deletion,
                 None => false,
             },

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -727,8 +727,8 @@ impl Cipher {
 
     pub async fn is_deletable_by_user(&self, user_uuid: &UserId, conn: &DbConn) -> bool {
         let manage_required = match self.organization_uuid {
-            Some(ref org_id) => match Organization::find_by_uuid(&org_id, &conn).await {
-                Some(org) => org.limit_item_deletion,
+            Some(ref org_id) => match Organization::find_collection_settings_by_uuid(&org_id, &conn).await {
+                Some(settings) => settings.limit_item_deletion,
                 None => false,
             },
             None => false,

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -25,7 +25,7 @@ use macros::UuidFromParam;
 
 use super::{
     Archive, Attachment, CollectionCipher, CollectionId, Favorite, FolderCipher, FolderId, Group, Membership,
-    MembershipStatus, MembershipType, OrganizationId, User, UserId,
+    MembershipStatus, MembershipType, Organization, OrganizationId, User, UserId,
 };
 
 #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
@@ -719,6 +719,21 @@ impl Cipher {
     pub async fn is_write_accessible_to_user(&self, user_uuid: &UserId, conn: &DbConn) -> bool {
         match self.get_access_restrictions(user_uuid, None, conn).await {
             Some((read_only, _hide_passwords, manage)) => !read_only || manage,
+            None => false,
+        }
+    }
+
+    pub async fn is_deletable_by_user(&self, user_uuid: &UserId, conn: &DbConn) -> bool {
+        let manage_required = match self.organization_uuid {
+            Some(ref org_id) => match Organization::find_by_uuid(&org_id, &conn).await {
+                Some(org) => org.limit_item_deletion,
+                None => false,
+            },
+            None => false,
+        };
+
+        match self.get_access_restrictions(user_uuid, None, conn).await {
+            Some((read_only, _hide_passwords, manage)) => (!manage_required && !read_only) || manage,
             None => false,
         }
     }

--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -395,8 +395,8 @@ impl Cipher {
             json_object["viewPassword"] = json!(!hide_passwords);
             // The new key used by clients since v2025.6.0
             json_object["permissions"] = json!({
-                "delete": can_delete && self.deleted_at.is_none(),
-                "restore": can_delete && self.deleted_at.is_none(),
+                "delete": can_delete,
+                "restore": can_delete,
             });
         }
 

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -31,8 +31,8 @@ pub use self::folder::{Folder, FolderCipher, FolderId};
 pub use self::group::{CollectionGroup, Group, GroupId, GroupUser};
 pub use self::org_policy::{OrgPolicy, OrgPolicyId, OrgPolicyType};
 pub use self::organization::{
-    Membership, MembershipId, MembershipStatus, MembershipType, OrgApiKeyId, Organization, OrganizationApiKey,
-    OrganizationId,
+    Membership, MembershipId, MembershipStatus, MembershipType, OrgApiKeyId, OrgCollectionSetting, Organization,
+    OrganizationApiKey, OrganizationId,
 };
 pub use self::send::{Send, SendFileId, SendId, SendType};
 pub use self::sso_auth::{OIDCAuthenticatedUser, OIDCCodeResponseError, SsoAuth};

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -43,7 +43,7 @@ pub struct OrganizationCollectionSettings(i16);
 
 impl OrganizationCollectionSettings {
     pub fn get_flag(self, flag: OrgCollectionSetting) -> bool {
-        (self.0 | flag as i16) > 0
+        (self.0 & flag as i16) > 0
     }
 
     pub fn set_flag(&mut self, flag: OrgCollectionSetting, val: bool) {

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -557,9 +557,9 @@ impl Membership {
                 "accessImportExport": false,
                 "accessReports": false,
                 // If the following 3 Collection roles are set to true a custom user has access all permission
-                "createNewCollections": membership_type == 4 && self.access_all,
+                "createNewCollections": membership_type == 4 && self.access_all && !org.collection_settings.limit_collection_creation,
                 "editAnyCollection": membership_type == 4 && self.access_all,
-                "deleteAnyCollection": membership_type == 4 && self.access_all,
+                "deleteAnyCollection": membership_type == 4 && self.access_all && !org.collection_settings.limit_collection_deletion,
                 "manageGroups": false,
                 "managePolicies": false,
                 "manageSso": false, // Not supported

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -38,6 +38,11 @@ pub struct Organization {
     pub billing_email: String,
     pub private_key: Option<String>,
     pub public_key: Option<String>,
+
+    pub allow_admin_access_to_all_collection_items: bool,
+    pub limit_collection_creation: bool,
+    pub limit_collection_deletion: bool,
+    pub limit_item_deletion: bool,
 }
 
 #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
@@ -193,6 +198,10 @@ impl Organization {
             billing_email,
             private_key,
             public_key,
+            allow_admin_access_to_all_collection_items: true,
+            limit_collection_creation: false,
+            limit_collection_deletion: false,
+            limit_item_deletion: false,
         }
     }
     // https://github.com/bitwarden/server/blob/9ebe16587175b1c0e9208f84397bb75d0d595510/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -219,9 +228,10 @@ impl Organization {
             "useApi": true,
             "hasPublicAndPrivateKeys": self.private_key.is_some() && self.public_key.is_some(),
             "useResetPassword": CONFIG.mail_enabled(),
-            "allowAdminAccessToAllCollectionItems": true,
-            "limitCollectionCreation": true,
-            "limitCollectionDeletion": true,
+            "allowAdminAccessToAllCollectionItems": self.allow_admin_access_to_all_collection_items,
+            "limitCollectionCreation": self.limit_collection_creation,
+            "limitCollectionDeletion": self.limit_collection_deletion,
+            "limitItemDeletion": self.limit_item_deletion,
 
             "businessName": self.name,
             "businessAddress1": null,
@@ -509,11 +519,12 @@ impl Membership {
             "familySponsorshipValidUntil": null,
             "familySponsorshipToDelete": null,
             "accessSecretsManager": false,
-            // limit collection creation to managers with access_all permission to prevent issues
-            "limitCollectionCreation": self.atype < MembershipType::Manager || !self.access_all,
-            "limitCollectionDeletion": true,
-            "limitItemDeletion": false,
-            "allowAdminAccessToAllCollectionItems": true,
+
+            "allowAdminAccessToAllCollectionItems": org.allow_admin_access_to_all_collection_items,
+            "limitCollectionCreation": org.limit_collection_creation,
+            "limitCollectionDeletion": org.limit_collection_deletion,
+            "limitItemDeletion": org.limit_item_deletion,
+
             "userIsManagedByOrganization": false, // Means not managed via the Members UI, like SSO
             "userIsClaimedByOrganization": false, // The new key instead of the obsolete userIsManagedByOrganization
 

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -5,8 +5,15 @@ use std::{
 
 use chrono::{NaiveDateTime, Utc};
 use derive_more::{AsRef, Deref, Display, From};
-use diesel::prelude::*;
+use diesel::{
+    deserialize::FromSql,
+    prelude::*,
+    serialize::{IsNull, ToSql},
+    sql_types::SmallInt,
+};
 use num_traits::FromPrimitive;
+#[cfg(feature = "sqlite")]
+use num_traits::ToPrimitive;
 use serde_json::Value;
 
 use crate::{
@@ -28,6 +35,77 @@ use super::{
     OrgPolicyType, TwoFactor, User, UserId,
 };
 
+#[derive(Debug, Clone, Copy, FromSqlRow, AsExpression)]
+#[diesel(sql_type = SmallInt)]
+pub struct OrganizationCollectionSettings {
+    pub allow_admin_access_to_all_collection_items: bool,
+    pub limit_collection_creation: bool,
+    pub limit_collection_deletion: bool,
+    pub limit_item_deletion: bool,
+}
+
+impl From<&OrganizationCollectionSettings> for i16 {
+    fn from(value: &OrganizationCollectionSettings) -> Self {
+        (0b1 * (value.allow_admin_access_to_all_collection_items as i16))
+            | (0b10 * (value.limit_collection_creation as i16))
+            | (0b100 * (value.limit_collection_deletion as i16))
+            | (0b1000 * (value.limit_item_deletion as i16))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+use diesel::sqlite::Sqlite;
+#[cfg(feature = "sqlite")]
+impl ToSql<SmallInt, Sqlite> for OrganizationCollectionSettings
+where
+    i16: ToSql<SmallInt, Sqlite>,
+{
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Sqlite>) -> diesel::serialize::Result {
+        out.set_value(i16::from(self).to_i32());
+        Ok(IsNull::No)
+    }
+}
+
+#[cfg(feature = "postgresql")]
+use diesel::pg::Pg;
+#[cfg(feature = "postgresql")]
+impl ToSql<SmallInt, Pg> for OrganizationCollectionSettings
+where
+    i16: ToSql<SmallInt, Pg>,
+{
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Pg>) -> diesel::serialize::Result {
+        <i16 as ToSql<SmallInt, Pg>>::to_sql(&i16::from(self), &mut out.reborrow())
+    }
+}
+
+#[cfg(feature = "mysql")]
+use diesel::mysql::Mysql;
+#[cfg(feature = "mysql")]
+impl ToSql<SmallInt, Mysql> for OrganizationCollectionSettings
+where
+    i16: ToSql<SmallInt, Mysql>,
+{
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Mysql>) -> diesel::serialize::Result {
+        <i16 as ToSql<SmallInt, Mysql>>::to_sql(&i16::from(self), &mut out.reborrow())
+    }
+}
+
+impl<DB> FromSql<SmallInt, DB> for OrganizationCollectionSettings
+where
+    DB: diesel::backend::Backend,
+    i16: FromSql<SmallInt, DB>,
+{
+    fn from_sql(bytes: DB::RawValue<'_>) -> diesel::deserialize::Result<Self> {
+        let val = i16::from_sql(bytes)?;
+        Ok(Self {
+            allow_admin_access_to_all_collection_items: (val & 0b1) != 0,
+            limit_collection_creation: (val & 0b10) != 0,
+            limit_collection_deletion: (val & 0b100) != 0,
+            limit_item_deletion: (val & 0b1000) != 0,
+        })
+    }
+}
+
 #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name = organizations)]
 #[diesel(treat_none_as_null = true)]
@@ -39,10 +117,7 @@ pub struct Organization {
     pub private_key: Option<String>,
     pub public_key: Option<String>,
 
-    pub allow_admin_access_to_all_collection_items: bool,
-    pub limit_collection_creation: bool,
-    pub limit_collection_deletion: bool,
-    pub limit_item_deletion: bool,
+    pub collection_settings: OrganizationCollectionSettings,
 }
 
 #[derive(Identifiable, Queryable, Insertable, AsChangeset)]
@@ -198,10 +273,12 @@ impl Organization {
             billing_email,
             private_key,
             public_key,
-            allow_admin_access_to_all_collection_items: true,
-            limit_collection_creation: false,
-            limit_collection_deletion: false,
-            limit_item_deletion: false,
+            collection_settings: OrganizationCollectionSettings {
+                allow_admin_access_to_all_collection_items: true,
+                limit_collection_creation: false,
+                limit_collection_deletion: false,
+                limit_item_deletion: false,
+            },
         }
     }
     // https://github.com/bitwarden/server/blob/9ebe16587175b1c0e9208f84397bb75d0d595510/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -228,10 +305,10 @@ impl Organization {
             "useApi": true,
             "hasPublicAndPrivateKeys": self.private_key.is_some() && self.public_key.is_some(),
             "useResetPassword": CONFIG.mail_enabled(),
-            "allowAdminAccessToAllCollectionItems": self.allow_admin_access_to_all_collection_items,
-            "limitCollectionCreation": self.limit_collection_creation,
-            "limitCollectionDeletion": self.limit_collection_deletion,
-            "limitItemDeletion": self.limit_item_deletion,
+            "allowAdminAccessToAllCollectionItems": self.collection_settings.allow_admin_access_to_all_collection_items,
+            "limitCollectionCreation": self.collection_settings.limit_collection_creation,
+            "limitCollectionDeletion": self.collection_settings.limit_collection_deletion,
+            "limitItemDeletion": self.collection_settings.limit_item_deletion,
 
             "businessName": self.name,
             "businessAddress1": null,
@@ -406,6 +483,20 @@ impl Organization {
         conn.run(move |conn| organizations::table.filter(organizations::uuid.eq(uuid)).first::<Self>(conn).ok()).await
     }
 
+    pub async fn find_collection_settings_by_uuid(
+        uuid: &OrganizationId,
+        conn: &DbConn,
+    ) -> Option<OrganizationCollectionSettings> {
+        conn.run(move |conn| {
+            organizations::table
+                .filter(organizations::uuid.eq(uuid))
+                .select(organizations::collection_settings)
+                .first::<OrganizationCollectionSettings>(conn)
+                .ok()
+        })
+        .await
+    }
+
     pub async fn find_by_name(name: &str, conn: &DbConn) -> Option<Self> {
         conn.run(move |conn| organizations::table.filter(organizations::name.eq(name)).first::<Self>(conn).ok()).await
     }
@@ -520,10 +611,10 @@ impl Membership {
             "familySponsorshipToDelete": null,
             "accessSecretsManager": false,
 
-            "allowAdminAccessToAllCollectionItems": org.allow_admin_access_to_all_collection_items,
-            "limitCollectionCreation": org.limit_collection_creation,
-            "limitCollectionDeletion": org.limit_collection_deletion,
-            "limitItemDeletion": org.limit_item_deletion,
+            "allowAdminAccessToAllCollectionItems": org.collection_settings.allow_admin_access_to_all_collection_items,
+            "limitCollectionCreation": org.collection_settings.limit_collection_creation,
+            "limitCollectionDeletion": org.collection_settings.limit_collection_deletion,
+            "limitItemDeletion": org.collection_settings.limit_item_deletion,
 
             "userIsManagedByOrganization": false, // Means not managed via the Members UI, like SSO
             "userIsClaimedByOrganization": false, // The new key instead of the obsolete userIsManagedByOrganization

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -37,6 +37,7 @@ use super::{
 
 #[derive(Debug, Clone, Copy, FromSqlRow, AsExpression)]
 #[diesel(sql_type = SmallInt)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct OrganizationCollectionSettings {
     pub allow_admin_access_to_all_collection_items: bool,
     pub limit_collection_creation: bool,
@@ -46,10 +47,10 @@ pub struct OrganizationCollectionSettings {
 
 impl From<&OrganizationCollectionSettings> for i16 {
     fn from(value: &OrganizationCollectionSettings) -> Self {
-        (0b1 * (value.allow_admin_access_to_all_collection_items as i16))
-            | (0b10 * (value.limit_collection_creation as i16))
-            | (0b100 * (value.limit_collection_deletion as i16))
-            | (0b1000 * (value.limit_item_deletion as i16))
+        i16::from(value.allow_admin_access_to_all_collection_items)
+            | (0b10 * i16::from(value.limit_collection_creation))
+            | (0b100 * i16::from(value.limit_collection_deletion))
+            | (0b1000 * i16::from(value.limit_item_deletion))
     }
 }
 

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -5,15 +5,9 @@ use std::{
 
 use chrono::{NaiveDateTime, Utc};
 use derive_more::{AsRef, Deref, Display, From};
-use diesel::{
-    deserialize::FromSql,
-    prelude::*,
-    serialize::{IsNull, ToSql},
-    sql_types::SmallInt,
-};
+use diesel::{deserialize::FromSql, prelude::*, serialize::ToSql, sql_types::SmallInt};
 use num_traits::FromPrimitive;
 #[cfg(feature = "sqlite")]
-use num_traits::ToPrimitive;
 use serde_json::Value;
 
 use crate::{
@@ -35,59 +29,39 @@ use super::{
     OrgPolicyType, TwoFactor, User, UserId,
 };
 
+#[repr(i16)]
+pub enum OrgCollectionSetting {
+    AllowAdminAccessToAllCollectionItems = 0b1,
+    LimitCollectionCreation = 0b10,
+    LimitCollectionDeletion = 0b100,
+    LimitItemDeletion = 0b1000,
+}
+
 #[derive(Debug, Clone, Copy, FromSqlRow, AsExpression)]
 #[diesel(sql_type = SmallInt)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct OrganizationCollectionSettings {
-    pub allow_admin_access_to_all_collection_items: bool,
-    pub limit_collection_creation: bool,
-    pub limit_collection_deletion: bool,
-    pub limit_item_deletion: bool,
-}
+pub struct OrganizationCollectionSettings(i16);
 
-impl From<&OrganizationCollectionSettings> for i16 {
-    fn from(value: &OrganizationCollectionSettings) -> Self {
-        i16::from(value.allow_admin_access_to_all_collection_items)
-            | (0b10 * i16::from(value.limit_collection_creation))
-            | (0b100 * i16::from(value.limit_collection_deletion))
-            | (0b1000 * i16::from(value.limit_item_deletion))
+impl OrganizationCollectionSettings {
+    pub fn get_flag(self, flag: OrgCollectionSetting) -> bool {
+        (self.0 | flag as i16) > 0
+    }
+
+    pub fn set_flag(&mut self, flag: OrgCollectionSetting, val: bool) {
+        if val {
+            self.0 |= flag as i16;
+        } else {
+            self.0 &= i16::MAX - flag as i16;
+        }
     }
 }
 
-#[cfg(feature = "sqlite")]
-use diesel::sqlite::Sqlite;
-#[cfg(feature = "sqlite")]
-impl ToSql<SmallInt, Sqlite> for OrganizationCollectionSettings
+impl<DB> ToSql<SmallInt, DB> for OrganizationCollectionSettings
 where
-    i16: ToSql<SmallInt, Sqlite>,
+    DB: diesel::backend::Backend,
+    i16: ToSql<SmallInt, DB>,
 {
-    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Sqlite>) -> diesel::serialize::Result {
-        out.set_value(i16::from(self).to_i32());
-        Ok(IsNull::No)
-    }
-}
-
-#[cfg(feature = "postgresql")]
-use diesel::pg::Pg;
-#[cfg(feature = "postgresql")]
-impl ToSql<SmallInt, Pg> for OrganizationCollectionSettings
-where
-    i16: ToSql<SmallInt, Pg>,
-{
-    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Pg>) -> diesel::serialize::Result {
-        <i16 as ToSql<SmallInt, Pg>>::to_sql(&i16::from(self), &mut out.reborrow())
-    }
-}
-
-#[cfg(feature = "mysql")]
-use diesel::mysql::Mysql;
-#[cfg(feature = "mysql")]
-impl ToSql<SmallInt, Mysql> for OrganizationCollectionSettings
-where
-    i16: ToSql<SmallInt, Mysql>,
-{
-    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, Mysql>) -> diesel::serialize::Result {
-        <i16 as ToSql<SmallInt, Mysql>>::to_sql(&i16::from(self), &mut out.reborrow())
+    fn to_sql<'b>(&'b self, out: &mut diesel::serialize::Output<'b, '_, DB>) -> diesel::serialize::Result {
+        self.0.to_sql(out)
     }
 }
 
@@ -98,12 +72,7 @@ where
 {
     fn from_sql(bytes: DB::RawValue<'_>) -> diesel::deserialize::Result<Self> {
         let val = i16::from_sql(bytes)?;
-        Ok(Self {
-            allow_admin_access_to_all_collection_items: (val & 0b1) != 0,
-            limit_collection_creation: (val & 0b10) != 0,
-            limit_collection_deletion: (val & 0b100) != 0,
-            limit_item_deletion: (val & 0b1000) != 0,
-        })
+        Ok(Self(val))
     }
 }
 
@@ -274,12 +243,11 @@ impl Organization {
             billing_email,
             private_key,
             public_key,
-            collection_settings: OrganizationCollectionSettings {
-                allow_admin_access_to_all_collection_items: true,
-                limit_collection_creation: false,
-                limit_collection_deletion: false,
-                limit_item_deletion: false,
-            },
+
+            // Collection Management Settings default to AllowAdminAccessToAllCollectionItems
+            collection_settings: OrganizationCollectionSettings(
+                OrgCollectionSetting::AllowAdminAccessToAllCollectionItems as i16,
+            ),
         }
     }
     // https://github.com/bitwarden/server/blob/9ebe16587175b1c0e9208f84397bb75d0d595510/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -306,10 +274,10 @@ impl Organization {
             "useApi": true,
             "hasPublicAndPrivateKeys": self.private_key.is_some() && self.public_key.is_some(),
             "useResetPassword": CONFIG.mail_enabled(),
-            "allowAdminAccessToAllCollectionItems": self.collection_settings.allow_admin_access_to_all_collection_items,
-            "limitCollectionCreation": self.collection_settings.limit_collection_creation,
-            "limitCollectionDeletion": self.collection_settings.limit_collection_deletion,
-            "limitItemDeletion": self.collection_settings.limit_item_deletion,
+            "allowAdminAccessToAllCollectionItems": self.collection_settings.get_flag(OrgCollectionSetting::AllowAdminAccessToAllCollectionItems),
+            "limitCollectionCreation": self.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation),
+            "limitCollectionDeletion": self.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionDeletion),
+            "limitItemDeletion": self.collection_settings.get_flag(OrgCollectionSetting::LimitItemDeletion),
 
             "businessName": self.name,
             "businessAddress1": null,
@@ -557,9 +525,9 @@ impl Membership {
                 "accessImportExport": false,
                 "accessReports": false,
                 // If the following 3 Collection roles are set to true a custom user has access all permission
-                "createNewCollections": membership_type == 4 && self.access_all && !org.collection_settings.limit_collection_creation,
+                "createNewCollections": membership_type == 4 && self.access_all && !org.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation),
                 "editAnyCollection": membership_type == 4 && self.access_all,
-                "deleteAnyCollection": membership_type == 4 && self.access_all && !org.collection_settings.limit_collection_deletion,
+                "deleteAnyCollection": membership_type == 4 && self.access_all && !org.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation),
                 "manageGroups": false,
                 "managePolicies": false,
                 "manageSso": false, // Not supported
@@ -612,10 +580,10 @@ impl Membership {
             "familySponsorshipToDelete": null,
             "accessSecretsManager": false,
 
-            "allowAdminAccessToAllCollectionItems": org.collection_settings.allow_admin_access_to_all_collection_items,
-            "limitCollectionCreation": org.collection_settings.limit_collection_creation,
-            "limitCollectionDeletion": org.collection_settings.limit_collection_deletion,
-            "limitItemDeletion": org.collection_settings.limit_item_deletion,
+            "allowAdminAccessToAllCollectionItems": org.collection_settings.get_flag(OrgCollectionSetting::AllowAdminAccessToAllCollectionItems),
+            "limitCollectionCreation": org.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionCreation),
+            "limitCollectionDeletion": org.collection_settings.get_flag(OrgCollectionSetting::LimitCollectionDeletion),
+            "limitItemDeletion": org.collection_settings.get_flag(OrgCollectionSetting::LimitItemDeletion),
 
             "userIsManagedByOrganization": false, // Means not managed via the Members UI, like SSO
             "userIsClaimedByOrganization": false, // The new key instead of the obsolete userIsManagedByOrganization

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -126,6 +126,10 @@ table! {
         billing_email -> Text,
         private_key -> Nullable<Text>,
         public_key -> Nullable<Text>,
+        allow_admin_access_to_all_collection_items -> Bool,
+        limit_collection_creation -> Bool,
+        limit_collection_deletion -> Bool,
+        limit_item_deletion -> Bool,
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -126,10 +126,7 @@ table! {
         billing_email -> Text,
         private_key -> Nullable<Text>,
         public_key -> Nullable<Text>,
-        allow_admin_access_to_all_collection_items -> Bool,
-        limit_collection_creation -> Bool,
-        limit_collection_deletion -> Bool,
-        limit_item_deletion -> Bool,
+        collection_settings -> SmallInt,
     }
 }
 

--- a/src/static/templates/scss/vaultwarden.scss.hbs
+++ b/src/static/templates/scss/vaultwarden.scss.hbs
@@ -100,11 +100,6 @@ app-organization-plans > form > bit-section:nth-child(2) {
   @extend %vw-hide;
 }
 
-/* Hide Collection Management Form */
-app-org-account form.ng-untouched:nth-child(5) {
-  @extend %vw-hide;
-}
-
 /* Hide 'Member Access' Report Card from Org Reports */
 app-org-reports-home > app-report-list > div.tw-inline-grid > div:nth-child(6) {
   @extend %vw-hide;


### PR DESCRIPTION
[Collection Management settings](https://bitwarden.com/resources/resource-collections-management-settings/) is a brick of 4 flags in organization settings, allowing to fine-tune what roles and/or permissions are required for certain critical operations.

![](https://bitwarden.com/assets/1uXfq8ozy8Zybjrd9Ob5NE/ec4b02f858cb88e8c8fa45b8f117b820/Screenshot_2025-10-14_121451.png)

## Design choices

- The `allow_admin_access_to_all_collection_items` flag defaults to true, to match Vaultwarden current behavior.
- The settings are stored as an `i16` (SMALLINT in schema), in the form of a bit flagset.

## TODO

- [x] Implement settings form and persistance
- [ ] Add checks for "Allow owners and admins to manage all collections and items from the Admin Console"
- [x] Add checks for "Restrict collection creation to owners and admins"
- [x] Add checks for "Restrict collection deletion to owners and admins"
- [x] Add checks for "Restrict item deletion to members with the `Manage collection` permission"