### PR TITLE
Update supported Bitwarden client feature flags for 2026.7

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -382,14 +382,19 @@
 ##
 ## The following flags are available:
 ## - "pm-5594-safari-account-switching": Enable account switching in the Safari browser extension. (Verified in Browser 2026.7.0)
+## - "pm-32413-multi-client-password-management": Enable this authentication-sensitive client rollout. (Verified in Browser/Desktop 2026.7.0)
+## - "pm-4516-devices-add-last-activity-date": Show device last activity when supplied by the server. Vaultwarden does not currently supply this field. (Verified in Browser/Desktop 2026.7.0)
 ## - "undetermined-cipher-scenario-logic": Enable the browser extension's updated autofill matching logic. (Verified in Browser 2026.7.0)
 ## - "macos-native-credential-sync": Enable native macOS credential-provider sync in Desktop. (Verified in Desktop 2026.7.0)
 ## - "fill-assist-targeting-rules": Enable Fill Assist targeting rules for autofill. (Verified in Browser/Android/iOS 2026.7.0)
 ## - "pm-39071-default-password-manager-prompt": Prompt new browser-extension installations to make Bitwarden the default password manager. (Verified in Browser 2026.7.0)
+## - "pm-29968-fill-after-save": Fill matching logins after saving them. (Verified in Browser 2026.7.0)
+## - "content-script-ipc-channel-framework": Enable this internal/experimental client rollout. (Verified in Browser 2026.7.0)
 ## - "windows-desktop-autotype": Enable Windows Desktop auto-type for Premium accounts. (Verified in Desktop 2026.7.0)
 ## - "windows-desktop-autotype-ga": Show Windows Desktop auto-type controls; also enable "windows-desktop-autotype". (Verified in Desktop 2026.7.0)
 ## - "ssh-agent-v2": Enable the current SSH agent implementation in Desktop. (Verified in Desktop 2026.7.0)
 ## - "ssh-ecdsa": Allow importing supported ECDSA SSH keys in Desktop; also enable "ssh-agent-v2". (Verified in Desktop 2026.7.0)
+## - "pm-32783-electron-storage-cache": Enable this internal/experimental client rollout. (Verified in Desktop 2026.7.0)
 ## - "desktop-ui-settings-dialog": Use the Desktop settings dialog. (Verified in Desktop 2026.7.0)
 ## - "innovation-sprint-shared-unlock-part-1": Enable the shared-unlock Desktop/Browser leader. Must be enabled with part 2.
 ## - "innovation-sprint-shared-unlock-part-2": Enable the shared-unlock Browser/Web follower and controls. Must be enabled with part 1.
@@ -397,6 +402,12 @@
 ## - "pm-30529-webauthn-related-origins": Allow passkey operations across domains a site declares as related. (Verified in Browser 2026.7.0)
 ## - "pm-34410-attachment-upload-progress": Show attachment upload progress in supported clients. (Verified in Browser/Desktop 2026.7.0)
 ## - "phishing-detection": Warn in the browser extension when a visited site matches its phishing data. (Verified in Browser 2026.7.0)
+## - "pm-37785-vault-batch-bar": Enable the Vault batch bar. Both batch-bar flags are required for Desktop. (Verified in Browser/Desktop 2026.7.0)
+## - "pm-37785-desktop-vault-batch-bar": Enable the Desktop Vault batch bar. Both batch-bar flags are required for Desktop. (Verified in Desktop 2026.7.0)
+## - "pm-31039-item-action-in-extension": Show item actions in the browser extension. (Verified in Browser 2026.7.0)
+## - "pm-32380-btn-text-add-create": Use Add/Create button text. (Verified in Browser/Desktop 2026.7.0)
+## - "pm-28091-add-copy-and-quick-launch-actions": Add Copy and Quick Launch actions. (Verified in Browser/Desktop 2026.7.0)
+## - "pm-32016-remove-at-risk-callout": Suppress the at-risk password callout. (Verified in Browser/Desktop 2026.7.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=
 
 ## Require new device emails. When a user logs in an email is required to be sent.

--- a/.env.template
+++ b/.env.template
@@ -381,22 +381,21 @@
 ## Note that clients cache the /api/config endpoint for about 1 hour and it could take some time before they are enabled or disabled!
 ##
 ## The following flags are available:
