### PR TITLE
Add `pm-32009-new-item-types` feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -393,6 +393,7 @@
 ## - "cxp-import-mobile": Enable the import via CXP on iOS (Clients >= 2025.9.2)
 ## - "cxp-export-mobile": Enable the export via CXP on iOS (Clients >= 2025.9.2)
 ## - "pm-30529-webauthn-related-origins":
+## - "pm-32009-new-item-types": Enable new item types: Bank Account, Driver's License, and Passport (Clients >= 2026.4.0)
 ## - "desktop-ui-migration-milestone-1": Special feature flag for desktop UI (Desktop >= 2026.2.0)
 ## - "desktop-ui-migration-milestone-2": Special feature flag for desktop UI (Desktop >= 2026.2.0)
 ## - "desktop-ui-migration-milestone-3": Special feature flag for desktop UI (Desktop >= 2026.2.0)

--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -266,6 +266,9 @@ pub struct CipherData {
     Card = 3,
     Identity = 4,
     SshKey = 5
+    BankAccount = 6
+    DriversLicense = 7
+    Passport = 8
     */
     pub r#type: i32,
     pub name: String,
@@ -278,6 +281,9 @@ pub struct CipherData {
     card: Option<Value>,
     identity: Option<Value>,
     ssh_key: Option<Value>,
+    bank_account: Option<Value>,
+    drivers_license: Option<Value>,
+    passport: Option<Value>,
 
     favorite: Option<bool>,
     reprompt: Option<i32>,
@@ -510,6 +516,9 @@ pub async fn update_cipher_from_data(
         3 => data.card,
         4 => data.identity,
         5 => data.ssh_key,
+        6 => data.bank_account,
+        7 => data.drivers_license,
+        8 => data.passport,
         _ => err!("Invalid type"),
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1436,6 +1436,8 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     "cxp-export-mobile",
     // Platform Team
     "pm-30529-webauthn-related-origins",
+    // Vault Team
+    "pm-32009-new-item-types",
 ];
 
 impl Config {


### PR DESCRIPTION
Introduced in 2026.4.0 for all clients, enables new item types bank account, driver's license, and passport.

Tested with 1.37.0's web build 2026.6.4 and Android 2026.6.1(21713) from Google Play Store.

`EXPERIMENTAL_CLIENT_FEATURE_FLAGS=desktop-ui-migration-milestone-1,desktop-ui-migration-milestone-2,desktop-ui-migration-milestone-3,desktop-ui-migration-milestone-4,pm-34171-card-scanner,pm-32009-new-item-types`

<img width="1141" height="679" alt="Screenshot From 2026-07-24 17-17-15" src="https://github.com/user-attachments/assets/9f885c2d-f8c7-4676-8a6e-720ec9804f48" />
