### PR TITLE
fix: add autofillOnPageLoad and fido2Credentials fields for SDK 0.2.0 compatibility

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -233,6 +233,11 @@ impl Cipher {
                 d.into_iter()
                     .filter_map(|d| match d.data.get("password") {
                         Some(p) if p.is_string() => Some(d.data),
+                        Some(_) => {
+                            let mut data = d.data;
+                            data["password"] = json!("");
+                            Some(data)
+                        }
                         _ => None,
                     })
                     .map(|mut d| {
@@ -279,6 +284,14 @@ impl Cipher {
             // Check if `passwordRevisionDate` is a valid date, else convert it
             if let Some(pw_revision) = type_data_json["passwordRevisionDate"].as_str() {
                 type_data_json["passwordRevisionDate"] = json!(validate_and_format_date(pw_revision));
+            }
+
+            // SDK 0.2.0 compatibility: Bitwarden extension v2026.7.0 expects these fields
+            if type_data_json.get("autofillOnPageLoad").is_none() {
+                type_data_json["autofillOnPageLoad"] = Value::Null;
+            }
+            if type_data_json.get("fido2Credentials").is_none() {
+                type_data_json["fido2Credentials"] = Value::Array(Vec::new());
             }
         }
 


### PR DESCRIPTION


## Description

The Bitwarden browser extension v2026.7.0, released on July 23, 2026, ships with SDK internal `0.2.0` which introduced stricter deserialization rules for cipher data. After upgrading, users of self-hosted Vaultwarden can successfully authenticate and sync (HTTP 200), but the vault appears completely empty — no credentials are displayed.

The root cause was identified as two issues in `src/db/models/cipher.rs`:

### 1. Missing fields in login cipher data

The SDK's `CipherLoginModel` gained two new fields that the browser extension's WASM deserializer expects to exist in the JSON response: `autofillOnPageLoad` and `fido2Credentials`. Vaultwarden did not emit these keys, causing the WASM deserializer to panic.

### 2. Strict password history deserialization

The SDK's `CipherPasswordHistoryModel` uses **non-optional** `String` fields for `password` and `lastUsedDate`. Entries with null-like password values could trigger deserialization failures.

## Changes

- **autofillOnPageLoad**: Now emitted as `null` when not set by the user
- **fido2Credentials**: Now emitted as `[]` (empty array) when the user has no FIDO2 credentials
- **passwordHistory**: Non-string password values are replaced with empty string `""` instead of dropping the entry

## Compatibility

- ✅ **Browser extension v2026.7.0**: Fixed — vault now displays correctly
- ✅ **CLI v2026.7.0**: Works (CLI does not use WASM SDK)
- ✅ **Web Vault**: No regression
- ✅ **Mobile apps**: No regression

## Related

- Closes #7462
- Ref: https://github.com/bitwarden/clients/issues/22013
- SDK update PR: https://github.com/bitwarden/clients/pull/21233
- SDK CipherLoginModel: https://github.com/bitwarden/sdk-internal/blob/main/crates/bitwarden-api-api/src/models/cipher_login_model.rs
