### PR TITLE
fix(security): rate limit prelogin and auth request endpoints

### DIFF
--- a/src/api/core/accounts.rs
+++ b/src/api/core/accounts.rs
@@ -1340,11 +1340,13 @@ pub struct PreloginData {
 }
 
 #[post("/accounts/prelogin", data = "<data>")]
-async fn post_prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
-    prelogin(data, conn).await
+async fn post_prelogin(data: Json<PreloginData>, ip: ClientIp, conn: DbConn) -> JsonResult {
+    prelogin(data, ip, conn).await
 }
 
-pub async fn prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
+pub async fn prelogin(data: Json<PreloginData>, ip: ClientIp, conn: DbConn) -> JsonResult {
+    crate::ratelimit::check_limit_unauthenticated(&ip.ip)?;
+
     let data: PreloginData = data.into_inner();
 
     let (kdf_type, kdf_iter, kdf_mem, kdf_para) = match User::find_by_mail(&data.email, &conn).await {
@@ -1352,7 +1354,7 @@ pub async fn prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
         None => (User::CLIENT_KDF_TYPE_DEFAULT, User::CLIENT_KDF_ITER_DEFAULT, None, None),
     };
 
-    Json(json!({
+    Ok(Json(json!({
         "kdf": kdf_type,
         "kdfIterations": kdf_iter,
         "kdfMemory": kdf_mem,
@@ -1364,7 +1366,7 @@ pub async fn prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
             "parallelism": kdf_para
         },
         "salt": null,
-    }))
+    })))
 }
 
 // https://github.com/bitwarden/server/blob/9ebe16587175b1c0e9208f84397bb75d0d595510/src/Api/Auth/Models/Request/Accounts/SecretVerificationRequestModel.cs
@@ -1595,6 +1597,8 @@ async fn post_auth_request(
     conn: DbConn,
     nt: Notify<'_>,
 ) -> JsonResult {
+    crate::ratelimit::check_limit_unauthenticated(&client_headers.ip.ip)?;
+
     let data = data.into_inner();
 
     let Some(user) = User::find_by_mail(&data.email, &conn).await else {
@@ -1756,6 +1760,8 @@ async fn get_auth_request_response(
     client_headers: ClientHeaders,
     conn: DbConn,
 ) -> JsonResult {
+    crate::ratelimit::check_limit_unauthenticated(&client_headers.ip.ip)?;
+
     let Some(auth_request) = AuthRequest::find_by_uuid(&auth_request_id, &conn).await else {
         err!("AuthRequest doesn't exist", "User not found")
     };

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -1050,13 +1050,13 @@ async fn json_err_twofactor(
 }
 
 #[post("/accounts/prelogin", data = "<data>")]
-async fn post_prelogin(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
-    prelogin(data, conn).await
+async fn post_prelogin(data: Json<PreloginData>, ip: ClientIp, conn: DbConn) -> JsonResult {
+    prelogin(data, ip, conn).await
 }
 
 #[post("/accounts/prelogin/password", data = "<data>")]
-async fn prelogin_password(data: Json<PreloginData>, conn: DbConn) -> Json<Value> {
-    prelogin(data, conn).await
+async fn prelogin_password(data: Json<PreloginData>, ip: ClientIp, conn: DbConn) -> JsonResult {
+    prelogin(data, ip, conn).await
 }
 
 #[post("/accounts/register", data = "<data>")]


### PR DESCRIPTION
Four unauthenticated endpoints have no rate limit. `check_limit_unauthenticated` is applied on the other anonymous routes (`accounts.rs:1220`, `1297`, `1544`, `sends.rs:477`, `554`, `identity.rs:112`, `1088`) but these were missed.

`POST /auth-requests` looks up a user by email and, on a device match, pushes an approval prompt to every one of that user's devices. Unauthenticated and unmetered, it is an MFA fatigue amplifier: the prompt the user is being trained to approve grants a full vault unlock. It also grows the `auth_requests` table until the purge job runs.

`GET /auth-requests/<id>/response?code=` is guarded only by a device type, an IP match and the access code. The comparison is constant time, but nothing bounded the number of attempts.

`POST /accounts/prelogin` and `POST /accounts/prelogin/password` return the account's real `kdfType`, `kdfIterations`, `kdfMemory` and `kdfParallelism` when the email exists, and fixed defaults when it does not. Any account not on the exact defaults, every Argon2id user and every legacy 100k PBKDF2 user, is enumerable one request at a time.

All four now call `check_limit_unauthenticated`. The three `prelogin` routes share one implementation, so the check sits there and the callers pass a `ClientIp`; the return type becomes `JsonResult` so a 429 can be returned.

I used the unauthenticated limiter rather than the login one on purpose. The auth request response endpoint is polled by the client while it waits for approval, and the login limiter's default burst of 10 per minute would break that. The unauthenticated limiter defaults to 50, and its own config docs say it is shared across endpoints and needs to be more lenient. This should not affect legitimate traffic on `prelogin` either: it always precedes a login, and `password_login` already applies the stricter login limiter, so anything that would trip the new limit already trips the existing one.

Verified with `cargo fmt --all --check`, `cargo clippy --features sqlite -- -D warnings` and `cargo test --features sqlite`, all clean.

No unit test is added. These are four one-line guards over `governor` limiters held in global `LazyLock` statics that read their quota from the config on first use, so a test would be execution-order dependent and would exercise the crate rather than anything here. Asserting that a route calls the guard needs an HTTP harness the project does not have on the Rust side.

Note that the `prelogin` oracle is a different vector from the password hint timing described in #7345, which this does not address.
