### PR TITLE
Strip null values from optional Login cipher fields

### DIFF
--- a/src/db/models/cipher.rs
+++ b/src/db/models/cipher.rs
@@ -280,6 +280,23 @@ impl Cipher {
             if let Some(pw_revision) = type_data_json["passwordRevisionDate"].as_str() {
                 type_data_json["passwordRevisionDate"] = json!(validate_and_format_date(pw_revision));
             }
+
+            // Strip `null`s from optional Login fields — newer WASM clients panic (see #7361).
+            if let Value::Object(ref mut map) = type_data_json {
+                for key in [
+                    "password",
+                    "username",
+                    "totp",
+                    "autofillOnPageLoad",
+                    "fido2Credentials",
+                    "passwordRevisionDate",
+                    "uris",
+                ] {
+                    if map.get(key).is_some_and(Value::is_null) {
+                        map.remove(key);
+                    }
+                }
+            }
         }
 
         // Fix secure note issues when data is invalid


### PR DESCRIPTION
## Description

Fixes vault-load crashes on Bitwarden 2026.5+ clients caused by explicit `null` values on optional Login cipher fields.

Refs: #7361, [bitwarden/clients#21135](https://github.com/bitwarden/clients/issues/21135). Same class of bug as #7308 (SSH-key) but for the Login (`atype=1`) type.

## Symptom

Angular UI hangs on the skeleton loading screen after successful unlock. Console:

```
Unhandled error in angular Error: Error: invalid type: JsValue(Object({...Login cipher shape...})), expected a string
    je bitwarden_wasm_internal_bg.js:6830
    ...
    getStore browser-local-storage.service.ts:78
```

Serde aborts on the first failing cipher, so a single bad item blanks the entire vault.

## Root cause

The 2026.5+ `sdk-internal` WASM deserializer routes JS `null` values into `EncString::deserialize` (a custom `Deserialize` impl expecting a string) rather than short-circuiting `Option<T>` to `None` the way `serde-json` does. Vaultwarden emits explicit `null` values for optional Login fields; upstream Bitwarden's server serializes them with `#[serde(skip_serializing_if = "Option::is_none")]` and always omits the key instead. Missing key becomes `None` and works. Present as null crashes the new decoder.

Wire schema for reference: [`CipherLoginModel`](https://github.com/bitwarden/sdk-internal/blob/main/crates/bitwarden-api-api/src/models/cipher_login_model.rs), every optional field is `#[serde(skip_serializing_if = "Option::is_none")]`.

## Fix

Post-process `type_data_json` for `atype == 1` (Login) ciphers to strip `null`-valued keys before emit, matching upstream's shape. Covers: `password`, `username`, `totp`, `autofillOnPageLoad`, `fido2Credentials`, `passwordRevisionDate`, `uris`.

The legacy `uri` (singular) field, unconditionally set to `Value::Null` at line 261 as backwards-compat for old mobile clients per the existing comment, is deliberately left untouched.

## Verification

Tested against a real vault of ~1000 Login ciphers, 703 of which (71%) hold at least one `null` on the affected keys:

| Binary | Result |
|---|---|
| Stock `1.36.0` | Vault fails to load, console shows the trace above |
| Patched (this PR) | Vault loads cleanly, Firefox extension v2026.5.x, no console errors |

Rollback / reapply cycle confirms the patch is the necessary and sufficient change.

## Scope

- Read-path only, no schema change, no migration, trivially revertible.
- Login (`atype=1`) only. Card (`atype=3`) and Identity (`atype=4`) may share the same root cause but are not covered here (no reports found, would prefer a separate PR once reproduced).
