### PR TITLE
Remove unused fields

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -693,10 +693,6 @@ struct UnlockData {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChangeKdfData {
-    #[allow(dead_code)]
-    new_master_password_hash: String,
-    #[allow(dead_code)]
-    key: String,
     authentication_data: AuthenticationData,
     unlock_data: UnlockData,
     master_password_hash: String,


### PR DESCRIPTION
Starting with client version `2026.7.0` the fields are not sent anymore (client [used](https://github.com/Timshel/oidc_web_vault/releases/download/v2026.7.0-1/oidc_button_web_vault.tar.gz)).
This prevents deserialization when trying to change the key settings. 