### PR TITLE
fix(security): revoke 2FA remember tokens when credentials or 2FA change

### DIFF
--- a/src/api/core/two_factor/mod.rs
+++ b/src/api/core/two_factor/mod.rs
@@ -16,8 +16,8 @@ use crate::{
     db::{
         DbConn, DbPool,
         models::{
-            DeviceType, EventType, Membership, MembershipType, OrgPolicyType, Organization, OrganizationId, TwoFactor,
-            TwoFactorIncomplete, TwoFactorType, User, UserId,
+            Device, DeviceType, EventType, Membership, MembershipType, OrgPolicyType, Organization, OrganizationId,
+            TwoFactor, TwoFactorIncomplete, TwoFactorType, User, UserId,
         },
     },
     mail,
@@ -151,6 +151,7 @@ async fn disable_twofactor(data: Json<DisableTwoFactorData>, headers: Headers, c
 
     if let Some(twofactor) = TwoFactor::find_by_user_and_type(&user.uuid, type_, &conn).await {
         twofactor.delete(&conn).await?;
+        Device::clear_twofactor_remember_by_user(&user.uuid, &conn).await?;
         log_user_event(EventType::UserDisabled2fa as i32, &user.uuid, headers.device.atype, &headers.ip.ip, &conn)
             .await;
     }

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -905,6 +905,12 @@ async fn twofactor_auth(
 
             // Remove all twofactors from the user
             TwoFactor::delete_all_by_user(&user.uuid, conn).await?;
+
+            // No device may keep skipping 2FA once every second factor is gone.
+            // `device` is cleared in memory too, since saving it later would restore its token.
+            Device::clear_twofactor_remember_by_user(&user.uuid, conn).await?;
+            device.delete_twofactor_remember();
+
             enforce_2fa_policy(user, &user.uuid, device.atype, &ip.ip, conn).await?;
 
             log_user_event(EventType::UserRecovered2fa as i32, &user.uuid, device.atype, &ip.ip, conn).await;

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -266,9 +266,21 @@ impl Device {
         let devices = Self::find_by_user(user_uuid, conn).await;
         for mut device in devices {
             device.refresh_token = Device::generate_refresh_token();
+            device.twofactor_remember = None;
             device.save(false, conn).await?;
         }
         Ok(())
+    }
+
+    pub async fn clear_twofactor_remember_by_user(user_uuid: &UserId, conn: &DbConn) -> EmptyResult {
+        conn.run(move |conn| {
+            diesel::update(devices::table)
+                .filter(devices::user_uuid.eq(user_uuid))
+                .set(devices::twofactor_remember.eq::<Option<String>>(None))
+                .execute(conn)
+                .map_res("Error removing two factor remember tokens")
+        })
+        .await
     }
 }
 


### PR DESCRIPTION
The 2FA remember token is a 30 day JWT stored in `devices.twofactor_remember` that skips the second factor entirely at login (`identity.rs`, `TwoFactorType::Remember`). Nothing invalidated it.

`User::reset_security_stamp` rotates every device's refresh token, so a password change does end the user's sessions. It left the remember token untouched, which undercuts the point: the next login from a remembered browser still skips 2FA. `delete_twofactor_remember` had a single caller, on the failure path in `twofactor_auth`. `post_sstamp` was the only flow that cleared these, and only incidentally, through `Device::delete_all_by_user`.

The sharpest case is removing a compromised authenticator. The user deletes the TOTP entry and enrolls a new one, and every browser that had ticked "remember me" keeps skipping the new second factor for up to 30 days, with nothing in the UI to show or revoke it.

Three places now clear it:

- `Device::rotate_refresh_tokens_by_user` clears the token in the loop that already writes each row, so no extra query. This covers every password and KDF change, emergency access takeover, organization admin password reset, and the admin panel actions, since they all reach it through `reset_security_stamp`.
- `disable_twofactor`, which does not reset the security stamp.
- The recovery code branch of `twofactor_auth`, which removes every second factor and also does not reset the stamp.

On the recovery code path the in-memory `device` is cleared as well. It is saved later in the login response, and a database-only clear would be written straight back over.

When an account has several second factors and only one is disabled, all remember tokens are dropped. Which factor a remembered device was skipping is not knowable, and the cost is one extra prompt at the next login.

Verified with `cargo fmt --all --check`, `cargo clippy --features sqlite,mysql,postgresql -- -D warnings` and `cargo test`, all clean.

No test is added, and this is a real coverage gap rather than an oversight. The change is a database function plus its call sites; there is no integration harness on the Rust side, the existing unit tests cover pure functions only, and the Playwright suite sets up 2FA but never exercises the remember flow. Closing that gap properly means a Playwright case that logs in with remember enabled, changes the password or disables the factor, and asserts the next login is challenged. Happy to add it if you would like it in this PR.
