### PR TITLE
Return 503 instead of 200 when admin panel is disabled

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -98,8 +98,11 @@ static CAN_BACKUP: LazyLock<bool> = LazyLock::new(|| ACTIVE_DB_TYPE.get().is_som
 static CAN_BACKUP: LazyLock<bool> = LazyLock::new(|| false);
 
 #[get("/")]
-fn admin_disabled() -> &'static str {
-    "The admin panel is disabled, please configure the 'ADMIN_TOKEN' variable to enable it"
+fn admin_disabled() -> (Status, &'static str) {
+    (
+        Status::ServiceUnavailable,
+        "The admin panel is disabled, please configure the 'ADMIN_TOKEN' variable to enable it",
+    )
 }
 
 const COOKIE_NAME: &str = "VW_ADMIN";


### PR DESCRIPTION
## What
Changes the `admin_disabled` handler in `src/api/admin.rs` to return HTTP 503 Service Unavailable instead of 200 OK when the admin panel is disabled (i.e. `ADMIN_TOKEN` is not set).

## Why
Monitoring/health-check tools hitting `/admin` currently see a 200 OK even though the admin panel isn't actually functional, which is misleading.

## Testing
Ran locally with `ADMIN_TOKEN` unset:

Before:
curl -I http://localhost:8000/admin → HTTP/1.1 200 OK

After:
curl -I http://localhost:8000/admin → HTTP/1.1 503 Service Unavailable

Fixes #7493