### PR TITLE
Log IP/username on two-factor email-login credential failures

### DIFF
--- a/src/api/core/two_factor/email.rs
+++ b/src/api/core/two_factor/email.rs
@@ -63,13 +63,19 @@ async fn send_email_login(data: Json<SendEmailLoginData>, client_headers: Client
 
     let user = if let Some(email) = email {
         let Some(user) = User::find_by_mail(email, &conn).await else {
-            err!("Username or password is incorrect. Try again.")
+            err!(
+                "Username or password is incorrect. Try again",
+                format!("IP: {}. Username: {email}.", client_headers.ip.ip)
+            )
         };
 
         if let Some(master_password_hash) = master_password_hash {
             // Check password
             if !user.check_valid_password(master_password_hash) {
-                err!("Username or password is incorrect. Try again.")
+                err!(
+                    "Username or password is incorrect. Try again",
+                    format!("IP: {}. Username: {email}.", client_headers.ip.ip)
+                )
             }
         } else if let Some(auth_request_id) = auth_request_id {
             let Some(auth_request) = AuthRequest::find_by_uuid(auth_request_id, &conn).await else {
@@ -96,7 +102,10 @@ async fn send_email_login(data: Json<SendEmailLoginData>, client_headers: Client
         };
         // SSO login only sends device id, so we get the user by the most recently used device
         let Some(user) = User::find_by_device_for_email2fa(device_identifier, &conn).await else {
-            err!("Username or password is incorrect. Try again.")
+            err!(
+                "Username or password is incorrect. Try again",
+                format!("IP: {}. Device: {device_identifier}.", client_headers.ip.ip)
+            )
         };
 
         user


### PR DESCRIPTION
The three `"Username or password is incorrect"` errors in `send_email_login()` (`src/api/core/two_factor/email.rs`) don't log the client IP or submitted identifier, unlike the equivalent wrong-password error in `password_login()` (`src/api/identity.rs`), which logs both via `format!("IP: {}. Username: {username}.", ip.ip)`.

This makes the two code paths inconsistent for the same underlying error, and means any log-based tooling keyed on the `identity.rs` error's `IP: x.x.x.x` pattern can't do the same for this endpoint -- a burst of failures here is currently indistinguishable, log-wise, from a single occurrence.

Brings `email.rs`'s three call sites in line with `identity.rs`'s existing format. The two email-present branches log IP+Username (the submitted email); the device-identifier-only branch (SSO path, where no email is in scope) logs IP+Device instead of fabricating a username field that doesn't exist there.

Small, mechanical, symmetry-restoring change -- no new plumbing, `client_headers.ip.ip` is already in scope in this function (used two lines above for the rate-limit check).

**Verified locally** (no CI access): `cargo build`, `cargo test --profile ci --features sqlite` (29/29 pass, including the two existing unit tests in this file), `cargo clippy --features sqlite -- -D warnings` (clean), `cargo fmt --all -- --check` (clean).