### PR TITLE
fix(api): reject SSH Key ciphers with missing or empty key members

### DIFF
--- a/src/api/core/ciphers.rs
+++ b/src/api/core/ciphers.rs
@@ -513,14 +513,28 @@ pub async fn update_cipher_from_data(
         _ => err!("Invalid type"),
     };
 
-    let type_data = if let Some(mut data) = type_data_opt {
+    let type_data = if let Some(mut type_value) = type_data_opt {
         // Remove the 'Response' key from the base object.
-        data.as_object_mut().unwrap().remove("response");
+        type_value.as_object_mut().unwrap().remove("response");
         // Remove the 'Response' key from every Uri.
-        if data["uris"].is_array() {
-            data["uris"] = clean_cipher_data(data["uris"].clone());
+        if type_value["uris"].is_array() {
+            type_value["uris"] = clean_cipher_data(type_value["uris"].clone());
         }
-        data
+        // An SSH Key cipher (type 5) requires all three key members to be
+        // non-empty strings. Bitwarden's server rejects the request otherwise;
+        // accepting it here would store a cipher whose sshKey payload is
+        // dropped by clients on read, which looks like a successful save but
+        // silently loses the key material.
+        if data.r#type == 5 {
+            let obj = type_value.as_object().unwrap();
+            for member in ["privateKey", "publicKey", "keyFingerprint"] {
+                let valid = matches!(obj.get(member), Some(Value::String(s)) if !s.is_empty());
+                if !valid {
+                    err!(format!("SshKey.{member} is required and must be a non-empty string"));
+                }
+            }
+        }
+        type_value
     } else {
         err!("Data missing")
     };


### PR DESCRIPTION
## Problem

A type-5 (SSH Key) cipher whose `sshKey` object carries `null` — or any non-string value — in `privateKey`, `publicKey`, or `keyFingerprint` is accepted and stored, but clients drop the malformed payload on read. The save looks successful while the key material silently disappears.

Bitwarden's own server rejects the identical request with a validation error, so a client that is correct against cloud gets a success response and silent data loss against Vaultwarden. That asymmetry is the actual problem: the write looks like it worked.

## What changed

`src/api/core/ciphers.rs` — after the existing type-specific payload handling in the create/update path, a type-5 cipher now requires all three `sshKey` members to be present as non-empty strings; otherwise the request fails with `SshKey.<member> is required and must be a non-empty string`.

- Presence check only, matching the cloud behavior established in #7514's payload matrix (cloud refuses nulls, accepts arbitrary non-empty strings) — key material itself is not parsed or validated.
- Other cipher types are untouched.
- No schema or migration change: this only gates what reaches `cipher.data`.

## Verification

- `cargo check --features sqlite` passes with no new warnings
- `cargo fmt --check` clean

Manual reproduction of the reported shape (`type: 5`, `sshKey` with `"privateKey": null`) now returns 400 with the message above instead of storing a cipher that loses its payload on read.

Fixes #7514
