### PR TITLE
Revert PR #6890 until custom roles are merged

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -506,10 +506,6 @@ async fn post_organization_collections(
     let data: FullCollectionData = data.into_inner();
     data.validate(&org_id, &conn).await?;
 
-    if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
-        err!("You don't have permission to create collections")
-    }
-
     let collection = Collection::new(org_id.clone(), data.name, data.external_id);
     collection.save(&conn).await?;
 
@@ -548,6 +544,10 @@ async fn post_organization_collections(
             &conn,
         )
         .await?;
+    }
+
+    if headers.membership.atype == MembershipType::Manager && !headers.membership.access_all {
+        CollectionUser::save(&headers.membership.user_uuid, &collection.uuid, false, false, false, &conn).await?;
     }
 
     Ok(Json(collection.to_json_details(&headers.membership.user_uuid, None, &conn).await))

--- a/src/db/models/organization.rs
+++ b/src/db/models/organization.rs
@@ -522,8 +522,7 @@ impl Membership {
             "familySponsorshipValidUntil": null,
             "familySponsorshipToDelete": null,
             "accessSecretsManager": false,
-            // limit collection creation to managers with access_all permission to prevent issues
-            "limitCollectionCreation": self.atype < MembershipType::Manager || !self.access_all,
+            "limitCollectionCreation": self.atype < MembershipType::Manager, // If less then a manager return true, to limit collection creations
             "limitCollectionDeletion": true,
             "limitItemDeletion": false,
             "allowAdminAccessToAllCollectionItems": true,


### PR DESCRIPTION
Hi and first of all thanks for you work on Vaultwarden. It is truly amazing to have an fully open source alternative to Bitwarden!

However, there seems to be a huge usability regression with the merge of #6890. We (as many others) need a way to group/organize stored credentials in organizations. The ability to provide permissions to create collections without giving the user access to all other credentials is key.

Adding custom roles (#7397) would solve this problem from what I can tell, but reviewing and testing a PR with +1000 lines of code is not done overnight and I fully understand that you don't have the time for that in the near future. Therefore, my intermediate solution to solve this problem is to simply revert #6890 until #7397 is merged.

Just to point out how many others struggle with this change, here a short list of various issues/discussions etc.:
- See how many "revert commit" messages appeared on #6890 after the merge
- The discussion of people looking for solutions for collection management after : #7087
- Confusion about the current state of collection management: #6131

Disclaimer: I have not tested the change since I am not familiar with rust at all, but this seems to be just a logic change that should work as intended.

Of course, if you still disagree with this intermediate solution, feel free to close the PR.