### PR TITLE
Always send initOrganization and orgUserHasExistingUser in invite URL

### DIFF
--- a/src/mail.rs
+++ b/src/mail.rs
@@ -307,9 +307,18 @@ pub async fn send_invite(
         if CONFIG.sso_enabled() && CONFIG.sso_only() {
             query_params.append_pair("orgSsoIdentifier", &org_id);
         }
-        if user.private_key.is_some() {
-            query_params.append_pair("orgUserHasExistingUser", "true");
-        }
+
+        // The web vault requires both of these parameters to be present.
+        // If either is missing it rejects the invite client-side, before any
+        // request reaches the server, showing only "Unable to accept invitation".
+        query_params.append_pair("initOrganization", "false");
+
+        let org_user_has_existing_user = if user.private_key.is_some() {
+            "true"
+        } else {
+            "false"
+        };
+        query_params.append_pair("orgUserHasExistingUser", org_user_has_existing_user);
     }
 
     let Some(query_string) = query.query() else {


### PR DESCRIPTION
Fixes [#7481](https://github.com/dani-garcia/vaultwarden/issues/7481).

The web vault bundled with 1.37.0 (2026.6.4) requires seven query parameters in the accept-organization URL:

    fromUrlParams(e){ return null==e ? null :
      isGuid(e.organizationId) && isGuid(e.organizationUserId)
      && null!=e.email && null!=e.token && null!=e.organizationName
      && null!=e.initOrganization && null!=e.orgUserHasExistingUser
        ? new bi({...}) : null }

send_invite() never appended initOrganization, and appended orgUserHasExistingUser only when the invited user already had an account. With either missing, fromUrlParams returns null and the component shows inviteAcceptFailed without sending any request to the server — which is why the log shows no POST /api/organizations/<org_id>/users/<member_id>/accept at all.

This regressed in 1.37.0: web vault 2026.4.1 (shipped with 1.36.0) had the same logic under the name fromParams and required only the two GUIDs, reading the rest null-safely.

This patch always sends both parameters. Verified on 1.37.0 with SMTP enabled: before the change the invite link is rejected client-side; after appending &initOrganization=false manually the invite is accepted, the membership moves to Accepted, and confirmation by the owner works as usual. Reported independently by another user in the issue.