### PR TITLE
Fix organization import failing with missing field groups

### DIFF
--- a/src/api/core/organizations.rs
+++ b/src/api/core/organizations.rs
@@ -132,7 +132,6 @@ struct FullCollectionData {
     name: String,
     groups: Vec<CollectionGroupData>,
     users: Vec<CollectionMembershipData>,
-    id: Option<CollectionId>,
     external_id: Option<String>,
 }
 
@@ -1793,11 +1792,22 @@ async fn bulk_public_keys(
 use super::ciphers::CipherData;
 use super::ciphers::update_cipher_from_data;
 
+// The import endpoint only ever uses the name/id/external_id of a collection.
+// Bitwarden's own server ignores `groups`/`users` here too, so do not make them
+// mandatory: clients are free to leave them out.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportCollectionData {
+    name: String,
+    id: Option<CollectionId>,
+    external_id: Option<String>,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ImportData {
     ciphers: Vec<CipherData>,
-    collections: Vec<FullCollectionData>,
+    collections: Vec<ImportCollectionData>,
     collection_relationships: Vec<RelationsData>,
 }
 


### PR DESCRIPTION
Importing a `.kdbx` into an organization always fails with a `422`:

```
Data guard `Json < ImportData >` failed: Parse(..., Error("missing field `groups`", ...))
```

`ImportData.collections` uses `FullCollectionData`, which requires `groups`/`users` — but the import handler only ever reads `name`, `id` and `external_id` and throws the rest away. Bitwarden has both optional and ignores them on import too. Came in with #5542.

It only hits `.kdbx` because that's the one format going through the SDK importer, which leaves both keys out of the payload entirely. Every other format still sends `"groups": [], "users": []`. More formats are moving to that importer though.

So: own collection struct for the import path with just the fields it uses. `id` drops out of `FullCollectionData` since the import was its only reader.

Tested on SQLite against 1.37.2 and this branch: the payload the SDK sends gives `422` before and `200` after, ciphers land in the right collection. CSV import via web vault v2026.7.0 still works.

Fixes #7698
