### PR TITLE
Include sso_identifier in /admin/users JSON API response Fixes #6413

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -355,7 +355,7 @@ fn logout(cookies: &CookieJar<'_>) -> Redirect {
 async fn get_users_json(_token: AdminToken, conn: DbConn) -> Json<Value> {
     let users = User::get_all(&conn).await;
     let mut users_json = Vec::with_capacity(users.len());
-    for (u, _) in users {
+    for (u, sso_u) in users {
         let mut usr = u.to_json(&conn).await;
         usr["userEnabled"] = json!(u.enabled);
         usr["createdAt"] = json!(format_naive_datetime_local(&u.created_at, DT_FMT));
@@ -363,9 +363,9 @@ async fn get_users_json(_token: AdminToken, conn: DbConn) -> Json<Value> {
             Some(dt) => json!(format_naive_datetime_local(&dt, DT_FMT)),
             None => json!(None::<String>),
         };
+        usr["ssoIdentifier"] = json!(sso_u.map_or(String::new(), |u| u.identifier.to_string()));
         users_json.push(usr);
     }
-
     Json(Value::Array(users_json))
 }
 


### PR DESCRIPTION
## What
`/admin/users` (the JSON API, `get_users_json`) was discarding the `SsoUser` half of the tuple returned by `User::get_all()`, so it never included SSO identity info in its response — even though the HTML page at `/admin/users/overview` (`users_overview`) already includes it as `sso_identifier`.

This adds `ssoIdentifier` to the JSON response, matching the camelCase convention already used by this function's other added fields (`userEnabled`, `createdAt`, `lastActive`).

## Testing
Ran locally with a test admin token and one invited user:

Before: `ssoIdentifier` key absent from `/admin/users` response
After: `"ssoIdentifier":""` present in the response for a non-SSO user

Fixes #6413