### PR TITLE
Include user email in successful login logs

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -318,7 +318,7 @@ async fn sso_login(
         Some((user, _)) if !user.enabled => {
             err!(
                 "This user has been disabled",
-                format!("IP: {}. Username: {}.", ip.ip, user.display_name()),
+                format!("IP: {}. Username: {}.", ip.ip, user.email),
                 ErrorEvent {
                     event: EventType::UserFailedLogIn
                 }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -577,7 +577,7 @@ async fn authenticated_response(
         result["TwoFactorToken"] = Value::String(token);
     }
 
-    info!("User {} logged in successfully. IP: {}", user.display_name(), ip.ip);
+    info!("User {} logged in successfully. IP: {}", user.email, ip.ip);
     Ok(Json(result))
 }
 


### PR DESCRIPTION
Include the user's email address in successful password and SSO login log messages.

This preserves the existing display name while adding a stable identifier that can be used to correlate authentication events in SIEM and audit platforms.

Example:

User john@example.com logged in successfully. IP: 192.0.2.10

Successful API key logins already include the user's email address.

Related to discussion [#7418](https://github.com/dani-garcia/vaultwarden/discussions/7418).