### PR TITLE
Add `pm-34171-card-scanner` feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -393,6 +393,7 @@
 ## - "cxp-import-mobile": Enable the import via CXP on iOS (Clients >= 2025.9.2)
 ## - "cxp-export-mobile": Enable the export via CXP on iOS (Clients >= 2025.9.2)
 ## - "pm-30529-webauthn-related-origins":
+## - "pm-34171-card-scanner": Enable the new card scanner feature on mobile (Android >= 2026.4.1, iOS >= 2026.4.1)
 ## - "desktop-ui-migration-milestone-1": Special feature flag for desktop UI (Desktop >= 2026.2.0)
 ## - "desktop-ui-migration-milestone-2": Special feature flag for desktop UI (Desktop >= 2026.2.0)
 ## - "desktop-ui-migration-milestone-3": Special feature flag for desktop UI (Desktop >= 2026.2.0)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1434,6 +1434,7 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     "mutual-tls",
     "cxp-import-mobile",
     "cxp-export-mobile",
+    "pm-34171-card-scanner",
     // Platform Team
     "pm-30529-webauthn-related-origins",
 ];


### PR DESCRIPTION
Introduced in 2026.4.1 Mobile releases (Android and iOS), enables use of device camera to autofill a card type item.

N.B. This feature relies on Google ML Kit. F-Droid policy disallows Google ML Kit. Because of this, F-Droid builds do not ship with card scanner feature. (See https://github.com/bitwarden/android/pull/6890)