### PR TITLE
Fix Import destination gated by org role instead of the actual per-collection Manage permission

### DIFF
--- a/playwright/tests/import-managed-collection.spec.ts
+++ b/playwright/tests/import-managed-collection.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type TestInfo } from '@playwright/test';
+
+import * as utils from "../global-utils";
+import * as orgs from './setups/orgs';
+import { createAccount, logUser } from './setups/user';
+
+let users = utils.loadEnv();
+
+test.beforeAll('Setup', async ({ browser }, testInfo: TestInfo) => {
+    await utils.startVault(browser, testInfo);
+});
+
+test.afterAll('Teardown', async ({}) => {
+    utils.stopVault();
+});
+
+test('A member with Manage permission on a collection can import into it under the ownership policy', async ({ page }) => {
+    test.setTimeout(300_000);
+
+    // The member account has to exist before being invited (no SMTP configured for this suite).
+    await createAccount(test, page, users.user2);
+    await createAccount(test, page, users.user1);
+
+    await orgs.create(test, page, 'ImportOrg');
+
+    await test.step('Create a managed and a locked collection', async () => {
+        await page.getByRole('button', { name: 'New', exact: true }).click();
+        await page.getByRole('menuitem', { name: 'Collection' }).click();
+        await page.getByRole('textbox', { name: 'Name * (required)', exact: true }).fill('Managed');
+        await page.getByRole('button', { name: 'Save' }).click();
+        await utils.checkNotification(page, 'Created collection Managed');
+
+        await page.getByRole('button', { name: 'New', exact: true }).click();
+        await page.getByRole('menuitem', { name: 'Collection' }).click();
+        await page.getByRole('textbox', { name: 'Name * (required)', exact: true }).fill('Locked');
+        await page.getByRole('button', { name: 'Save' }).click();
+        await utils.checkNotification(page, 'Created collection Locked');
+    });
+
+    await test.step('Enable the organisation ownership policy', async () => {
+        await orgs.policies(test, page, 'ImportOrg');
+        await page.getByRole('button', { name: /^Centralise organisation ownership/ }).click();
+        await page.getByRole('checkbox', { name: 'Turn on' }).check();
+        await page.getByRole('button', { name: 'Save' }).click();
+    });
+
+    await orgs.members(test, page, 'ImportOrg');
+    await test.step(`Invite ${users.user2.email} with Manage collection on Managed only`, async () => {
+        await page.getByRole('button', { name: 'Invite member' }).click();
+        await page.getByRole('textbox', { name: 'Email * (required)', exact: true }).fill(users.user2.email);
+        await page.getByRole('tab', { name: 'Collections' }).click();
+        await page.getByRole('combobox', { name: 'Permission' }).click();
+        await page.getByRole('option', { name: 'Manage collection', exact: true }).click();
+        await page.getByRole('combobox', { name: 'Select collections' }).click();
+        await page.getByLabel('Options List').getByText('Managed', { exact: true }).click();
+        await page.getByRole('columnheader', { name: 'Collection', exact: true }).click();
+        await page.getByRole('button', { name: 'Save' }).click();
+        await utils.checkNotification(page, 'User(s) invited');
+    });
+
+    await orgs.confirm(test, page, 'ImportOrg', users.user2.email);
+
+    await logUser(test, page, users.user2);
+
+    await test.step('The import destination and file fields are enabled for the managed collection', async () => {
+        await page.goto('/#/tools/import');
+
+        const vaultSelect = page.getByRole('combobox', { name: /^Vault/ });
+        await expect(vaultSelect).toBeEnabled();
+        // The member has exactly one org they can manage a collection in, so it's preselected
+        // instead of "My vault".
+        await expect(page.getByText('ImportOrg', { exact: true })).toBeVisible();
+
+        const collectionSelect = page.getByRole('combobox', { name: 'Collection' });
+        await expect(collectionSelect).toBeEnabled();
+
+        await expect(page.getByRole('combobox', { name: /^File format/ })).toBeEnabled();
+        await expect(page.getByRole('textbox', { name: /or copy\/paste the import file contents/ })).toBeEnabled();
+    });
+});