-## - "pm-5594-safari-account-switching": Enable account switching in Safari. (Safari >= 2026.2.0)
-## - "ssh-agent": Enable SSH agent support on Desktop. (Desktop >= 2024.12.0)
-## - "ssh-agent-v2": Enable newer SSH agent support. (Desktop >= 2026.2.1)
-## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Clients >= 2024.12.0)
-## - "pm-25373-windows-biometrics-v2": Enable the new implementation of biometrics on Windows. (Desktop >= 2025.11.0)
-## - "pm-26340-linux-biometrics-v2": Enable the new implementation of biometrics on Linux. (Desktop >= 2025.11.0)
-## - "anon-addy-self-host-alias": Enable configuring self-hosted Anon Addy alias generator. (Android >= 2025.3.0, iOS >= 2025.4.0)
-## - "simple-login-self-host-alias": Enable configuring self-hosted Simple Login alias generator. (Android >= 2025.3.0, iOS >= 2025.4.0)
-## - "mutual-tls": Enable the use of mutual TLS on Android (Clients >= 2025.2.0)
-## - "cxp-import-mobile": Enable the import via CXP on iOS (Clients >= 2025.9.2)
-## - "cxp-export-mobile": Enable the export via CXP on iOS (Clients >= 2025.9.2)
-## - "pm-30529-webauthn-related-origins":
-## - "desktop-ui-migration-milestone-1": Special feature flag for desktop UI (Desktop >= 2026.2.0)
-## - "desktop-ui-migration-milestone-2": Special feature flag for desktop UI (Desktop >= 2026.2.0)
-## - "desktop-ui-migration-milestone-3": Special feature flag for desktop UI (Desktop >= 2026.2.0)
-## - "desktop-ui-migration-milestone-4": Special feature flag for desktop UI (Desktop >= 2026.2.0)
+## - "pm-5594-safari-account-switching": Enable account switching in the Safari browser extension. (Verified in Browser 2026.7.0)
+## - "undetermined-cipher-scenario-logic": Enable the browser extension's updated autofill matching logic. (Verified in Browser 2026.7.0)
+## - "macos-native-credential-sync": Enable native macOS credential-provider sync in Desktop. (Verified in Desktop 2026.7.0)
+## - "fill-assist-targeting-rules": Enable Fill Assist targeting rules for autofill. (Verified in Browser/Android/iOS 2026.7.0)
+## - "pm-39071-default-password-manager-prompt": Prompt new browser-extension installations to make Bitwarden the default password manager. (Verified in Browser 2026.7.0)
+## - "windows-desktop-autotype": Enable Windows Desktop auto-type for Premium accounts. (Verified in Desktop 2026.7.0)
+## - "windows-desktop-autotype-ga": Show Windows Desktop auto-type controls; also enable "windows-desktop-autotype". (Verified in Desktop 2026.7.0)
+## - "ssh-agent-v2": Enable the current SSH agent implementation in Desktop. (Verified in Desktop 2026.7.0)
+## - "ssh-ecdsa": Allow importing supported ECDSA SSH keys in Desktop; also enable "ssh-agent-v2". (Verified in Desktop 2026.7.0)
+## - "desktop-ui-settings-dialog": Use the Desktop settings dialog. (Verified in Desktop 2026.7.0)
+## - "pm-34171-card-scanner": Scan a payment card to populate card-item details. (Verified in Android/iOS 2026.7.0)
+## - "pm-34224-mobile-attachment-updates": Use the updated Android attachment screen. (Verified in Android 2026.7.0)
+## - "pm-30529-webauthn-related-origins": Allow passkey operations across domains a site declares as related. (Verified in Browser 2026.7.0)
+## - "pm-34410-attachment-upload-progress": Show attachment upload progress in supported clients. (Verified in Browser/Desktop 2026.7.0)
+## - "phishing-detection": Warn in the browser extension when a visited site matches its phishing data. (Verified in Browser 2026.7.0)
 # EXPERIMENTAL_CLIENT_FEATURE_FLAGS=
 
 ## Require new device emails. When a user logs in an email is required to be sent.

--- a/.env.template
+++ b/.env.template
@@ -391,6 +391,8 @@
 ## - "ssh-agent-v2": Enable the current SSH agent implementation in Desktop. (Verified in Desktop 2026.7.0)
 ## - "ssh-ecdsa": Allow importing supported ECDSA SSH keys in Desktop; also enable "ssh-agent-v2". (Verified in Desktop 2026.7.0)
 ## - "desktop-ui-settings-dialog": Use the Desktop settings dialog. (Verified in Desktop 2026.7.0)
