### PR TITLE
refactor(admin): return 503 status code when admin panel is disabled

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -98,8 +98,11 @@ static CAN_BACKUP: LazyLock<bool> = LazyLock::new(|| ACTIVE_DB_TYPE.get().is_som
 static CAN_BACKUP: LazyLock<bool> = LazyLock::new(|| false);
 
 #[get("/")]
-fn admin_disabled() -> &'static str {
-    "The admin panel is disabled, please configure the 'ADMIN_TOKEN' variable to enable it"
+fn admin_disabled() -> (Status, &'static str) {
+    (
+        Status::ServiceUnavailable,
+        "The admin panel is disabled, please configure the 'ADMIN_TOKEN' variable to enable it"
+    )
 }
 
 const COOKIE_NAME: &str = "VW_ADMIN";


### PR DESCRIPTION
This PR addresses #7493 

Currently, when the Vaultwarden instance does not have the `ADMIN_TOKEN` configured, navigating to the `/admin` path  returns a plain text message with an HTTP 200.

This PR changes the `HTTP 200` by an `HTTP 503 service unavailable` to allow health checks and other monitoring systems to get the actual status of the Admin panel.