### PR TITLE
Add `pm-32413-multi-client-password-management` feature flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -390,6 +390,7 @@
 ##
 ## The following flags are available:
 ## - "pm-5594-safari-account-switching": Enable account switching in Safari. (Safari >= 2026.2.0)
+## - "pm-32413-multi-client-password-management": Enable changing the master password directly in the client. (Desktop/Extension >= 2026.4.0)
 ## - "ssh-agent": Enable SSH agent support on Desktop. (Desktop >= 2024.12.0)
 ## - "ssh-agent-v2": Enable newer SSH agent support. (Desktop >= 2026.2.1)
 ## - "ssh-key-vault-item": Enable the creation and use of SSH key vault items. (Clients >= 2024.12.0)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1425,6 +1425,7 @@ pub const SUPPORTED_FEATURE_FLAGS: &[&str] = &[
     "desktop-ui-migration-milestone-4",
     // Auth Team
     "pm-5594-safari-account-switching",
+    "pm-32413-multi-client-password-management",
     // Autofill Team
     "ssh-agent",
     "ssh-agent-v2",


### PR DESCRIPTION
Adds the `pm-32413-multi-client-password-management` flag to the supported client feature flags allowlist. Bitwarden gates changing the master password directly in the browser extension and desktop client behind this flag (clients >= 2026.4.0); without it self-hosted users are sent to the web vault instead.