+## - "innovation-sprint-shared-unlock-part-1": Enable the shared-unlock Desktop/Browser leader. Must be enabled with part 2.
+## - "innovation-sprint-shared-unlock-part-2": Enable the shared-unlock Browser/Web follower and controls. Must be enabled with part 1.
 ## - "pm-34224-mobile-attachment-updates": Use the updated Android attachment screen. (Verified in Android 2026.7.0)
 ## - "pm-30529-webauthn-related-origins": Allow passkey operations across domains a site declares as related. (Verified in Browser 2026.7.0)
 ## - "pm-34410-attachment-upload-progress": Show attachment upload progress in supported clients. (Verified in Browser/Desktop 2026.7.0)

--- a/.env.template
+++ b/.env.template
@@ -391,7 +391,6 @@
 ## - "ssh-agent-v2": Enable the current SSH agent implementation in Desktop. (Verified in Desktop 2026.7.0)
 ## - "ssh-ecdsa": Allow importing supported ECDSA SSH keys in Desktop; also enable "ssh-agent-v2". (Verified in Desktop 2026.7.0)
 ## - "desktop-ui-settings-dialog": Use the Desktop settings dialog. (Verified in Desktop 2026.7.0)
-## - "pm-34171-card-scanner": Scan a payment card to populate card-item details. (Verified in Android/iOS 2026.7.0)
 ## - "pm-34224-mobile-attachment-updates": Use the updated Android attachment screen. (Verified in Android 2026.7.0)
 ## - "pm-30529-webauthn-related-origins": Allow passkey operations across domains a site declares as related. (Verified in Browser 2026.7.0)
 ## - "pm-34410-attachment-upload-progress": Show attachment upload progress in supported clients. (Verified in Browser/Desktop 2026.7.0)