--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -1837,9 +1837,12 @@ async fn post_org_import(
     for col in data.collections {
         let existing = col.id.as_ref().and_then(|col_id| existing_collections.get(col_id));
         let collection_uuid = if let Some(collection) = existing {
-            // When not an Owner or Admin, check if the member is allowed to write to the collection.
+            // When not an Owner or Admin, the member must have the "Manage collection" permission
+            // (directly or via a group) on the collection. Plain edit/write access is not enough:
+            // importing creates items in bulk on the member's behalf, so it requires the same
+            // permission level as manually managing the collection's contents.
             if headers.membership.atype < MembershipType::Admin
-                && !collection.is_writable_by_user(&headers.membership.user_uuid, &conn).await
+                && !collection.is_manageable_by_user(&headers.membership.user_uuid, &conn).await
             {
                 err!(Compact, "The current user isn't allowed to manage this collection")
             }
@@ -1863,6 +1866,17 @@ async fn post_org_import(
     let mut relations = Vec::with_capacity(data.collection_relationships.len());
     for relation in data.collection_relationships {
         relations.push((relation.key, relation.value));
+    }
+
+    // Members without full organization access (e.g. importing into collections they manage
+    // under an active "Organization Data Ownership" policy) can only ever act within collections
+    // they're allowed to manage. Reject the whole import up-front if any cipher wouldn't end up
+    // assigned to at least one such collection, so we never create orphaned organization items.
+    if headers.membership.atype < MembershipType::Admin
+        && !headers.membership.has_full_access()
+        && !every_cipher_assigned_to_a_collection(data.ciphers.len(), &relations, !collections.is_empty())
+    {
+        err!(Compact, "Every imported item must be assigned to a collection you're allowed to manage")
     }
 
     let headers: Headers = headers.into();
@@ -1898,6 +1912,60 @@ async fn post_org_import(
 
     let mut user = headers.user;
     user.update_revision(&conn).await
+}
+
+/// Returns whether every cipher in `0..cipher_count` appears as the cipher-index side of at
+/// least one entry in `relations`. Used to reject an organization import up-front, before any
+/// ciphers are created, when the importing member doesn't have full org access and therefore
+/// must place every item into a collection they're allowed to manage.
+fn every_cipher_assigned_to_a_collection(
+    cipher_count: usize,
+    relations: &[(usize, usize)],
+    has_any_collection: bool,
+) -> bool {
+    if cipher_count == 0 {
+        return true;
+    }
+    if !has_any_collection {
+        return false;
+    }
+    let assigned: HashSet<usize> = relations.iter().map(|(cipher_idx, _)| *cipher_idx).collect();
+    (0..cipher_count).all(|i| assigned.contains(&i))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::every_cipher_assigned_to_a_collection;
+
+    #[test]
+    fn no_ciphers_is_always_allowed() {
+        assert!(every_cipher_assigned_to_a_collection(0, &[], false));
+    }
+
+    #[test]
+    fn ciphers_without_any_collection_are_rejected() {
+        assert!(!every_cipher_assigned_to_a_collection(2, &[], false));
+    }
+
+    #[test]
+    fn every_cipher_mapped_to_a_collection_is_allowed() {
+        let relations = [(0, 0), (1, 0)];
+        assert!(every_cipher_assigned_to_a_collection(2, &relations, true));
+    }
+
+    #[test]
+    fn a_cipher_missing_from_relations_is_rejected() {
+        // Cipher index 1 has no entry in `relations`.
+        let relations = [(0, 0)];
+        assert!(!every_cipher_assigned_to_a_collection(2, &relations, true));
+    }
+
+    #[test]
+    fn a_cipher_assigned_to_multiple_collections_still_counts_as_assigned() {
+        // Cipher 0 is mapped to two collections, cipher 1 to one: both are covered.
+        let relations = [(0, 0), (0, 1), (1, 0)];
+        assert!(every_cipher_assigned_to_a_collection(2, &relations, true));
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/db/models/collection.rs
+++ b/src/db/models/collection.rs
@@ -108,19 +108,22 @@ impl Collection {
                 // Owners and Admins always have true. Users are not able to have full access
                 Some(m) if m.has_full_access() => (false, false, m.atype >= MembershipType::Manager),
                 Some(m) => {
-                    // Only let a manager manage collections when the have full read/write access
+                    // The explicit per-collection "Manage" permission applies regardless of the
+                    // member's org-level role. Additionally, a Manager with full (non-restricted)
+                    // read/write access to a collection is also allowed to manage it, even without
+                    // that flag explicitly set.
                     let is_manager = m.atype == MembershipType::Manager;
                     if let Some(cu) = cipher_sync_data.user_collections.get(&self.uuid) {
                         (
                             cu.read_only,
                             cu.hide_passwords,
-                            is_manager && (cu.manage || (!cu.read_only && !cu.hide_passwords)),
+                            cu.manage || (is_manager && !cu.read_only && !cu.hide_passwords),
                         )
                     } else if let Some(cg) = cipher_sync_data.user_collections_groups.get(&self.uuid) {
                         (
                             cg.read_only,
                             cg.hide_passwords,
-                            is_manager && (cg.manage || (!cg.read_only && !cg.hide_passwords)),
+                            cg.manage || (is_manager && !cg.read_only && !cg.hide_passwords),
                         )
                     } else {
                         (false, false, false)
@@ -138,7 +141,9 @@ impl Collection {
                     let is_manager = m.atype == MembershipType::Manager;
                     let read_only = !self.is_writable_by_user(user_uuid, conn).await;
                     let hide_passwords = self.hide_passwords_for_user(user_uuid, conn).await;
-                    (read_only, hide_passwords, is_manager && !read_only && !hide_passwords)
+                    let manage = self.is_manageable_by_user(user_uuid, conn).await
+                        || (is_manager && !read_only && !hide_passwords);
+                    (read_only, hide_passwords, manage)
                 }
                 _ => (true, true, false),
             }


### PR DESCRIPTION
## Summary

When the "Enforce organization data ownership" policy (`OrgPolicyType::PersonalOwnership`) is active, a non-admin/owner member can no longer own personal items and must save new items to an organization instead. The official web-vault already supports this: the Import page offers an organization as an import destination whenever the member has `manage: true` on at least one of that org's collections in their sync data.

That flag, however, was wrong for exactly the members this policy is meant to keep working: `Collection::to_json_details()` only ever set `manage: true` when the member's *organization role* was "Manager" — completely ignoring the actual per-collection "Manage collection" permission granted to a plain "User" role member. So a member with `access_all=false`, org role `User`, and an explicit Manage grant on a collection was reported with `manage: false` for every collection, the web-vault found no eligible import destination, and disabled the entire Import form — vault, collection, file format and file content all greyed out.

## Root cause

`src/db/models/collection.rs`, `Collection::to_json_details()`, both the sync-cache path and the DB-fallback path:

```rust
// before
let is_manager = m.atype == MembershipType::Manager;
...
is_manager && (cu.manage || (!cu.read_only && !cu.hide_passwords))
```

`manage` was gated on `is_manager` first, so the explicit per-collection `cu.manage` flag (or the group equivalent) was never honored for a regular `User` role — even though that's precisely what "Manage collection" is supposed to grant, independent of the member's org-wide role.

## Fix

- **`src/db/models/collection.rs`**: compute `manage` from the per-collection flag / group grant directly (`cu.manage || cg.manage`), independent of org role. The existing fallback — a Manager with full, unrestricted read/write access on a collection is also allowed to manage it even without the flag explicitly set — is preserved. Applied to both the sync-cache path and the direct DB-query fallback (which now reuses the existing `is_manageable_by_user()` helper instead of duplicating the logic).

- **`src/api/core/organizations.rs`, `post_org_import`** (the `/ciphers/import-organization` endpoint): hardens the existing authorization now that more members can reach this path via the UI.
  - Importing into an *existing* collection now requires "Manage collection" specifically (via `is_manageable_by_user()`), not just write/edit access — matching the permission level required to manage a collection's contents manually.
  - New up-front check: if a member without full org access (not Admin/Owner/`access_all`) would end up with any imported item not assigned to a collection they can manage, the **entire import is rejected before any cipher is created** — closing a path where such items were previously dropped silently, cipher-by-cipher, rather than the import failing cleanly.
  - No behavior change for Owners, Admins, or members with `access_all`.

## Security impact

Both changes only *harden* existing authorization, never relax it:
- The `manage` flag now more accurately reflects real permissions (previously under-reported for `User`-role members, never over-reported).
- `post_org_import` now requires strictly more (Manage instead of Edit) for existing collections, and adds a check that previously didn't exist (no cipher left uncollected for restricted members).
- Both paths reuse the same central permission logic already used for manual collection management (`Collection::is_manageable_by_user` / `is_coll_manageable_by_user`) — no second, divergent authorization implementation.

## Testing

- Added Rust unit tests for the new `every_cipher_assigned_to_a_collection` pre-check (no ciphers / no collection / fully assigned / partially assigned / multi-collection assignment).
- Added `playwright/tests/import-managed-collection.spec.ts`: end-to-end test against a real Vaultwarden + the currently pinned official web-vault build.
  1. Owner creates an org, two collections ("Managed", "Locked"), and enables the ownership policy.
  2. A `User`-role member is invited with **Manage collection** on "Managed" only (not "Locked").
  3. As that member, the Import page is opened: the org is preselected as destination (instead of "My vault"), and the Vault/Collection/File format/File content fields are all enabled — reproducing, and then fixing, the exact "fully disabled Import dialog" symptom.

Manual verification steps:
1. Create an org, enable "Enforce organization data ownership".
2. Invite a regular member, grant them "Manage collection" on one collection only.
3. Log in as that member → Tools → Import: the org should now be selectable as destination with the managed collection available, personal vault should not be offered/selected.
4. Confirm importing into a collection the member does *not* manage is still rejected server-side (`403`, no logout).

## Out of scope / known remaining limitation

Creating a **new** collection is still restricted to org roles Manager/Admin/Owner (`ManagerHeadersLoose` guard on `POST /organizations/<id>/collections`), regardless of any per-collection Manage grant — this mirrors the existing `limitCollectionCreation` value Vaultwarden already reports to the client, but is stricter than official Bitwarden's model (which lets admins opt to allow any member to create collections via an org-wide setting Vaultwarden doesn't implement). Unrelated to this fix; left as a separate, pre-existing gap.