### PR TITLE
Fix iOS registration token response

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -1086,10 +1086,9 @@ enum RegisterVerificationResponse {
     PlainToken(String),
 }
 
-// The iOS client sends `Accept: */*` and reads the raw body as its token, so it would end up with
-// the quotes of a JSON string. Every other client keeps the JSON string.
+// Return JSON only when the client explicitly requests it, otherwise return plain text.
 fn accepts_json(accept: Option<&Accept>) -> bool {
-    accept.is_none_or(|accept| accept.preferred().media_type() != &MediaType::Any)
+    accept.is_some_and(|accept| accept.preferred().media_type() == &MediaType::JSON)
 }
 
 #[post("/accounts/register/send-verification-email", data = "<data>")]

--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -3,7 +3,7 @@ use num_traits::FromPrimitive;
 use rocket::{
     Route,
     form::{Form, FromForm},
-    http::{Cookie, CookieJar, SameSite},
+    http::{Accept, Cookie, CookieJar, MediaType, SameSite},
     response::Redirect,
     serde::json::Json,
 };
@@ -1083,11 +1083,19 @@ enum RegisterVerificationResponse {
     #[response(status = 204)]
     NoContent(()),
     Token(Json<String>),
+    PlainToken(String),
+}
+
+// The iOS client sends `Accept: */*` and reads the raw body as its token, so it would end up with
+// the quotes of a JSON string. Every other client keeps the JSON string.
+fn accepts_json(accept: Option<&Accept>) -> bool {
+    accept.is_none_or(|accept| accept.preferred().media_type() != &MediaType::Any)
 }
 
 #[post("/accounts/register/send-verification-email", data = "<data>")]
 async fn register_verification_email(
     data: Json<RegisterVerificationData>,
+    accept: Option<&Accept>,
     ip: ClientIp,
     conn: DbConn,
 ) -> ApiResult<RegisterVerificationResponse> {
@@ -1125,7 +1133,11 @@ async fn register_verification_email(
     } else {
         // If email verification is not required, return the token directly
         // the clients will use this token to finish the registration
-        Ok(RegisterVerificationResponse::Token(Json(token)))
+        Ok(if accepts_json(accept) {
+            RegisterVerificationResponse::Token(Json(token))
+        } else {
+            RegisterVerificationResponse::PlainToken(token)
+        })
     }
 }
 


### PR DESCRIPTION
When SIGNUPS_VERIFY is disabled, /identity/accounts/register/send-verification-email returns the token as a JSON string ("eyJ..."). The iOS client reads the raw response body as the token, so the quotes become part of it and /identity/accounts/register/finish fails with Error decoding JWT: Error(Base64(InvalidByte(0, 34))).

The iOS client sends Accept: */*. This change now returns JSON only when the client explicitly requests application/json; otherwise, the token is returned as text/plain:

* Accept: application/json → "eyJ..."
* all other cases → raw eyJ...

Returning a plain String for every request would not be enough: api.service.ts only parses the body when the content type is application/json, so clients expecting JSON could silently get undefined. Clients that require JSON explicitly request it, while all other requests receive the raw token as plain text. The 204 No Content response when email verification is required is unchanged.

Tested on iOS, signup works now. Web Vault also works as expected. I don’t have an Android device, so I could only test the response behavior with curl.

Discussion: https://github.com/dani-garcia/vaultwarden/discussions/7712