### PR TITLE
Ignore reset-password auto-enroll when mail is disabled

### DIFF
--- a/src/db/models/org_policy.rs
+++ b/src/db/models/org_policy.rs
@@ -318,6 +318,13 @@ impl OrgPolicy {
     }
 
     pub async fn org_is_reset_password_auto_enroll(org_uuid: &OrganizationId, conn: &DbConn) -> bool {
+        // Account recovery depends on outbound mail. When SMTP is disabled, treat the
+        // auto-enroll policy as inactive so invites/registration are not forced to
+        // supply a reset-password key (see check_reset_password_applicable).
+        if !CONFIG.mail_enabled() {
+            return false;
+        }
+
         match OrgPolicy::find_by_org_and_type(org_uuid, OrgPolicyType::ResetPassword, conn).await {
             Some(policy) => match serde_json::from_str::<ResetPasswordDataModel>(&policy.data) {
                 Ok(opts) => {


### PR DESCRIPTION
## Summary
- Make `OrgPolicy::org_is_reset_password_auto_enroll` return `false` when mail/SMTP is disabled.
- Invite/accept and enrollment paths that rely on auto-enroll no longer require a reset-password key on email-disabled instances.
- Aligns with `check_reset_password_applicable`, which already rejects password reset when mail is off.

Fixes #7459

## Test plan
- [x] `cargo check --profile ci --features sqlite`
- [ ] With SMTP enabled and Account Recovery auto-enroll on, invite/accept still requires enrollment when configured.
- [ ] Disable SMTP afterward; invite/register a new org user without a reset-password key and confirm it succeeds.
- [ ] With SMTP still disabled, password-reset admin actions remain unavailable as before.