--- a/src/api/core/mod.rs
+++ b/src/api/core/mod.rs
@@ -211,10 +211,10 @@ fn get_api_webauthn(_headers: Headers) -> Json<Value> {
 fn config() -> Json<Value> {
     let domain = CONFIG.domain();
     // Official available feature flags can be found here:
-    // Server (v2026.2.1): https://github.com/bitwarden/server/blob/0e42725d0837bd1c0dabd864ff621a579959744b/src/Core/Constants.cs#L135
-    // Client (v2026.2.1): https://github.com/bitwarden/clients/blob/f96380c3138291a028bdd2c7a5fee540d5c98ba5/libs/common/src/enums/feature-flag.enum.ts#L12
-    // Android (v2026.2.1): https://github.com/bitwarden/android/blob/6902c19c0093fa476bbf74ccaa70c9f14afbb82f/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt#L31
-    // iOS (v2026.2.1): https://github.com/bitwarden/ios/blob/cdd9ba1770ca2ffc098d02d12cc3208e3a830454/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
+    // Server (v2026.7.1): https://github.com/bitwarden/server/blob/97ad380f0f82b560d81c1e2e684cef9e85b3379e/src/Core/Constants.cs#L120
+    // Client (v2026.7.0): https://github.com/bitwarden/clients/blob/adf0337e4a0f788b895933792fc04fa162669eff/libs/common/src/enums/feature-flag.enum.ts#L10
+    // Android (v2026.7.0-bwpm): https://github.com/bitwarden/android/blob/36c892e1887b5051270ead6021afb16420663566/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt#L28
+    // iOS (v2026.7.0-bwpm): https://github.com/bitwarden/ios/blob/e9514dc0f85092ef3cf2a2ccbe07dc5a4f661b0c/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L5
     let mut feature_states = parse_experimental_client_feature_flags(
         &CONFIG.experimental_client_feature_flags(),
         &FeatureFlagFilter::ValidOnly,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1429,7 +1429,6 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     // Desktop Team
     "desktop-ui-settings-dialog",
     // Mobile Team
-    "pm-34171-card-scanner",
     "pm-34224-mobile-attachment-updates",
     // Platform Team
     "pm-30529-webauthn-related-origins",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1416,16 +1416,21 @@ pub enum PathType {
 pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     // Auth Team
     "pm-5594-safari-account-switching",
+    "pm-32413-multi-client-password-management",
+    "pm-4516-devices-add-last-activity-date",
     // Autofill Team
     "undetermined-cipher-scenario-logic",
     "macos-native-credential-sync",
     "fill-assist-targeting-rules",
     "pm-39071-default-password-manager-prompt",
+    "pm-29968-fill-after-save",
+    "content-script-ipc-channel-framework",
     // Desktop Native Team
     "windows-desktop-autotype",
     "windows-desktop-autotype-ga",
     "ssh-agent-v2",
     "ssh-ecdsa",
+    "pm-32783-electron-storage-cache",
     // Desktop Team
     "desktop-ui-settings-dialog",
     // Key Management Team
@@ -1438,6 +1443,13 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     "pm-34410-attachment-upload-progress",
     // DIRT Team
     "phishing-detection",
+    // Vault Team
+    "pm-37785-vault-batch-bar",
+    "pm-37785-desktop-vault-batch-bar",
+    "pm-31039-item-action-in-extension",
+    "pm-32380-btn-text-add-create",
+    "pm-28091-add-copy-and-quick-launch-actions",
+    "pm-32016-remove-at-risk-callout",
 ];
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1409,33 +1409,33 @@ pub enum PathType {
 }
 
 // Official available feature flags can be found here:
-// Server (v2026.2.1): https://github.com/bitwarden/server/blob/0e42725d0837bd1c0dabd864ff621a579959744b/src/Core/Constants.cs#L135
-// Client (v2026.2.1): https://github.com/bitwarden/clients/blob/f96380c3138291a028bdd2c7a5fee540d5c98ba5/libs/common/src/enums/feature-flag.enum.ts#L12
-// Android (v2026.2.1): https://github.com/bitwarden/android/blob/6902c19c0093fa476bbf74ccaa70c9f14afbb82f/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt#L31
-// iOS (v2026.2.1): https://github.com/bitwarden/ios/blob/cdd9ba1770ca2ffc098d02d12cc3208e3a830454/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L7
+// Server (v2026.7.1): https://github.com/bitwarden/server/blob/97ad380f0f82b560d81c1e2e684cef9e85b3379e/src/Core/Constants.cs#L120
+// Client (v2026.7.0): https://github.com/bitwarden/clients/blob/adf0337e4a0f788b895933792fc04fa162669eff/libs/common/src/enums/feature-flag.enum.ts#L10
+// Android (v2026.7.0-bwpm): https://github.com/bitwarden/android/blob/36c892e1887b5051270ead6021afb16420663566/core/src/main/kotlin/com/bitwarden/core/data/manager/model/FlagKey.kt#L28
+// iOS (v2026.7.0-bwpm): https://github.com/bitwarden/ios/blob/e9514dc0f85092ef3cf2a2ccbe07dc5a4f661b0c/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift#L5
 pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
-    // Architecture
-    "desktop-ui-migration-milestone-1",
-    "desktop-ui-migration-milestone-2",
-    "desktop-ui-migration-milestone-3",
-    "desktop-ui-migration-milestone-4",
     // Auth Team
     "pm-5594-safari-account-switching",
     // Autofill Team
-    "ssh-agent",
+    "undetermined-cipher-scenario-logic",
+    "macos-native-credential-sync",
+    "fill-assist-targeting-rules",
+    "pm-39071-default-password-manager-prompt",
+    // Desktop Native Team
+    "windows-desktop-autotype",
+    "windows-desktop-autotype-ga",
     "ssh-agent-v2",
-    // Key Management Team
-    "ssh-key-vault-item",
-    "pm-25373-windows-biometrics-v2",
-    "pm-26340-linux-biometrics-v2",
+    "ssh-ecdsa",
+    // Desktop Team
+    "desktop-ui-settings-dialog",
     // Mobile Team
-    "anon-addy-self-host-alias",
-    "simple-login-self-host-alias",
-    "mutual-tls",
-    "cxp-import-mobile",
-    "cxp-export-mobile",
+    "pm-34171-card-scanner",
+    "pm-34224-mobile-attachment-updates",
     // Platform Team
     "pm-30529-webauthn-related-origins",
+    "pm-34410-attachment-upload-progress",
+    // DIRT Team
+    "phishing-detection",
 ];
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1428,6 +1428,9 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     "ssh-ecdsa",
     // Desktop Team
     "desktop-ui-settings-dialog",
+    // Key Management Team
+    "innovation-sprint-shared-unlock-part-1",
+    "innovation-sprint-shared-unlock-part-2",
     // Mobile Team
     "pm-34224-mobile-attachment-updates",
     // Platform Team

--- a/src/util.rs
+++ b/src/util.rs
@@ -804,6 +804,23 @@ pub fn parse_experimental_client_feature_flags(
         .collect()
 }
 
+#[cfg(test)]
+mod feature_flag_tests {
+    use super::*;
+
+    #[test]
+    fn feature_flag_filters_preserve_supported_boolean_flags() {
+        let configured = format!(" unknown, {}, removed ", SUPPORTED_FEATURE_FLAGS.join(", "));
+        let valid = parse_experimental_client_feature_flags(&configured, &FeatureFlagFilter::ValidOnly);
+        let invalid = parse_experimental_client_feature_flags(&configured, &FeatureFlagFilter::InvalidOnly);
+
+        assert_eq!(valid.len(), SUPPORTED_FEATURE_FLAGS.len());
+        assert!(valid.values().all(|value| *value));
+        assert!(invalid.contains_key("unknown"));
+        assert!(invalid.contains_key("removed"));
+    }
+}
+
 /// TODO: This is extracted from IpAddr::is_global, which is unstable:
 /// https://doc.rust-lang.org/nightly/std/net/enum.IpAddr.html#method.is_global
 /// Remove once https://github.com/rust-lang/rust/issues/27709 is merged

--- a/src/util.rs
+++ b/src/util.rs
@@ -819,6 +819,22 @@ mod feature_flag_tests {
         assert!(invalid.contains_key("unknown"));
         assert!(invalid.contains_key("removed"));
     }
+
+    #[test]
+    fn shared_unlock_feature_flags_are_supported() {
+        let flags = parse_experimental_client_feature_flags(
+            "innovation-sprint-shared-unlock-part-1, innovation-sprint-shared-unlock-part-2",
+            &FeatureFlagFilter::ValidOnly,
+        );
+
+        assert_eq!(
+            flags,
+            HashMap::from([
+                ("innovation-sprint-shared-unlock-part-1".to_owned(), true),
+                ("innovation-sprint-shared-unlock-part-2".to_owned(), true),
+            ]),
+        );
+    }
 }
 
 /// TODO: This is extracted from IpAddr::is_global, which is unstable:

--- a/src/util.rs
+++ b/src/util.rs
@@ -835,6 +835,31 @@ mod feature_flag_tests {
             ]),
         );
     }
