### PR TITLE
SSO: Set verified_at for existing users associated via SSO_SIGNUPS_MATCH_EMAIL

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -337,6 +337,13 @@ async fn sso_login(
                 }
 
                 user.save(conn).await?;
+            } else if user.verified_at.is_none()
+                && user.email == user_infos.email
+                && user_infos.email_verified.unwrap_or(CONFIG.sso_allow_unknown_email_verification())
+            {
+                // The email verification is handled by the provider, backfill for accounts created before SSO
+                user.verified_at = Some(now);
+                user.save(conn).await?;
             }
 
             if user.email != user_infos.email {


### PR DESCRIPTION
When an existing non-SSO account is associated with an SSO login via
`SSO_SIGNUPS_MATCH_EMAIL`, the user's `verified_at` is never set, even though
the provider vouches for the address on every SSO login (new SSO users get
`verified_at` set on signup under the same conditions). Such users keep seeing
the "verify your email" nudge unless they go through the manual email
verification flow.

Two commits:

1. Backfill `verified_at` when associating an existing account, if the provider
   email matches the locally stored one. This mirrors the existing behavior for
   new SSO users.

2. Edit: This commit was dropped following discussion in https://github.com/dani-garcia/vaultwarden/pull/7465#discussion_r3643625402 ~Only set `verified_at` when the provider asserts `email_verified == true`, in
   both the new-user path and the backfill, regardless of
   `SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION`. That flag still allows logging in
   without the claim, but the account is no longer marked verified on the
   strength of a claim that was never made; the user can still verify through
   the regular email flow. This is a behavioral change for deployments using
   `SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION`, so this commit can be dropped if that
   isn't wanted. The first commit stands on its own.~

Issue identified by me, patches written by 🤖 and reviewed by me.