### PR TITLE
Fix Debian cross-linking with xx-cargo

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -100,7 +100,8 @@ RUN source /env-cargo && \
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
     # https://github.com/dani-garcia/vaultwarden/discussions/7522
     if xx-info is-cross; then \
-        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        export XX_RUSTFLAGS; \
     fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     find . -not -path "./target*" -delete
@@ -121,7 +122,8 @@ RUN source /env-cargo && \
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
     # https://github.com/dani-garcia/vaultwarden/discussions/7522
     if xx-info is-cross; then \
-        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        export XX_RUSTFLAGS; \
     fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     if [[ "${CARGO_PROFILE}" == "dev" ]] ; then \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -96,8 +96,12 @@ ARG DB=sqlite,mysql,postgresql
 # dummy project, except the target folder
 # This folder contains the compiled dependencies
 RUN source /env-cargo && \
-    # Workaround for xx related build issues
+    # Configure xx-cargo for target pkg-config and Debian transitive library lookup
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    # https://github.com/dani-garcia/vaultwarden/discussions/7522
+    if xx-info is-cross; then \
+        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+    fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     find . -not -path "./target*" -delete
 
@@ -113,8 +117,12 @@ RUN source /env-cargo && \
     # Also do this for build.rs to ensure the version is rechecked
     touch build.rs src/main.rs && \
     # Create a symlink to the binary target folder to easy copy the binary in the final stage
-    # Workaround for xx related build issues
+    # Configure xx-cargo for target pkg-config and Debian transitive library lookup
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    # https://github.com/dani-garcia/vaultwarden/discussions/7522
+    if xx-info is-cross; then \
+        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+    fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}" && \
     if [[ "${CARGO_PROFILE}" == "dev" ]] ; then \
         ln -vfsr "/app/target/${CARGO_TARGET}/debug" /app/target/final ; \

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -32,7 +32,8 @@
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
     # https://github.com/dani-garcia/vaultwarden/discussions/7522
     if xx-info is-cross; then \
-        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+        export XX_RUSTFLAGS; \
     fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}"
 {%- endmacro %}

--- a/docker/Dockerfile.j2
+++ b/docker/Dockerfile.j2
@@ -28,8 +28,12 @@
 #     [docker.io/vaultwarden/web-vault:{{ vault_version | replace('+', '_') }}]
 #
 {% macro xx_cargo_config() -%}
-# Workaround for xx related build issues
+# Configure xx-cargo for target pkg-config and Debian transitive library lookup
     # https://github.com/tonistiigi/xx/pull/108#issuecomment-3700635977
+    # https://github.com/dani-garcia/vaultwarden/discussions/7522
+    if xx-info is-cross; then \
+        export XX_RUSTFLAGS="-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)"; \
+    fi && \
     PKG_CONFIG="$(command -v "$(xx-info)-pkg-config")" xx-cargo build --features ${DB} --profile "${CARGO_PROFILE}"
 {%- endmacro %}
 FROM --platform=linux/amd64 docker.io/vaultwarden/web-vault@{{ vault_image_digest }} AS vault


### PR DESCRIPTION
## Summary

- add the Debian target multiarch directory as a link-time search path for
  `xx-cargo` cross builds
- apply the same target-specific Rust flags to the dependency-cache and final
  build stages
- regenerate `docker/Dockerfile.debian` from `docker/Dockerfile.j2`

## Root cause

Since the switch to `xx-cargo` in #6640, Debian builds use the target clang/BFD
linker. `pkg-config` correctly adds direct target libraries such as
`libcrypto`, `libpq`, and `libmariadb`, but BFD does not search their Debian
multiarch directory for transitive `DT_NEEDED` libraries. Cross builds then
fail to find zlib, zstd, GSSAPI, and LDAP and finish with undefined references.

The change sets `XX_RUSTFLAGS` only when `xx-info is-cross` and passes:

```text
-C link-arg=-Wl,-rpath-link,/usr/lib/$(xx-info triple)
```

This is a link-time lookup path, not a runtime RPATH. Native builds keep their
existing behavior.

## Validation

- RED: [Vaultwarden 1.37.1 ARM64 host → amd64 target](https://github.com/ASEnough/vaultwarden/actions/runs/30561454936)
  reproduces the four missing-library warnings and final link failure with
  QEMU/binfmt installed.
- Initial GREEN:
  [same host/target with the final-link flag](https://github.com/ASEnough/vaultwarden/actions/runs/30562769342)
  builds successfully and exports an x86-64 ELF binary.
- Final matrix:
  [both reported cross directions](https://github.com/ASEnough/vaultwarden/actions/runs/30565042360)
  passes with the source-template version of this fix for ARM64 → amd64 and
  amd64 → ARM64, exporting x86-64 and ARM aarch64 ELF binaries respectively.
- `make -C docker` regenerates the checked-in Dockerfiles without unrelated
  changes.

Related discussion: #7522

AI assistance disclosure: OpenAI Codex (GPT-5) assisted with tracing the
`xx-cargo`/BFD argument flow, preparing the change, and running the public
red/green validation. The linked runs contain the complete reproducible
evidence.
