### PR TITLE
Fix sendmail executable permission check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3233,18 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -5867,6 +5885,7 @@ dependencies = [
  "macros",
  "mimalloc",
  "moka",
+ "nix",
  "num-derive",
  "num-traits",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ oidc-accept-string-booleans = ["openidconnect/accept-string-booleans"]
 unstable = []
 
 [target."cfg(unix)".dependencies]
+nix = { version = "0.31.3", features = ["fs"] }
 # Logging
 syslog = "7.0.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1164,7 +1164,7 @@ fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
                     #[cfg(unix)]
                     {
                         use std::os::unix::fs::PermissionsExt;
-                        if !metadata.permissions().mode() & 0o111 != 0 {
+                        if metadata.permissions().mode() & 0o111 == 0 {
                             err!(format!("sendmail command at `{path:?}` isn't executable"));
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1162,11 +1162,8 @@ fn validate_config(cfg: &ConfigItems, on_update: bool) -> Result<(), Error> {
                     }
 
                     #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::PermissionsExt;
-                        if metadata.permissions().mode() & 0o111 == 0 {
-                            err!(format!("sendmail command at `{path:?}` isn't executable"));
-                        }
+                    if nix::unistd::access(&path, nix::unistd::AccessFlags::X_OK).is_err() {
+                        err!(format!("sendmail command at `{path:?}` isn't executable"));
                     }
                 }
             }


### PR DESCRIPTION
Fixes #7445

The previous permission check inspected the Unix mode bits directly and
could reject commands that were executable by the current process.

Use `nix::unistd::access` with `AccessFlags::X_OK` to check whether the
sendmail command is executable by the running process.

Checks performed:

- `cargo fmt --check`
- `cargo check --features sqlite`
- `cargo test --features sqlite,mysql,postgresql`
- `cargo clippy --features sqlite,mysql,postgresql -- -D warnings`