+
+    #[test]
+    fn additional_2026_7_client_feature_flags_are_supported() {
+        let flags = parse_experimental_client_feature_flags(
+            "pm-37785-vault-batch-bar,pm-37785-desktop-vault-batch-bar,pm-31039-item-action-in-extension,pm-29968-fill-after-save,pm-32380-btn-text-add-create,pm-28091-add-copy-and-quick-launch-actions,pm-32016-remove-at-risk-callout,pm-32783-electron-storage-cache,content-script-ipc-channel-framework,pm-32413-multi-client-password-management,pm-4516-devices-add-last-activity-date",
+            &FeatureFlagFilter::ValidOnly,
+        );
+
+        assert_eq!(
+            flags,
+            HashMap::from([
+                ("pm-37785-vault-batch-bar".to_owned(), true),
+                ("pm-37785-desktop-vault-batch-bar".to_owned(), true),
+                ("pm-31039-item-action-in-extension".to_owned(), true),
+                ("pm-29968-fill-after-save".to_owned(), true),
+                ("pm-32380-btn-text-add-create".to_owned(), true),
+                ("pm-28091-add-copy-and-quick-launch-actions".to_owned(), true),
+                ("pm-32016-remove-at-risk-callout".to_owned(), true),
+                ("pm-32783-electron-storage-cache".to_owned(), true),
+                ("content-script-ipc-channel-framework".to_owned(), true),
+                ("pm-32413-multi-client-password-management".to_owned(), true),
+                ("pm-4516-devices-add-last-activity-date".to_owned(), true),
+            ]),
+        );
+    }
 }
 
 /// TODO: This is extracted from IpAddr::is_global, which is unstable:


### PR DESCRIPTION
## Summary

- Update immutable upstream feature-flag source references.
- Add client-compatible Boolean flags with tagged-source consumers.
- Remove flags no longer consumed by current tagged clients.
- Document every available flag in `.env.template`.

## Upstream release baselines

| Component | Tag | Full commit SHA |
| --- | --- | --- |
| Vaultwarden base | 1.37.0 | 46ae59eaf444f0ae0a799070cf2bd6c415284a51 |
| Bitwarden Server | v2026.7.1 | 97ad380f0f82b560d81c1e2e684cef9e85b3379e |
| Browser/Web/Desktop | browser/web/desktop-v2026.7.0 | adf0337e4a0f788b895933792fc04fa162669eff |
| Android Password Manager | v2026.7.0-bwpm | 36c892e1887b5051270ead6021afb16420663566 |
| iOS Password Manager | v2026.7.0-bwpm | e9514dc0f85092ef3cf2a2ccbe07dc5a4f661b0c |

## Added

- `undetermined-cipher-scenario-logic`, `macos-native-credential-sync`, `fill-assist-targeting-rules`, and `pm-39071-default-password-manager-prompt`: client-local autofill behavior.
- `windows-desktop-autotype`, `windows-desktop-autotype-ga`, `ssh-ecdsa`, and `desktop-ui-settings-dialog`: current Desktop UI/native behavior; ECDSA requires `ssh-agent-v2`.
- `innovation-sprint-shared-unlock-part-1` and `innovation-sprint-shared-unlock-part-2`: client-local Desktop/Browser/Web shared unlock; both parts must be enabled together.
- `pm-37785-vault-batch-bar`, `pm-37785-desktop-vault-batch-bar`, `pm-31039-item-action-in-extension`, `pm-29968-fill-after-save`, `pm-32380-btn-text-add-create`, and `pm-28091-add-copy-and-quick-launch-actions`: tagged Vault UI behavior; Desktop batch-bar support requires both batch-bar flags.
- `pm-32016-remove-at-risk-callout`: suppresses the at-risk password callout when explicitly enabled.
- `pm-32783-electron-storage-cache` and `content-script-ipc-channel-framework`: internal/experimental Desktop and Browser client rollouts.
- `pm-32413-multi-client-password-management`: authentication-sensitive Browser/Desktop client rollout.
- `pm-4516-devices-add-last-activity-date`: displays last activity only when supplied by the server; Vaultwarden does not currently supply this field.
- `pm-34224-mobile-attachment-updates`: current mobile UI behavior using existing APIs.
- `pm-34410-attachment-upload-progress` and `phishing-detection`: existing client upload UI and Browser phishing warning behavior.

## Retained

- `pm-5594-safari-account-switching`, `ssh-agent-v2`, and `pm-30529-webauthn-related-origins` remain consumed by tagged clients.

## Removed

- Removed legacy SSH, Desktop biometrics, alias, mTLS, CXP, and desktop UI-milestone flags. Exact-string searches of Browser/Web/Desktop, Android, and iOS 2026.7 sources found no current consumer.

## Deliberately excluded

- Numeric/string, QA/debug, billing/cloud, encryption/KDF, SDK migration, and unsupported server-behavior flags.
- `pm-32009-new-item-types`: excluded because open #7478 provides the required Vaultwarden cipher model/API support.
- `pm-34171-card-scanner`: excluded because open #7477 already adds it.

## Parallel work

- #7477 adds `pm-34171-card-scanner` and is intentionally not duplicated here.
- #7478 remains open and is intentionally not duplicated here.
- `phishing-detection` has self-hosted test discussion: https://github.com/dani-garcia/vaultwarden/discussions/7036

## Testing

- `cargo fmt --all -- --check`
- `cargo test --profile ci --features sqlite` (32 passed), including the focused feature-flag regressions
- `cargo test --profile ci --features mysql`
- `cargo test --profile ci --features sqlite,mysql,postgresql,enable_mimalloc,s3`
- `cargo clippy --profile ci --features sqlite,mysql,postgresql,enable_mimalloc,s3`
- Documentation parity check (27 flags)
- `git diff --check`
- MySQL-enabled commands use Homebrew `mysql-client@8.4` through per-command `MYSQLCLIENT_LIB_DIR` and `MYSQLCLIENT_VERSION` overrides; the default MySQL 9.7 client remains unchanged.

Static source verification only; no runtime tagged-client test was run.
